### PR TITLE
Fix Nginx 502 Bad Gateway in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       DOMAIN: localhost
       REPO_DIR: /usr/share/nginx/html
       APP_PORT: ${PORT:-8080}
+      BACKEND_HOST: backend
     depends_on:
       backend:
         condition: service_healthy

--- a/scripts/nginx-portfolio.conf.template
+++ b/scripts/nginx-portfolio.conf.template
@@ -1,6 +1,7 @@
 # Nginx server block for andykeys.me portfolio.
 # Rendered by `envsubst` with an explicit allow-list (DOMAIN, REPO_DIR,
-# APP_PORT) so Nginx-native $vars (e.g. $host, $uri) are preserved.
+# APP_PORT, BACKEND_HOST) so Nginx-native $vars (e.g. $host, $uri) are preserved.
+# BACKEND_HOST defaults to 127.0.0.1 for production, override to 'backend' for Docker.
 # Used by both scripts/pi-setup.sh (initial setup) and scripts/deploy.sh
 # (continuous deployment).
 server {
@@ -15,7 +16,7 @@ server {
 
     # Proxy all backend API routes to Node
     location ~ ^/(auth|travel|contact|posts|upload)(/|$) {
-        proxy_pass http://127.0.0.1:${APP_PORT};
+        proxy_pass http://${BACKEND_HOST:-127.0.0.1}:${APP_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -24,7 +25,7 @@ server {
 
     # Health check
     location /health {
-        proxy_pass http://127.0.0.1:${APP_PORT};
+        proxy_pass http://${BACKEND_HOST:-127.0.0.1}:${APP_PORT};
     }
 
     # Uploaded media served directly by Nginx from repo-root uploads/ dir


### PR DESCRIPTION
## Summary

Fixes Nginx 502 Bad Gateway errors when accessing travel and other API routes in Docker.

## Problem

In Docker, the backend service isn't at `127.0.0.1` — it's at the internal service name `backend`. The Nginx template was hardcoded to proxy to `127.0.0.1:${APP_PORT}`, which failed with 502 Bad Gateway.

## Solution

- Update Nginx template to use `${BACKEND_HOST:-127.0.0.1}` 
- Docker passes `BACKEND_HOST: backend` to Nginx
- Production deployments use the default `127.0.0.1` (no change needed)

## Testing

```bash
docker-compose down
docker-compose up --build
```

Visit `http://localhost/travel.html` — should load travel memories without 502 errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_