### PR TITLE
Fix Nginx 502 Bad Gateway in Docker (BACKEND_HOST)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -78,8 +78,9 @@ if [ "$NGINX_CHANGED" -gt 0 ]; then
         else
             command -v envsubst >/dev/null || sudo apt-get install -y gettext-base
 
-            export DOMAIN REPO_DIR APP_PORT
-            envsubst '${DOMAIN} ${REPO_DIR} ${APP_PORT}' \
+            BACKEND_HOST=127.0.0.1
+            export DOMAIN REPO_DIR APP_PORT BACKEND_HOST
+            envsubst '${DOMAIN} ${REPO_DIR} ${APP_PORT} ${BACKEND_HOST}' \
                 < "$REPO_DIR/scripts/nginx-portfolio.conf.template" \
                 > /tmp/portfolio.conf
 

--- a/scripts/nginx-portfolio.conf.template
+++ b/scripts/nginx-portfolio.conf.template
@@ -16,7 +16,7 @@ server {
 
     # Proxy all backend API routes to Node
     location ~ ^/(auth|travel|contact|posts|upload)(/|$) {
-        proxy_pass http://${BACKEND_HOST:-127.0.0.1}:${APP_PORT};
+        proxy_pass http://${BACKEND_HOST}:${APP_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -25,7 +25,7 @@ server {
 
     # Health check
     location /health {
-        proxy_pass http://${BACKEND_HOST:-127.0.0.1}:${APP_PORT};
+        proxy_pass http://${BACKEND_HOST}:${APP_PORT};
     }
 
     # Uploaded media served directly by Nginx from repo-root uploads/ dir

--- a/scripts/pi-setup.sh
+++ b/scripts/pi-setup.sh
@@ -105,8 +105,9 @@ echo "[7/7] Configuring Nginx..."
 # envsubst lives in gettext-base; install if missing
 command -v envsubst >/dev/null || sudo apt-get install -y gettext-base
 
-export DOMAIN REPO_DIR APP_PORT
-envsubst '${DOMAIN} ${REPO_DIR} ${APP_PORT}' \
+BACKEND_HOST=127.0.0.1
+export DOMAIN REPO_DIR APP_PORT BACKEND_HOST
+envsubst '${DOMAIN} ${REPO_DIR} ${APP_PORT} ${BACKEND_HOST}' \
     < "$REPO_DIR/scripts/nginx-portfolio.conf.template" \
     | sudo tee /etc/nginx/sites-available/portfolio > /dev/null
 


### PR DESCRIPTION
## Summary

Fixes Nginx 502 Bad Gateway errors in Docker by properly configuring the backend proxy host.

## Problem

1. Nginx template used hardcoded `127.0.0.1` for backend proxy, which doesn't work in Docker
2. Initial fix attempt used bash default syntax `${VAR:-default}` which Nginx doesn't support
3. Resulted in Nginx startup error: "closing bracket in BACKEND_HOST variable is missing"

## Solution

- Update Nginx template to use plain `${BACKEND_HOST}` variable syntax
- Set `BACKEND_HOST` explicitly in all environments:
  - **Docker**: `BACKEND_HOST: backend` (internal service name)
  - **Pi (production)**: `BACKEND_HOST=127.0.0.1` (loopback)
- Update both `deploy.sh` and `pi-setup.sh` to set BACKEND_HOST=127.0.0.1 and include it in envsubst

## Testing

```bash
docker-compose down
docker-compose up --build
```

All services should start cleanly. Travel API calls should return 200, not 502.

## Files Changed

- `scripts/nginx-portfolio.conf.template`: Use `${BACKEND_HOST}` instead of hardcoded 127.0.0.1
- `docker-compose.yml`: Set `BACKEND_HOST: backend` for Nginx service
- `scripts/deploy.sh`: Set BACKEND_HOST=127.0.0.1 before envsubst
- `scripts/pi-setup.sh`: Set BACKEND_HOST=127.0.0.1 before envsubst

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_