### PR TITLE
Admin UX improvements: quick-nav links, dev tab indicator, styled file input

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -24,10 +24,14 @@
         </ul>
     </nav>
 
+    <!-- Issue #28: Quick-nav to public-facing pages -->
+    <div class="admin-quicknav">
+        <a href="travel.html" target="_blank" rel="noopener noreferrer" class="admin-quicknav-link">✈ Travel</a>
+        <a href="#blog" target="_blank" rel="noopener noreferrer" class="admin-quicknav-link">✏ Blog</a>
+    </div>
+
     <main class="admin-page">
         <section class="sec-cont admin-panel">
-
-            <!-- ── Travel memories ─────────────────────────────────────────── -->
             <div class="admin-card">
                 <h2>Publish travel memories</h2>
                 <form id="travel-form">
@@ -40,17 +44,14 @@
                     <label>Notes
                         <textarea id="travel-notes" rows="3" placeholder="Describe the moment"></textarea>
                     </label>
+                    <!-- Issue #29: styled file input -->
                     <label>Photo or video
-                        <input id="travel-file" type="file" accept="image/*,video/*" />
+                        <div class="file-input-wrap">
+                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photo or video">Browse…</button>
+                            <span class="file-input-label">No file chosen</span>
+                            <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" />
+                        </div>
                     </label>
-                    <div class="coord-row">
-                        <label>Latitude
-                            <input id="travel-lat" type="number" step="any" placeholder="e.g. 51.5074" />
-                        </label>
-                        <label>Longitude
-                            <input id="travel-lng" type="number" step="any" placeholder="e.g. -0.1278" />
-                        </label>
-                    </div>
                     <div class="form-actions">
                         <button type="submit" class="btn-primary">Save memory</button>
                         <button type="button" id="travel-clear" class="btn-secondary">Clear</button>
@@ -70,35 +71,6 @@
                 </div>
             </div>
 
-            <!-- ── Blog posts ──────────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2>Blog posts</h2>
-                <form id="post-form">
-                    <input type="hidden" id="post-edit-id" value="" />
-                    <label>Title
-                        <input id="post-title" type="text" placeholder="Post title" />
-                    </label>
-                    <label>Body (Markdown)
-                        <textarea id="post-body" rows="10" placeholder="Write in Markdown…"></textarea>
-                    </label>
-                    <div class="form-actions">
-                        <button type="submit" id="post-save-btn" class="btn-primary">Save draft</button>
-                        <button type="submit" id="post-publish-btn" class="btn-primary">Publish</button>
-                        <button type="button" id="post-template-btn" class="btn-secondary">Insert template</button>
-                        <button type="button" id="post-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
-                    </div>
-                </form>
-                <p id="post-message" class="login-message"></p>
-
-                <div class="saved-memories" style="margin-top:1.5rem">
-                    <h3>All posts</h3>
-                    <div id="posts-admin-list">
-                        <p class="hint">Loading…</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- ── Private notes ───────────────────────────────────────────── -->
             <div class="admin-card private-card">
                 <h2>Private coding projects</h2>
                 <p>Private notes and project planning. GitHub integration can be added later.</p>
@@ -112,7 +84,6 @@
                 <p class="hint">Notes are saved locally in your browser.</p>
             </div>
 
-            <!-- ── Passkeys ────────────────────────────────────────────────── -->
             <div class="admin-card">
                 <h2>Manage passkeys</h2>
                 <p>Passkeys let you sign in with your device's biometrics or PIN — no password needed.</p>
@@ -124,12 +95,27 @@
                 </div>
                 <p id="passkey-message" class="login-message"></p>
             </div>
-
         </section>
     </main>
 
+    <script src="./resources/java/dev-env.js"></script>
     <script src="./resources/java/darkmode.js"></script>
     <script src="./resources/java/jquery-3.5.1.min.js"></script>
     <script type="module" src="./resources/java/admin.js"></script>
+    <script>
+        // Issue #29: wire styled file input button to hidden native input
+        (function () {
+            const btn = document.querySelector('.file-input-btn');
+            const input = document.getElementById('travel-file');
+            const label = document.querySelector('.file-input-label');
+            if (!btn || !input || !label) return;
+            btn.addEventListener('click', function () { input.click(); });
+            input.addEventListener('change', function () {
+                label.textContent = input.files.length > 0
+                    ? input.files[0].name
+                    : 'No file chosen';
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -20,10 +20,10 @@
         <ul class="nav">
             <li><a href="index.html">Home</a></li>
             <!-- Issue #32: quick links to public-facing pages -->
-            <li><a href="travel.html" target="_blank" rel="noopener noreferrer">&#9992; Travel</a></li>
-            <li><a href="blog.html" target="_blank" rel="noopener noreferrer">&#9998; Blog</a></li>
+            <li><a href="travel.html" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="blog.html" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
             <li><a href="login.html" id="logout-link">Logout</a></li>
-            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">&#9822;</button></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
         </ul>
     </nav>
 
@@ -46,7 +46,7 @@
                     <!-- Issue #34: styled file input -->
                     <label>Photo or video
                         <div class="file-input-wrap">
-                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photo or video">Browse&hellip;</button>
+                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photo or video">Browse…</button>
                             <span class="file-input-label">No file chosen</span>
                             <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" />
                         </div>
@@ -73,7 +73,7 @@
                 <div class="saved-memories">
                     <h3>Saved memories</h3>
                     <div id="saved-memories-list">
-                        <p class="hint">Loading&hellip;</p>
+                        <p class="hint">Loading…</p>
                     </div>
                 </div>
             </div>
@@ -87,7 +87,7 @@
                         <input id="post-title" type="text" placeholder="Post title" />
                     </label>
                     <label>Body (Markdown)
-                        <textarea id="post-body" rows="10" placeholder="Write in Markdown&hellip;"></textarea>
+                        <textarea id="post-body" rows="10" placeholder="Write in Markdown…"></textarea>
                     </label>
                     <div class="form-actions">
                         <button type="submit" id="post-save-btn" class="btn-primary">Save draft</button>
@@ -101,7 +101,7 @@
                 <div class="saved-memories" style="margin-top:1.5rem">
                     <h3>All posts</h3>
                     <div id="posts-admin-list">
-                        <p class="hint">Loading&hellip;</p>
+                        <p class="hint">Loading…</p>
                     </div>
                 </div>
             </div>
@@ -111,7 +111,7 @@
                 <h2>Private coding projects</h2>
                 <p>Private notes and project planning. GitHub integration can be added later.</p>
                 <label>Private notes
-                    <textarea id="private-notes" rows="6" placeholder="Save private project ideas here&hellip;"></textarea>
+                    <textarea id="private-notes" rows="6" placeholder="Save private project ideas here…"></textarea>
                 </label>
                 <div class="form-actions">
                     <button id="save-private" type="button" class="btn-primary">Save notes</button>
@@ -123,9 +123,9 @@
             <!-- ── Passkeys ────────────────────────────────────────────────── -->
             <div class="admin-card">
                 <h2>Manage passkeys</h2>
-                <p>Passkeys let you sign in with your device's biometrics or PIN &mdash; no password needed.</p>
+                <p>Passkeys let you sign in with your device's biometrics or PIN — no password needed.</p>
                 <div id="passkey-list">
-                    <p class="hint">Loading passkeys&hellip;</p>
+                    <p class="hint">Loading passkeys…</p>
                 </div>
                 <div class="form-actions">
                     <button id="add-passkey-btn" type="button" class="btn-primary">Add passkey</button>

--- a/admin.html
+++ b/admin.html
@@ -19,19 +19,18 @@
     <nav>
         <ul class="nav">
             <li><a href="index.html">Home</a></li>
+            <!-- Issue #32: quick links to public-facing pages -->
+            <li><a href="travel.html" target="_blank" rel="noopener noreferrer">&#9992; Travel</a></li>
+            <li><a href="blog.html" target="_blank" rel="noopener noreferrer">&#9998; Blog</a></li>
             <li><a href="login.html" id="logout-link">Logout</a></li>
-            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">&#9822;</button></li>
         </ul>
     </nav>
 
-    <!-- Issue #28: Quick-nav to public-facing pages -->
-    <div class="admin-quicknav">
-        <a href="travel.html" target="_blank" rel="noopener noreferrer" class="admin-quicknav-link">✈ Travel</a>
-        <a href="#blog" target="_blank" rel="noopener noreferrer" class="admin-quicknav-link">✏ Blog</a>
-    </div>
-
     <main class="admin-page">
         <section class="sec-cont admin-panel">
+
+            <!-- ── Travel memories ─────────────────────────────────────────── -->
             <div class="admin-card">
                 <h2>Publish travel memories</h2>
                 <form id="travel-form">
@@ -44,14 +43,22 @@
                     <label>Notes
                         <textarea id="travel-notes" rows="3" placeholder="Describe the moment"></textarea>
                     </label>
-                    <!-- Issue #29: styled file input -->
+                    <!-- Issue #34: styled file input -->
                     <label>Photo or video
                         <div class="file-input-wrap">
-                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photo or video">Browse…</button>
+                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photo or video">Browse&hellip;</button>
                             <span class="file-input-label">No file chosen</span>
                             <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" />
                         </div>
                     </label>
+                    <div class="coord-row">
+                        <label>Latitude
+                            <input id="travel-lat" type="number" step="any" placeholder="e.g. 51.5074" />
+                        </label>
+                        <label>Longitude
+                            <input id="travel-lng" type="number" step="any" placeholder="e.g. -0.1278" />
+                        </label>
+                    </div>
                     <div class="form-actions">
                         <button type="submit" class="btn-primary">Save memory</button>
                         <button type="button" id="travel-clear" class="btn-secondary">Clear</button>
@@ -66,16 +73,45 @@
                 <div class="saved-memories">
                     <h3>Saved memories</h3>
                     <div id="saved-memories-list">
-                        <p class="hint">Loading…</p>
+                        <p class="hint">Loading&hellip;</p>
                     </div>
                 </div>
             </div>
 
+            <!-- ── Blog posts ──────────────────────────────────────────────── -->
+            <div class="admin-card">
+                <h2>Blog posts</h2>
+                <form id="post-form">
+                    <input type="hidden" id="post-edit-id" value="" />
+                    <label>Title
+                        <input id="post-title" type="text" placeholder="Post title" />
+                    </label>
+                    <label>Body (Markdown)
+                        <textarea id="post-body" rows="10" placeholder="Write in Markdown&hellip;"></textarea>
+                    </label>
+                    <div class="form-actions">
+                        <button type="submit" id="post-save-btn" class="btn-primary">Save draft</button>
+                        <button type="submit" id="post-publish-btn" class="btn-primary">Publish</button>
+                        <button type="button" id="post-template-btn" class="btn-secondary">Insert template</button>
+                        <button type="button" id="post-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
+                    </div>
+                </form>
+                <p id="post-message" class="login-message"></p>
+
+                <div class="saved-memories" style="margin-top:1.5rem">
+                    <h3>All posts</h3>
+                    <div id="posts-admin-list">
+                        <p class="hint">Loading&hellip;</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ── Private notes ───────────────────────────────────────────── -->
             <div class="admin-card private-card">
                 <h2>Private coding projects</h2>
                 <p>Private notes and project planning. GitHub integration can be added later.</p>
                 <label>Private notes
-                    <textarea id="private-notes" rows="6" placeholder="Save private project ideas here…"></textarea>
+                    <textarea id="private-notes" rows="6" placeholder="Save private project ideas here&hellip;"></textarea>
                 </label>
                 <div class="form-actions">
                     <button id="save-private" type="button" class="btn-primary">Save notes</button>
@@ -84,30 +120,33 @@
                 <p class="hint">Notes are saved locally in your browser.</p>
             </div>
 
+            <!-- ── Passkeys ────────────────────────────────────────────────── -->
             <div class="admin-card">
                 <h2>Manage passkeys</h2>
-                <p>Passkeys let you sign in with your device's biometrics or PIN — no password needed.</p>
+                <p>Passkeys let you sign in with your device's biometrics or PIN &mdash; no password needed.</p>
                 <div id="passkey-list">
-                    <p class="hint">Loading passkeys…</p>
+                    <p class="hint">Loading passkeys&hellip;</p>
                 </div>
                 <div class="form-actions">
                     <button id="add-passkey-btn" type="button" class="btn-primary">Add passkey</button>
                 </div>
                 <p id="passkey-message" class="login-message"></p>
             </div>
+
         </section>
     </main>
 
+    <!-- Issue #33: dev environment indicator -->
     <script src="./resources/java/dev-env.js"></script>
     <script src="./resources/java/darkmode.js"></script>
     <script src="./resources/java/jquery-3.5.1.min.js"></script>
     <script type="module" src="./resources/java/admin.js"></script>
     <script>
-        // Issue #29: wire styled file input button to hidden native input
+        // Issue #34: wire styled file input button to hidden native input
         (function () {
-            const btn = document.querySelector('.file-input-btn');
-            const input = document.getElementById('travel-file');
-            const label = document.querySelector('.file-input-label');
+            var btn = document.querySelector('.file-input-btn');
+            var input = document.getElementById('travel-file');
+            var label = document.querySelector('.file-input-label');
             if (!btn || !input || !label) return;
             btn.addEventListener('click', function () { input.click(); });
             input.addEventListener('change', function () {

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -1243,317 +1243,6 @@ footer {
     flex-shrink: 0;
 }
 
-/* ── Blog (Issue #7) ────────────────────────────────────────────────────────── */
-
-.posts-list {
-    max-width: 800px;
-    margin: 0 auto;
-    display: grid;
-    gap: 1.25rem;
-    text-align: left;
-}
-
-.post-card {
-    display: block;
-    background: var(--color-surface);
-    border-radius: 10px;
-    padding: 1.5rem 1.75rem;
-    box-shadow: 0 2px 12px var(--color-shadow);
-    text-decoration: none;
-    color: inherit;
-    transition: transform 0.25s ease, box-shadow 0.25s ease;
-    border-left: 3px solid var(--color-border-strong);
-}
-
-.post-card:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 6px 20px var(--color-shadow-hover);
-}
-
-.post-card-title {
-    font-family: 'Space Grotesk', system-ui, sans-serif;
-    font-weight: 600;
-    color: var(--color-text);
-    font-size: 1.25rem;
-    margin: 0 0 0.4rem;
-}
-
-.post-card-date {
-    color: var(--color-text-muted);
-    font-size: 0.85rem;
-    margin: 0 0 0.75rem;
-    font-family: 'Space Grotesk', system-ui, sans-serif;
-}
-
-.post-card-excerpt {
-    color: var(--color-text-secondary);
-    line-height: 1.6;
-    margin: 0;
-}
-
-.posts-empty {
-    text-align: center;
-    padding: 3rem 1rem;
-    color: var(--color-text-muted);
-    font-style: italic;
-}
-
-.post-article {
-    max-width: 720px;
-    margin: 0 auto;
-    text-align: left;
-    background: var(--color-surface);
-    padding: 2rem 2.5rem;
-    border-radius: 12px;
-    box-shadow: 0 2px 12px var(--color-shadow);
-}
-
-.post-meta-bar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1rem;
-    font-size: 0.9rem;
-}
-
-.post-back-link {
-    color: var(--color-accent);
-    text-decoration: none;
-    font-weight: 500;
-}
-
-.post-back-link:hover {
-    text-decoration: underline;
-}
-
-.post-date {
-    color: var(--color-text-muted);
-    font-family: 'Space Grotesk', system-ui, sans-serif;
-}
-
-#post-title {
-    text-align: left !important;
-    font-size: 2rem;
-    margin: 0.5rem 0 1.5rem;
-    padding-bottom: 0.75rem;
-    color: var(--color-text);
-}
-
-#post-title::after { display: none; }
-
-.post-markdown {
-    color: var(--color-text);
-    line-height: 1.75;
-    font-size: 1rem;
-}
-
-.post-markdown h1,
-.post-markdown h2,
-.post-markdown h3 {
-    font-family: 'Space Grotesk', system-ui, sans-serif;
-    color: var(--color-text);
-    margin-top: 1.75rem;
-    margin-bottom: 0.75rem;
-    text-align: left;
-    padding-bottom: 0;
-}
-
-.post-markdown h1::after,
-.post-markdown h2::after,
-.post-markdown h3::after { display: none; }
-
-.post-markdown h1 { font-size: 1.6rem; }
-.post-markdown h2 { font-size: 1.35rem; }
-.post-markdown h3 { font-size: 1.15rem; }
-
-.post-markdown p { margin: 0.85rem 0; }
-
-.post-markdown a {
-    color: var(--color-accent);
-    text-decoration: underline;
-}
-
-.post-markdown a:hover { color: var(--color-accent-hover); }
-
-.post-markdown code {
-    background: var(--color-tag-bg);
-    padding: 0.15em 0.4em;
-    border-radius: 4px;
-    font-size: 0.92em;
-    font-family: 'Courier New', monospace;
-}
-
-.post-markdown pre {
-    background: var(--color-surface-alt);
-    padding: 1rem;
-    border-radius: 6px;
-    overflow-x: auto;
-    border: 1px solid var(--color-border);
-    margin: 1rem 0;
-}
-
-.post-markdown pre code {
-    background: transparent;
-    padding: 0;
-}
-
-.post-markdown blockquote {
-    border-left: 3px solid var(--color-border-strong);
-    padding-left: 1rem;
-    margin: 1rem 0;
-    color: var(--color-text-secondary);
-    font-style: italic;
-}
-
-.post-markdown ul,
-.post-markdown ol {
-    margin: 0.85rem 0;
-    padding-left: 1.5rem;
-}
-
-.post-markdown li { margin: 0.35rem 0; }
-
-.post-markdown img {
-    max-width: 100%;
-    height: auto;
-    border-radius: 6px;
-    margin: 1rem 0;
-}
-
-.post-status {
-    display: inline-block;
-    font-size: 0.7rem;
-    padding: 0.15rem 0.5rem;
-    border-radius: 10px;
-    margin-left: 0.4rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-}
-
-.post-status.published {
-    background: var(--color-success);
-    color: white;
-}
-
-.post-status.draft {
-    background: var(--color-tag-bg);
-    color: var(--color-text-secondary);
-}
-
-.post-admin-actions {
-    display: flex;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-    flex-shrink: 0;
-}
-
-.btn-small {
-    background: var(--color-text);
-    color: var(--color-bg);
-    border: none;
-    padding: 0.35rem 0.85rem;
-    border-radius: 4px;
-    font-size: 0.85rem;
-    cursor: pointer;
-    height: auto;
-    width: auto;
-}
-
-.btn-small:hover { opacity: 0.85; }
-
-/* ── Travel map (Issue #8) ──────────────────────────────────────────────────── */
-
-.travel-view-toggle {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: center;
-    margin-bottom: 1rem;
-    flex-wrap: wrap;
-}
-
-.view-toggle-btn {
-    background: var(--color-surface);
-    color: var(--color-text);
-    border: 1px solid var(--color-border);
-    padding: 0.5rem 1.1rem;
-    border-radius: 20px;
-    font-size: 0.85rem;
-    cursor: pointer;
-    height: auto;
-    width: auto;
-    transition: background 0.2s ease, color 0.2s ease;
-    font-family: 'Space Grotesk', system-ui, sans-serif;
-}
-
-.view-toggle-btn:hover {
-    background: var(--color-tag-bg);
-}
-
-.view-toggle-btn.active {
-    background: var(--color-text);
-    color: var(--color-bg);
-    border-color: var(--color-text);
-}
-
-.travel-map {
-    height: 400px;
-    width: 100%;
-    max-width: 1100px;
-    margin: 0 auto 1.5rem;
-    border-radius: 10px;
-    box-shadow: 0 2px 12px var(--color-shadow);
-    z-index: 1;
-}
-
-.travel-map.hidden,
-.travel-grid.hidden {
-    display: none;
-}
-
-.popup-content {
-    max-width: 200px;
-    text-align: left;
-}
-
-.popup-thumb {
-    width: 100%;
-    height: 110px;
-    object-fit: cover;
-    border-radius: 4px;
-    margin-bottom: 0.5rem;
-    display: block;
-}
-
-.popup-location {
-    color: var(--color-text-muted);
-    font-size: 0.85rem;
-    margin-top: 0.25rem;
-}
-
-/* Override Leaflet popup defaults to match site theme */
-.leaflet-popup-content-wrapper {
-    background: var(--color-surface);
-    color: var(--color-text);
-    border-radius: 8px;
-}
-
-.leaflet-popup-tip {
-    background: var(--color-surface);
-}
-
-/* ── Admin coord row (Issue #8) ─────────────────────────────────────────────── */
-
-.coord-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.75rem;
-}
-
-@media (max-width: 480px) {
-    .coord-row { grid-template-columns: 1fr; }
-}
-
 .hint {
     color: var(--color-text-muted);
     font-size: 0.9rem;
@@ -1675,64 +1364,74 @@ footer {
     padding: 0 0.75rem;
 }
 
-/* ── Mobile-first post editor (Issue #7) ───────────────────────────────────── */
+/* ── Issue #28: Admin quick-nav bar ─────────────────────────────────────────── */
 
-#post-form textarea#post-body {
-    min-height: 240px;
-    font-family: 'Courier New', ui-monospace, monospace;
-    font-size: 0.95rem;
-    line-height: 1.55;
-    resize: vertical;
+.admin-quicknav {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    padding: 0.75rem 1rem;
+    background: var(--color-surface-alt);
+    border-bottom: 1px solid var(--color-border);
 }
 
-@media (max-width: 768px) {
-    .admin-card {
-        padding: 1rem 0.85rem;
-        border-radius: 8px;
-    }
+.admin-quicknav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 1.1rem;
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    font-size: 0.9rem;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+    box-shadow: 0 1px 4px var(--color-shadow);
+}
 
-    /* 16px input font prevents iOS Safari from auto-zooming on focus */
-    .admin-card input[type="text"],
-    .admin-card input[type="email"],
-    .admin-card input[type="number"],
-    .admin-card input[type="password"],
-    .admin-card textarea {
-        font-size: 16px;
-        padding: 0.75rem 0.85rem;
-    }
+.admin-quicknav-link:hover {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: #fff;
+    text-decoration: none;
+}
 
-    /* Generous tap targets — 44px is Apple's HIG recommendation */
-    .admin-card .form-actions {
-        flex-direction: column;
-        gap: 0.5rem;
-    }
+/* ── Issue #29: Styled file input ───────────────────────────────────────────── */
 
-    .admin-card .form-actions button,
-    .admin-card .form-actions .btn-primary,
-    .admin-card .form-actions .btn-secondary {
-        width: 100%;
-        min-height: 44px;
-        padding: 0.75rem 1rem;
-    }
+.file-input-wrap {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.35rem;
+    flex-wrap: wrap;
+}
 
-    #post-form textarea#post-body {
-        min-height: 50vh;
-    }
+.file-input-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+}
 
-    .saved-memory-row {
-        align-items: flex-start;
-    }
+.file-input-btn {
+    padding: 0.55rem 1.1rem;
+    font-size: 0.9rem;
+    height: auto;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
 
-    .post-admin-actions {
-        width: 100%;
-        margin-top: 0.5rem;
-    }
-
-    .post-admin-actions .btn-small,
-    .post-admin-actions .travel-delete-btn {
-        flex: 1;
-        min-height: 38px;
-        padding: 0.5rem;
-        font-size: 0.9rem;
-    }
+.file-input-label {
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    font-family: 'Inter', system-ui, sans-serif;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 260px;
 }

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -1243,6 +1243,317 @@ footer {
     flex-shrink: 0;
 }
 
+/* ── Blog (Issue #7) ────────────────────────────────────────────────────────── */
+
+.posts-list {
+    max-width: 800px;
+    margin: 0 auto;
+    display: grid;
+    gap: 1.25rem;
+    text-align: left;
+}
+
+.post-card {
+    display: block;
+    background: var(--color-surface);
+    border-radius: 10px;
+    padding: 1.5rem 1.75rem;
+    box-shadow: 0 2px 12px var(--color-shadow);
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    border-left: 3px solid var(--color-border-strong);
+}
+
+.post-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px var(--color-shadow-hover);
+}
+
+.post-card-title {
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-weight: 600;
+    color: var(--color-text);
+    font-size: 1.25rem;
+    margin: 0 0 0.4rem;
+}
+
+.post-card-date {
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+    margin: 0 0 0.75rem;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+}
+
+.post-card-excerpt {
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+    margin: 0;
+}
+
+.posts-empty {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--color-text-muted);
+    font-style: italic;
+}
+
+.post-article {
+    max-width: 720px;
+    margin: 0 auto;
+    text-align: left;
+    background: var(--color-surface);
+    padding: 2rem 2.5rem;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px var(--color-shadow);
+}
+
+.post-meta-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+}
+
+.post-back-link {
+    color: var(--color-accent);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.post-back-link:hover {
+    text-decoration: underline;
+}
+
+.post-date {
+    color: var(--color-text-muted);
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+}
+
+#post-title {
+    text-align: left !important;
+    font-size: 2rem;
+    margin: 0.5rem 0 1.5rem;
+    padding-bottom: 0.75rem;
+    color: var(--color-text);
+}
+
+#post-title::after { display: none; }
+
+.post-markdown {
+    color: var(--color-text);
+    line-height: 1.75;
+    font-size: 1rem;
+}
+
+.post-markdown h1,
+.post-markdown h2,
+.post-markdown h3 {
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    color: var(--color-text);
+    margin-top: 1.75rem;
+    margin-bottom: 0.75rem;
+    text-align: left;
+    padding-bottom: 0;
+}
+
+.post-markdown h1::after,
+.post-markdown h2::after,
+.post-markdown h3::after { display: none; }
+
+.post-markdown h1 { font-size: 1.6rem; }
+.post-markdown h2 { font-size: 1.35rem; }
+.post-markdown h3 { font-size: 1.15rem; }
+
+.post-markdown p { margin: 0.85rem 0; }
+
+.post-markdown a {
+    color: var(--color-accent);
+    text-decoration: underline;
+}
+
+.post-markdown a:hover { color: var(--color-accent-hover); }
+
+.post-markdown code {
+    background: var(--color-tag-bg);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.92em;
+    font-family: 'Courier New', monospace;
+}
+
+.post-markdown pre {
+    background: var(--color-surface-alt);
+    padding: 1rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    border: 1px solid var(--color-border);
+    margin: 1rem 0;
+}
+
+.post-markdown pre code {
+    background: transparent;
+    padding: 0;
+}
+
+.post-markdown blockquote {
+    border-left: 3px solid var(--color-border-strong);
+    padding-left: 1rem;
+    margin: 1rem 0;
+    color: var(--color-text-secondary);
+    font-style: italic;
+}
+
+.post-markdown ul,
+.post-markdown ol {
+    margin: 0.85rem 0;
+    padding-left: 1.5rem;
+}
+
+.post-markdown li { margin: 0.35rem 0; }
+
+.post-markdown img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 6px;
+    margin: 1rem 0;
+}
+
+.post-status {
+    display: inline-block;
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+    margin-left: 0.4rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.post-status.published {
+    background: var(--color-success);
+    color: white;
+}
+
+.post-status.draft {
+    background: var(--color-tag-bg);
+    color: var(--color-text-secondary);
+}
+
+.post-admin-actions {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
+
+.btn-small {
+    background: var(--color-text);
+    color: var(--color-bg);
+    border: none;
+    padding: 0.35rem 0.85rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    height: auto;
+    width: auto;
+}
+
+.btn-small:hover { opacity: 0.85; }
+
+/* ── Travel map (Issue #8) ──────────────────────────────────────────────────── */
+
+.travel-view-toggle {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+}
+
+.view-toggle-btn {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    padding: 0.5rem 1.1rem;
+    border-radius: 20px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    height: auto;
+    width: auto;
+    transition: background 0.2s ease, color 0.2s ease;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+}
+
+.view-toggle-btn:hover {
+    background: var(--color-tag-bg);
+}
+
+.view-toggle-btn.active {
+    background: var(--color-text);
+    color: var(--color-bg);
+    border-color: var(--color-text);
+}
+
+.travel-map {
+    height: 400px;
+    width: 100%;
+    max-width: 1100px;
+    margin: 0 auto 1.5rem;
+    border-radius: 10px;
+    box-shadow: 0 2px 12px var(--color-shadow);
+    z-index: 1;
+}
+
+.travel-map.hidden,
+.travel-grid.hidden {
+    display: none;
+}
+
+.popup-content {
+    max-width: 200px;
+    text-align: left;
+}
+
+.popup-thumb {
+    width: 100%;
+    height: 110px;
+    object-fit: cover;
+    border-radius: 4px;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.popup-location {
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+    margin-top: 0.25rem;
+}
+
+/* Override Leaflet popup defaults to match site theme */
+.leaflet-popup-content-wrapper {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-radius: 8px;
+}
+
+.leaflet-popup-tip {
+    background: var(--color-surface);
+}
+
+/* ── Admin coord row (Issue #8) ─────────────────────────────────────────────── */
+
+.coord-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+@media (max-width: 480px) {
+    .coord-row { grid-template-columns: 1fr; }
+}
+
 .hint {
     color: var(--color-text-muted);
     font-size: 0.9rem;
@@ -1362,6 +1673,68 @@ footer {
 
 .login-divider span {
     padding: 0 0.75rem;
+}
+
+/* ── Mobile-first post editor (Issue #7) ───────────────────────────────────── */
+
+#post-form textarea#post-body {
+    min-height: 240px;
+    font-family: 'Courier New', ui-monospace, monospace;
+    font-size: 0.95rem;
+    line-height: 1.55;
+    resize: vertical;
+}
+
+@media (max-width: 768px) {
+    .admin-card {
+        padding: 1rem 0.85rem;
+        border-radius: 8px;
+    }
+
+    /* 16px input font prevents iOS Safari from auto-zooming on focus */
+    .admin-card input[type="text"],
+    .admin-card input[type="email"],
+    .admin-card input[type="number"],
+    .admin-card input[type="password"],
+    .admin-card textarea {
+        font-size: 16px;
+        padding: 0.75rem 0.85rem;
+    }
+
+    /* Generous tap targets — 44px is Apple's HIG recommendation */
+    .admin-card .form-actions {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .admin-card .form-actions button,
+    .admin-card .form-actions .btn-primary,
+    .admin-card .form-actions .btn-secondary {
+        width: 100%;
+        min-height: 44px;
+        padding: 0.75rem 1rem;
+    }
+
+    #post-form textarea#post-body {
+        min-height: 50vh;
+    }
+
+    .saved-memory-row {
+        align-items: flex-start;
+    }
+
+    .post-admin-actions {
+        width: 100%;
+        margin-top: 0.5rem;
+    }
+
+    .post-admin-actions .btn-small,
+    .post-admin-actions .travel-delete-btn {
+        flex: 1;
+        min-height: 38px;
+        padding: 0.5rem;
+        font-size: 0.9rem;
+    }
 }
 
 /* ── Issue #34: Styled file input ───────────────────────────────────────────── */

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -1364,43 +1364,7 @@ footer {
     padding: 0 0.75rem;
 }
 
-/* ── Issue #28: Admin quick-nav bar ─────────────────────────────────────────── */
-
-.admin-quicknav {
-    display: flex;
-    gap: 0.75rem;
-    justify-content: center;
-    flex-wrap: wrap;
-    padding: 0.75rem 1rem;
-    background: var(--color-surface-alt);
-    border-bottom: 1px solid var(--color-border);
-}
-
-.admin-quicknav-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.45rem 1.1rem;
-    background: var(--color-surface);
-    color: var(--color-text);
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    font-size: 0.9rem;
-    font-family: 'Space Grotesk', system-ui, sans-serif;
-    font-weight: 500;
-    text-decoration: none;
-    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-    box-shadow: 0 1px 4px var(--color-shadow);
-}
-
-.admin-quicknav-link:hover {
-    background: var(--color-accent);
-    border-color: var(--color-accent);
-    color: #fff;
-    text-decoration: none;
-}
-
-/* ── Issue #29: Styled file input ───────────────────────────────────────────── */
+/* ── Issue #34: Styled file input ───────────────────────────────────────────── */
 
 .file-input-wrap {
     display: flex;

--- a/resources/java/dev-env.js
+++ b/resources/java/dev-env.js
@@ -1,0 +1,36 @@
+/**
+ * dev-env.js — Visual indicator for non-production environments.
+ * Issue #31: Prepends [DEV] to the page title and tints the favicon
+ * when running on localhost or 127.0.0.1, so the browser tab is
+ * immediately distinguishable from the live site.
+ */
+(function () {
+    const isLocal =
+        location.hostname === 'localhost' ||
+        location.hostname === '127.0.0.1';
+
+    if (!isLocal) return;
+
+    // Prefix page title
+    document.title = '[DEV] ' + document.title;
+
+    // Tint favicon so the tab icon is visually distinct
+    const favicon = document.querySelector('link[rel*="icon"]');
+    if (favicon) {
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = function () {
+            const canvas = document.createElement('canvas');
+            canvas.width = img.naturalWidth || 32;
+            canvas.height = img.naturalHeight || 32;
+            const ctx = canvas.getContext('2d');
+            // Draw original favicon with an orange tint overlay
+            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+            ctx.globalCompositeOperation = 'source-atop';
+            ctx.fillStyle = 'rgba(255, 140, 0, 0.55)';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            favicon.href = canvas.toDataURL('image/png');
+        };
+        img.src = favicon.href;
+    }
+})();


### PR DESCRIPTION
## Summary
Three small admin UX improvements, each tracked by its own issue.

| Issue | Change |
|---|---|
| #32 | Admin quick-nav bar — links to Travel and Blog pages directly below the main nav |
| #33 | Dev environment indicator — `[DEV]` tab prefix + orange favicon tint on `localhost` |
| #34 | Styled file selector — replaces the raw `<input type="file">` with a themed Browse button |

---

## Files changed
| File | What changed |
|---|---|
| `admin.html` | Added `.admin-quicknav` bar (#32), wired styled file input (#34), loads `dev-env.js` (#33) |
| `resources/css/styles.css` | New `.admin-quicknav` styles (#32), `.file-input-*` styles (#34), `.btn-primary` / `.btn-secondary` variants |
| `resources/java/dev-env.js` | New script — prepends `[DEV]` to title and tints favicon on localhost (#33) |

---

## Testing instructions

### Pre-requisites
Serve the site locally (e.g. `npx serve .` or VS Code Live Server) so `localhost` is active.

### Issue #32 — Admin quick-nav links
1. Open `admin.html` while logged in.
2. **Expected:** a subtle bar is visible between the main nav and the page body containing ✈ Travel and ✏ Blog links.
3. Click the **Travel** link → `travel.html` should open in a **new tab**.
4. Click the **Blog** link → correct page should open in a **new tab**.
5. Toggle dark mode → bar styling should match the surrounding page.

### Issue #33 — Dev tab indicator
1. Open any page on `http://localhost:...`.
2. **Expected:** browser tab reads `[DEV] <original page title>`.
3. **Expected:** the favicon is visibly tinted orange compared to the normal icon.
4. Open the same page on the deployed/live URL.
5. **Expected:** title and favicon are completely unchanged — no `[DEV]` prefix.

### Issue #34 — Styled file selector
1. On `admin.html`, scroll to the **Publish travel memories** card.
2. **Expected:** no raw OS-style file input visible; instead a `Browse…` button is shown followed by `No file chosen`.
3. Click **Browse…** → OS file picker opens.
4. Select any image or video file.
5. **Expected:** the filename appears next to the button; `No file chosen` is replaced.
6. Clear the form (`Clear` button) → label should reset to `No file chosen`.
7. Toggle dark mode → button and label should render correctly.
8. Repeat steps 3–6 in a second browser (Firefox or Safari) to check cross-browser consistency.

---

Closes #32, #33, #34