### PR TITLE
fix(deps): upgrade multer to 2.1.1 — CVE-2025-47935, CVE-2025-47944, CVE-2025-48997

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.1.1",
     "nodemailer": "^8.0.7",
     "pg": "^8.10.0",
     "uuid": "^14.0.0"


### PR DESCRIPTION
## Security fix — multer DoS vulnerabilities

Upgrades `multer` from `^1.4.5-lts.1` to `^2.1.1` to resolve three High-severity DoS vulnerabilities flagged by Dependabot.

## CVEs resolved

| CVE | Severity | Description |
|---|---|---|
| **CVE-2025-47935** | High | Memory leak via unclosed streams under error conditions |
| **CVE-2025-47944** | High | Unhandled exception from malformed multipart request crashes server |
| **CVE-2025-48997** | High | Empty string field name causes server process crash |

All three are fixed in `multer@2.1.1`. Note: `2.0.x` introduced its own CVE so the safe minimum is `2.1.1`.

## Code compatibility

Reviewed `backend/routes/upload.js` — the only file using multer. The v2 API is **fully backward compatible** with the current usage:
- `multer.diskStorage()` ✅ unchanged
- `multer({ storage, limits, fileFilter })` ✅ unchanged
- `upload.single('file')` ✅ unchanged
- `multer.MulterError` ✅ unchanged

No changes to `upload.js` or any other file required.

## Testing checklist
- [ ] Run `npm install` in `backend/` to pull `multer@2.1.1`
- [ ] Test file upload via the admin travel form (image + video)
- [ ] Verify 20MB limit is enforced
- [ ] Verify unsupported file types are rejected
- [ ] Confirm Dependabot alert is resolved after merge