### PR TITLE
release: security fix — multer upgraded to 2.1.1 (CVE-2025-47935, CVE-2025-47944, CVE-2025-48997)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.1.1",
     "nodemailer": "^8.0.7",
     "pg": "^8.10.0",
     "uuid": "^14.0.0"


### PR DESCRIPTION
## Release summary

Patches three High-severity DoS vulnerabilities in `multer` by upgrading from `^1.4.5-lts.1` to `^2.1.1`.

## CVEs resolved

| CVE | Severity | Description |
|---|---|---|
| **CVE-2025-47935** | High | Memory leak via unclosed streams under error conditions |
| **CVE-2025-47944** | High | Unhandled exception from malformed multipart request crashes server |
| **CVE-2025-48997** | High | Empty string field name causes server process crash |

## Changes
- `backend/package.json` — `multer ^1.4.5-lts.1` → `^2.1.1`
- No application code changes required (v2 API is fully backward compatible)

## Post-merge action required
Run `npm install` in `backend/` to regenerate `package-lock.json` with the new version.

## Testing checklist
- [ ] File upload works via admin travel form (image + video)
- [ ] 20MB file size limit enforced
- [ ] Unsupported file types rejected
- [ ] Dependabot alert resolves after merge