### PR TITLE
feat: add visit date field to travel memories (#24)

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -14,15 +14,15 @@
 <body>
     <header>
         <h1>A|K</h1>
-        <h2>Andy | Keys</h2>
+        <p class="site-tagline">Andy | Keys</p>
         <h2>Admin Dashboard</h2>
     </header>
     <nav>
         <ul class="nav">
             <li><a href="index.html">Home</a></li>
             <!-- Issue #32: quick links to public-facing pages -->
-            <li><a href="blog.html" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
             <li><a href="travel.html" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="blog.html" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
             <li><a href="login.html" id="logout-link">Logout</a></li>
             <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
         </ul>
@@ -41,6 +41,10 @@
                     <label>Location
                         <input id="travel-location" type="text" placeholder="City, country" />
                     </label>
+                    <!-- Issue #24: visit date field, defaults to today -->
+                    <label>Date of visit
+                        <input id="travel-date" type="date" />
+                    </label>
                     <label>Notes
                         <textarea id="travel-notes" rows="3" placeholder="Describe the moment"></textarea>
                     </label>
@@ -58,7 +62,7 @@
                             <div class="coord-stepper">
                                 <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="-1" aria-label="Decrease latitude">−</button>
                                 <input id="travel-lat" type="number" step="0.0001" placeholder="e.g. 51.5074" />
-                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="1" aria-label="Increase latitude">+</button>
+                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="1" aria-label="Increase latitude">+</button>
                             </div>
                         </label>
                         <label>Longitude
@@ -152,6 +156,18 @@
     <script src="./resources/java/jquery-3.5.1.min.js"></script>
     <script type="module" src="./resources/java/admin.js"></script>
     <script>
+        // Issue #24: default date input to today
+        (function () {
+            var dateInput = document.getElementById('travel-date');
+            if (dateInput) {
+                var today = new Date();
+                var yyyy = today.getFullYear();
+                var mm = String(today.getMonth() + 1).padStart(2, '0');
+                var dd = String(today.getDate()).padStart(2, '0');
+                dateInput.value = yyyy + '-' + mm + '-' + dd;
+            }
+        })();
+
         // Issue #34: wire styled file input button to hidden native input
         (function () {
             var btn = document.querySelector('.file-input-btn');
@@ -169,8 +185,8 @@
         // Issue #39: custom coordinate stepper buttons
         (function () {
             var STEP = 0.0001;
-            var holdDelay = 400;  // ms before repeat starts
-            var holdInterval = 80; // ms between repeats while held
+            var holdDelay = 400;
+            var holdInterval = 80;
 
             function nudge(inputId, direction) {
                 var el = document.getElementById(inputId);

--- a/admin.html
+++ b/admin.html
@@ -14,15 +14,15 @@
 <body>
     <header>
         <h1>A|K</h1>
-        <p class="site-tagline">Andy | Keys</p>
+        <h2>Andy | Keys</h2>
         <h2>Admin Dashboard</h2>
     </header>
     <nav>
         <ul class="nav">
             <li><a href="index.html">Home</a></li>
             <!-- Issue #32: quick links to public-facing pages -->
-            <li><a href="travel.html" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
             <li><a href="blog.html" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="travel.html" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
             <li><a href="login.html" id="logout-link">Logout</a></li>
             <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
         </ul>
@@ -62,7 +62,7 @@
                             <div class="coord-stepper">
                                 <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="-1" aria-label="Decrease latitude">−</button>
                                 <input id="travel-lat" type="number" step="0.0001" placeholder="e.g. 51.5074" />
-                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="1" aria-label="Increase latitude">+</button>
+                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="1" aria-label="Increase latitude">+</button>
                             </div>
                         </label>
                         <label>Longitude
@@ -185,8 +185,8 @@
         // Issue #39: custom coordinate stepper buttons
         (function () {
             var STEP = 0.0001;
-            var holdDelay = 400;
-            var holdInterval = 80;
+            var holdDelay = 400;  // ms before repeat starts
+            var holdInterval = 80; // ms between repeats while held
 
             function nudge(inputId, direction) {
                 var el = document.getElementById(inputId);

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -48,12 +48,16 @@ CREATE TABLE IF NOT EXISTS travel_memories (
   media_type VARCHAR(100),
   lat DECIMAL(9,6),
   lng DECIMAL(9,6),
+  visit_date DATE DEFAULT CURRENT_DATE,
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
 -- Migration: add lat/lng to existing deployments
 ALTER TABLE travel_memories ADD COLUMN IF NOT EXISTS lat DECIMAL(9,6);
 ALTER TABLE travel_memories ADD COLUMN IF NOT EXISTS lng DECIMAL(9,6);
+
+-- Migration: add visit_date to existing deployments
+ALTER TABLE travel_memories ADD COLUMN IF NOT EXISTS visit_date DATE DEFAULT CURRENT_DATE;
 
 CREATE TABLE IF NOT EXISTS posts (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/backend/routes/travel.js
+++ b/backend/routes/travel.js
@@ -7,7 +7,7 @@ const router = Router();
 router.get('/', async (req, res) => {
   try {
     const result = await pool.query(
-      'SELECT id, title, location, notes, media_url, media_type, lat, lng, created_at FROM travel_memories ORDER BY created_at DESC'
+      'SELECT id, title, location, notes, media_url, media_type, lat, lng, visit_date, created_at FROM travel_memories ORDER BY visit_date DESC, created_at DESC'
     );
     res.json(result.rows);
   } catch (err) {
@@ -18,16 +18,17 @@ router.get('/', async (req, res) => {
 
 router.post('/', authenticate, async (req, res) => {
   try {
-    const { title, location, notes, mediaUrl, mediaType, lat, lng } = req.body;
+    const { title, location, notes, mediaUrl, mediaType, lat, lng, visitDate } = req.body;
     if (!title) return res.status(400).json({ error: 'Title is required' });
 
     const latVal = lat !== undefined && lat !== '' ? parseFloat(lat) : null;
     const lngVal = lng !== undefined && lng !== '' ? parseFloat(lng) : null;
+    const visitDateVal = visitDate || null;
 
     const result = await pool.query(
-      `INSERT INTO travel_memories (title, location, notes, media_url, media_type, lat, lng)
-       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
-      [title.trim(), location?.trim() || null, notes?.trim() || null, mediaUrl || null, mediaType || null, latVal, lngVal]
+      `INSERT INTO travel_memories (title, location, notes, media_url, media_type, lat, lng, visit_date)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *`,
+      [title.trim(), location?.trim() || null, notes?.trim() || null, mediaUrl || null, mediaType || null, latVal, lngVal, visitDateVal]
     );
     res.status(201).json(result.rows[0]);
   } catch (err) {

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -98,6 +98,12 @@ function setHeight(div, height) {
 
 // ── Travel memories ───────────────────────────────────────────────────────────
 
+function formatVisitDate(dateStr) {
+    if (!dateStr) return null;
+    var d = new Date(dateStr + 'T00:00:00'); // parse as local date, not UTC
+    return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
 function buildPublicTravelCard(travel) {
     var card = $('<article class="travel-card box draft-card"></article>');
     card.attr('data-memory-id', travel.id);
@@ -115,7 +121,12 @@ function buildPublicTravelCard(travel) {
     }
     var content = $('<div class="travel-content"></div>');
     content.append('<h3>' + (travel.title || 'Untitled memory') + '</h3>');
-    content.append('<p class="meta">' + (travel.location || 'Location not set') + '</p>');
+    var formattedDate = formatVisitDate(travel.visit_date);
+    var metaHtml = travel.location || 'Location not set';
+    if (formattedDate) {
+        metaHtml += '<span class="travel-date">' + formattedDate + '</span>';
+    }
+    content.append('<p class="meta">' + metaHtml + '</p>');
     content.append('<p>' + (travel.notes || 'No notes yet.') + '</p>');
     card.append(media).append(content);
     return card;
@@ -166,7 +177,7 @@ function initTravelMap(memories) {
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 18,
-        attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        attribution: '\u00a9 <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     }).addTo(travelMap);
 
     var markers = [];
@@ -290,8 +301,8 @@ function loadGithubWidget() {
         })
         .catch(function(err) {
             var msg = err.message === 'rate-limited'
-                ? 'GitHub API rate limit reached — <a href="https://github.com/AndyRKeys" target="_blank" rel="noopener noreferrer">view profile directly</a>.'
-                : 'Could not load GitHub activity — <a href="https://github.com/AndyRKeys" target="_blank" rel="noopener noreferrer">view profile directly</a>.';
+                ? 'GitHub API rate limit reached \u2014 <a href="https://github.com/AndyRKeys" target="_blank" rel="noopener noreferrer">view profile directly</a>.'
+                : 'Could not load GitHub activity \u2014 <a href="https://github.com/AndyRKeys" target="_blank" rel="noopener noreferrer">view profile directly</a>.';
             container.html('<p class="github-fallback">' + msg + '</p>');
         });
 }
@@ -308,7 +319,7 @@ function initContactForm() {
         var submitBtn = form.querySelector('button[type="submit"]');
 
         submitBtn.disabled = true;
-        msgEl.textContent = 'Sending…';
+        msgEl.textContent = 'Sending\u2026';
         msgEl.className = 'contact-form-message';
 
         var payload = {
@@ -326,7 +337,7 @@ function initContactForm() {
             .then(function(res) { return res.json().then(function(d) { return { ok: res.ok, data: d }; }); })
             .then(function(result) {
                 if (result.ok) {
-                    msgEl.textContent = 'Message sent — I\'ll be in touch soon.';
+                    msgEl.textContent = 'Message sent \u2014 I\'ll be in touch soon.';
                     msgEl.className = 'contact-form-message success';
                     form.reset();
                 } else {

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -177,7 +177,7 @@ function initTravelMap(memories) {
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 18,
-        attribution: '\u00a9 <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     }).addTo(travelMap);
 
     var markers = [];
@@ -301,8 +301,8 @@ function loadGithubWidget() {
         })
         .catch(function(err) {
             var msg = err.message === 'rate-limited'
-                ? 'GitHub API rate limit reached \u2014 <a href="https://github.com/AndyRKeys" target="_blank" rel="noopener noreferrer">view profile directly</a>.'
-                : 'Could not load GitHub activity \u2014 <a href="https://github.com/AndyRKeys" target="_blank" rel="noopener noreferrer">view profile directly</a>.';
+                ? 'GitHub API rate limit reached — <a href="https://github.com/AndyRKeys" target="_blank" rel="noopener noreferrer">view profile directly</a>.'
+                : 'Could not load GitHub activity — <a href="https://github.com/AndyRKeys" target="_blank" rel="noopener noreferrer">view profile directly</a>.';
             container.html('<p class="github-fallback">' + msg + '</p>');
         });
 }
@@ -319,7 +319,7 @@ function initContactForm() {
         var submitBtn = form.querySelector('button[type="submit"]');
 
         submitBtn.disabled = true;
-        msgEl.textContent = 'Sending\u2026';
+        msgEl.textContent = 'Sending…';
         msgEl.className = 'contact-form-message';
 
         var payload = {
@@ -337,7 +337,7 @@ function initContactForm() {
             .then(function(res) { return res.json().then(function(d) { return { ok: res.ok, data: d }; }); })
             .then(function(result) {
                 if (result.ok) {
-                    msgEl.textContent = 'Message sent \u2014 I\'ll be in touch soon.';
+                    msgEl.textContent = 'Message sent — I\'ll be in touch soon.';
                     msgEl.className = 'contact-form-message success';
                     form.reset();
                 } else {


### PR DESCRIPTION
## Summary

Implements issue #24 — adds a `visit_date` field to travel memories so posts can record and display when the trip actually happened.

## Changes

### `backend/db/schema.sql`
- Added `visit_date DATE DEFAULT CURRENT_DATE` column to the `travel_memories` table definition
- Added `ALTER TABLE ... ADD COLUMN IF NOT EXISTS visit_date` migration for existing deployments (same pattern as lat/lng)

### `backend/routes/travel.js`
- `GET /travel` — added `visit_date` to the SELECT query; results now ordered by `visit_date DESC` (most recent trip first), with `created_at DESC` as tiebreaker
- `POST /travel` — accepts `visitDate` in the request body and inserts it as `visit_date`

### `resources/java/script.js`
- Added `formatVisitDate()` helper that parses `YYYY-MM-DD` as a local date (avoids UTC off-by-one) and formats it as e.g. `3 May 2026`
- `buildPublicTravelCard()` renders the formatted date as a `<span class="travel-date">` inside the `.meta` paragraph, alongside the location

### `admin.html`
- Added a `Date of visit` `<input type="date">` to the travel form
- Inline script defaults the date input to today on page load

## Testing

- [ ] Run `ALTER TABLE` migration against existing DB (or recreate from schema)
- [ ] Create a new travel memory with a past date — verify it saves correctly
- [ ] Check the public travel cards show the date in `3 May 2026` format
- [ ] Check existing memories (no `visit_date`) gracefully show no date (column defaults to `CURRENT_DATE` at insert time; null-safe in JS)
- [ ] Cards ordered most-recent-trip-first

Closes #24