### PR TITLE
chore: add Prettier config and agent instructions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Dependencies and lock files
+node_modules/
+package-lock.json
+
+# Vendor / minified JS
+resources/java/jquery-3.5.1.min.js
+
+# Uploaded media
+uploads/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "tabWidth": 4,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Instructions
+
+Rules for AI agents (Perplexity, Copilot, etc.) working on this repo.
+
+## Scope
+
+- Only make changes explicitly requested in the linked issue or conversation
+- Never refactor, reorder, reformat, or "improve" code outside the stated scope
+- Never convert literal Unicode characters to escape sequences — `—`, `…`, `©`, `✏`, `✈`, `☾`, `−` etc. must stay as-is
+- If a change requires touching more than the requested lines, flag it and ask first — do not proceed
+
+## Branching & commits
+
+- Always branch from `dev`, never from `main`
+- Branch naming: `feat/issue-{n}-short-description`, `fix/issue-{n}-short-description`, `chore/short-description`
+- One feature or fix per branch and PR
+- Commit messages must follow Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`
+- PR title must reference the issue number where applicable: `feat: add X (#42)`
+
+## Workflow
+
+- Always read the current file from `dev` immediately before writing — never rely on a version read earlier in the session
+- Since `push_files` rewrites whole files, flag it explicitly in the PR description with: ⚠️ Full file rewrite — please check diff carefully for unintended changes
+- Raise PRs targeting `dev`; never push directly to `dev` or `main`
+- One PR per issue — do not bundle unrelated changes
+
+## Human-in-the-loop
+
+- You raise PRs; the human reviews, approves, and merges — never auto-merge
+- Deployments to the Pi are performed manually by the human via `deploy.sh`
+- If anything is unclear or the scope is ambiguous, ask before acting

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "format": "prettier --write \"**/*.{js,html,css,json}\" --ignore-path .prettierignore",
+    "format:check": "prettier --check \"**/*.{js,html,css,json}\" --ignore-path .prettierignore"
+  },
   "devDependencies": {
     "prettier": "2.7.1"
   }


### PR DESCRIPTION
## What

Adds Prettier formatting config and an `AGENTS.md` to govern AI agent behaviour in this repo.

## Files changed

| File | Purpose |
|---|---|
| `.prettierrc` | Formatting rules — literal Unicode characters preserved by default (fixes symbol escape issue) |
| `.prettierignore` | Excludes `uploads/`, minified jQuery, and lock files |
| `package.json` | Adds `format` and `format:check` scripts |
| `AGENTS.md` | Workflow rules and scope constraints for AI agents |

## Why

Recent PRs from AI agents (including this one) have inadvertently converted literal Unicode symbols (`—`, `…`, `©`) to escape sequences (`\u2014`, `\u2026`, `\u00a9`) when rewriting files. Having Prettier enforced means:
1. Running `npm run format` will restore escaped sequences back to literals
2. `npm run format:check` can be added to CI to catch regressions before merge

`AGENTS.md` documents the expected human-in-the-loop workflow so agents have explicit rules to follow from the start of each session.

## Notes

⚠️ Full file rewrite on `package.json` — diff only adds the `scripts` block, no other changes.