### PR TITLE
fix: graceful fallback for broken travel images (#23)

### DIFF
--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -110,14 +110,17 @@ function buildPublicTravelCard(travel) {
     var media = $('<div class="media"></div>');
     var mediaUrl = travel.media_url || travel.mediaUrl;
     var mediaType = travel.media_type || travel.mediaType;
+    var placeholder = './resources/img/placeholder-transparent.png';
     if (mediaUrl) {
         if (mediaType && mediaType.indexOf('video') === 0) {
             media.append('<video controls src="' + mediaUrl + '"></video>');
         } else {
-            media.append('<img src="' + mediaUrl + '" alt="Travel snapshot">');
+            var img = $('<img alt="Travel snapshot">').attr('src', mediaUrl);
+            img.on('error', function () { $(this).attr('src', placeholder); });
+            media.append(img);
         }
     } else {
-        media.append('<img src="./resources/img/placeholder-transparent.png" alt="Travel snapshot">');
+        media.append('<img src="' + placeholder + '" alt="Travel snapshot">');
     }
     var content = $('<div class="travel-content"></div>');
     content.append('<h3>' + (travel.title || 'Untitled memory') + '</h3>');


### PR DESCRIPTION
## Problem

Travel card images were not displaying on the travel page — showing a broken image icon instead of the placeholder.

## Root Cause

Two contributing factors:
1. The Nginx 502 Bad Gateway (fixed in earlier PR) meant the `/travel` API call failed entirely, so no cards rendered at all.
2. When `media_url` is set but the file can't be served (wrong path, upload failure before the `UPLOADS_DIR` fix), the `<img>` tag rendered a broken icon with no fallback.

## Fix

Added an `onerror` handler on travel card `<img>` elements that falls back to the placeholder image if the src fails to load. This gracefully handles any future cases where a stored URL can't be resolved.

## Files Changed

- `resources/java/script.js` — `onerror` fallback in `buildPublicTravelCard`

Closes #23

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_