### PR TITLE
fix: load draft body_markdown when editing posts (#22)

### DIFF
--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -55,6 +55,21 @@ router.get('/all', authenticate, async (req, res) => {
   }
 });
 
+// Admin: single post by id — includes drafts
+router.get('/admin/:id', authenticate, async (req, res) => {
+  try {
+    const result = await pool.query(
+      'SELECT id, title, slug, body_markdown, published_at, created_at FROM posts WHERE id = $1',
+      [req.params.id]
+    );
+    if (!result.rows.length) return res.status(404).json({ error: 'Post not found' });
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
 // Public: single post by slug
 router.get('/:slug', async (req, res) => {
   try {

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -377,8 +377,8 @@ async function loadAdminPosts() {
 function loadPostForEdit(post) {
     $('#post-edit-id').val(post.id);
     $('#post-title').val(post.title);
-    // Fetch full body since admin list only has excerpt
-    authFetch(`/posts/${encodeURIComponent(post.slug)}`).then(async r => {
+    // Fetch full body via admin route so drafts (published_at IS NULL) are included
+    authFetch(`/posts/admin/${post.id}`).then(async r => {
         if (r.ok) {
             const full = await r.json();
             $('#post-body').val(full.body_markdown);


### PR DESCRIPTION
Promotes fix for #22 from dev to main.\n\nDraft blog posts lost their content when clicking Edit because `loadPostForEdit` called the public `GET /posts/:slug` endpoint which filters by `published_at IS NOT NULL`. Added `GET /posts/admin/:id` (authenticated, no publish filter) and updated the frontend to use it.\n\nCloses #22

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_