### PR TITLE
fix: resolve uploads path mismatch in Docker (#23)

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -5,7 +5,9 @@ import { fileURLToPath } from 'url';
 import { authenticate } from '../middleware/authenticate.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const UPLOADS_DIR = path.join(__dirname, '..', '..', 'uploads');
+// UPLOADS_DIR env var overrides the default so Docker can point to /app/uploads
+// without the two-level relative path resolving to the container root.
+const UPLOADS_DIR = process.env.UPLOADS_DIR || path.join(__dirname, '..', '..', 'uploads');
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, UPLOADS_DIR),

--- a/backend/server.js
+++ b/backend/server.js
@@ -32,7 +32,8 @@ app.use(cors({
 app.use(express.json({ limit: '10mb' }));
 
 // Serve uploaded files in dev (Nginx handles this in production)
-app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));
+const UPLOADS_DIR = process.env.UPLOADS_DIR || path.join(__dirname, '..', 'uploads');
+app.use('/uploads', express.static(UPLOADS_DIR));
 
 app.use('/auth', authRoutes);
 app.use('/travel', travelRoutes);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-}
+      UPLOADS_DIR: /app/uploads
     ports:
       - "${PORT:-8080}:${PORT:-8080}"
     volumes:


### PR DESCRIPTION
## Problem

File uploads fail in Docker with `ENOENT: no such file or directory, open '/uploads/...'`.

In Docker, `__dirname` in `upload.js` resolves to `/app/routes`. Going up two levels lands at `/` (container root), not `/app` — so `path.join(__dirname, '..', '..', 'uploads')` becomes `/uploads` instead of `/app/uploads` where the volume is mounted.

Same issue in `server.js` for the static file middleware.

## Fix

- `backend/routes/upload.js`: use `process.env.UPLOADS_DIR || path.join(__dirname, '..', '..', 'uploads')`
- `backend/server.js`: same pattern for the `express.static` middleware
- `docker-compose.yml`: add `UPLOADS_DIR: /app/uploads` to backend environment

Native local dev is unaffected — the env var is only set in Docker.

## Test

```bash
docker-compose down
docker-compose up --build
```

Upload a photo on the travel memory form — should save without ENOENT and display on the travel page.

Closes #23

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_