### PR TITLE
fix: travel images and uploads path in Docker (#23)

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -5,7 +5,9 @@ import { fileURLToPath } from 'url';
 import { authenticate } from '../middleware/authenticate.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const UPLOADS_DIR = path.join(__dirname, '..', '..', 'uploads');
+// UPLOADS_DIR env var overrides the default so Docker can point to /app/uploads
+// without the two-level relative path resolving to the container root.
+const UPLOADS_DIR = process.env.UPLOADS_DIR || path.join(__dirname, '..', '..', 'uploads');
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, UPLOADS_DIR),

--- a/backend/server.js
+++ b/backend/server.js
@@ -32,7 +32,8 @@ app.use(cors({
 app.use(express.json({ limit: '10mb' }));
 
 // Serve uploaded files in dev (Nginx handles this in production)
-app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));
+const UPLOADS_DIR = process.env.UPLOADS_DIR || path.join(__dirname, '..', 'uploads');
+app.use('/uploads', express.static(UPLOADS_DIR));
 
 app.use('/auth', authRoutes);
 app.use('/travel', travelRoutes);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-}
+      UPLOADS_DIR: /app/uploads
     ports:
       - "${PORT:-8080}:${PORT:-8080}"
     volumes:

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -110,14 +110,17 @@ function buildPublicTravelCard(travel) {
     var media = $('<div class="media"></div>');
     var mediaUrl = travel.media_url || travel.mediaUrl;
     var mediaType = travel.media_type || travel.mediaType;
+    var placeholder = './resources/img/placeholder-transparent.png';
     if (mediaUrl) {
         if (mediaType && mediaType.indexOf('video') === 0) {
             media.append('<video controls src="' + mediaUrl + '"></video>');
         } else {
-            media.append('<img src="' + mediaUrl + '" alt="Travel snapshot">');
+            var img = $('<img alt="Travel snapshot">').attr('src', mediaUrl);
+            img.on('error', function () { $(this).attr('src', placeholder); });
+            media.append(img);
         }
     } else {
-        media.append('<img src="./resources/img/placeholder-transparent.png" alt="Travel snapshot">');
+        media.append('<img src="' + placeholder + '" alt="Travel snapshot">');
     }
     var content = $('<div class="travel-content"></div>');
     content.append('<h3>' + (travel.title || 'Untitled memory') + '</h3>');

--- a/scripts/dev-local.ps1
+++ b/scripts/dev-local.ps1
@@ -1,1 +1,3 @@
+$args = 'up'
+
 & 'C:\Program Files\Git\bin\bash.exe' -c "bash '$(Split-Path -Parent $PSScriptRoot)/scripts/dev-local.sh' $args"

--- a/scripts/prod-deploy.ps1
+++ b/scripts/prod-deploy.ps1
@@ -3,4 +3,4 @@
 #
 # Usage: .\scripts\prod-deploy.ps1
 
-& 'C:\Program Files\Git\bin\bash.exe' -c "ssh raspberrypi3 'bash ~/MyPortfolioSite/scripts/prod-deploy.sh'"
+ssh raspberrypi3 'bash ~/MyPortfolioSite/scripts/prod-deploy.sh'


### PR DESCRIPTION
Promotes two fixes for #23 from dev to main:\n\n- **Uploads path**: `UPLOADS_DIR` env var overrides the relative path in Docker so files are written to `/app/uploads` (the mounted volume) instead of `/uploads` at the container root (ENOENT)\n- **Image fallback**: `onerror` handler on travel card images falls back to placeholder if a stored URL can't be served\n\nAlso includes deploy script updates.\n\nCloses #23

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_