### PR TITLE
fix: use /api prefix for production API base URL (#61)

### DIFF
--- a/resources/java/config.js
+++ b/resources/java/config.js
@@ -1,3 +1,4 @@
 const isDev = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-// In dev, use same hostname as frontend (localhost/127.0.0.1) to ensure WebAuthn origin matching
-export const API = isDev ? `http://${window.location.hostname}:8080` : '';
+// In dev, point directly at the backend port so WebAuthn origin matching works.
+// In production, all API requests are prefixed with /api and proxied by nginx.
+export const API = isDev ? `http://${window.location.hostname}:8080` : '/api';


### PR DESCRIPTION
## Summary

Fixes #61 — all admin write operations (create, edit, publish, delete) were returning `405 Method Not Allowed` in production because API requests were hitting nginx at root-level paths (`/travel`, `/posts` etc.) instead of being proxied to the Node backend.

## Change

**`resources/java/config.js`**
```diff
- export const API = isDev ? `http://${window.location.hostname}:8080` : '';
+ export const API = isDev ? `http://${window.location.hostname}:8080` : '/api';
```

## Required server-side change

This fix also requires an nginx `location /api/` proxy block to be added on the Pi. Add the following to your nginx site config:

```nginx
location /api/ {
    proxy_pass http://localhost:3000/;
    proxy_http_version 1.1;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
}
```

Then reload nginx: `sudo nginx -s reload`

## Testing

- [ ] Travel memory create/edit/delete works in production
- [ ] Blog post create/edit/delete works in production
- [ ] Auth (login, passkey) still works
- [ ] File upload still works
- [ ] Dev environment unaffected (still uses `:8080` directly)

Closes #61