### PR TITLE
fix: use /api prefix for production API base URL (#61)

### DIFF
--- a/resources/java/config.js
+++ b/resources/java/config.js
@@ -1,3 +1,4 @@
 const isDev = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-// In dev, use same hostname as frontend (localhost/127.0.0.1) to ensure WebAuthn origin matching
-export const API = isDev ? `http://${window.location.hostname}:8080` : '';
+// In dev, point directly at the backend port so WebAuthn origin matching works.
+// In production, all API requests are prefixed with /api and proxied by nginx.
+export const API = isDev ? `http://${window.location.hostname}:8080` : '/api';


### PR DESCRIPTION
Promotes fix from #62 to main.

Fixes #61 — production API requests were hitting nginx at root-level paths causing `405 Method Not Allowed` on all admin write operations.

**Reminder:** nginx proxy block also required on the Pi after deploy:
```nginx
location /api/ {
    proxy_pass http://localhost:3000/;
    proxy_http_version 1.1;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
}
```
Then `sudo nginx -s reload`.

Closes #61