### PR TITLE
fix: nginx /api prefix, reliable deploy, correct setup guidance (#64)

### DIFF
--- a/resources/java/config.js
+++ b/resources/java/config.js
@@ -1,3 +1,4 @@
 const isDev = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-// In dev, use same hostname as frontend (localhost/127.0.0.1) to ensure WebAuthn origin matching
-export const API = isDev ? `http://${window.location.hostname}:8080` : '';
+// In dev, point directly at the backend port so WebAuthn origin matching works.
+// In production, all API requests are prefixed with /api and proxied by nginx.
+export const API = isDev ? `http://${window.location.hostname}:8080` : '/api';

--- a/scripts/nginx-portfolio.conf.template
+++ b/scripts/nginx-portfolio.conf.template
@@ -2,7 +2,7 @@
 # Rendered by `envsubst` with an explicit allow-list (DOMAIN, REPO_DIR,
 # APP_PORT, BACKEND_HOST) so Nginx-native $vars (e.g. $host, $uri) are preserved.
 # BACKEND_HOST defaults to 127.0.0.1 for production, override to 'backend' for Docker.
-# Used by both scripts/pi-setup.sh (initial setup) and scripts/deploy.sh
+# Used by both scripts/pi-setup.sh (initial setup) and scripts/prod-deploy.sh
 # (continuous deployment).
 server {
     listen 80;
@@ -14,9 +14,11 @@ server {
     # Allow larger file uploads (matches multer 20 MB limit + headroom)
     client_max_body_size 25M;
 
-    # Proxy all backend API routes to Node
-    location ~ ^/(auth|travel|contact|posts|upload)(/|$) {
-        proxy_pass http://${BACKEND_HOST}:${APP_PORT};
+    # Proxy all API traffic to Node backend.
+    # The /api prefix is stripped before forwarding (trailing slash on proxy_pass).
+    location /api/ {
+        proxy_pass http://${BACKEND_HOST}:${APP_PORT}/;
+        proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -25,7 +27,8 @@ server {
 
     # Health check
     location /health {
-        proxy_pass http://${BACKEND_HOST}:${APP_PORT};
+        proxy_pass http://${BACKEND_HOST}:${APP_PORT}/health;
+        proxy_set_header Host $host;
     }
 
     # Uploaded media served directly by Nginx from repo-root uploads/ dir

--- a/scripts/pi-setup.sh
+++ b/scripts/pi-setup.sh
@@ -13,7 +13,7 @@ echo "=== Portfolio Pi Setup ==="
 # ── 1. System packages ────────────────────────────────────────────────────────
 echo "[1/7] Installing system packages..."
 sudo apt-get update -qq
-sudo apt-get install -y curl git nginx postgresql postgresql-contrib
+sudo apt-get install -y curl git nginx postgresql postgresql-contrib gettext-base
 
 # ── 2. Node.js 20 LTS ─────────────────────────────────────────────────────────
 echo "[2/7] Installing Node.js 20..."
@@ -102,9 +102,6 @@ cd "$HOME"
 # ── 7. Nginx ──────────────────────────────────────────────────────────────────
 echo "[7/7] Configuring Nginx..."
 
-# envsubst lives in gettext-base; install if missing
-command -v envsubst >/dev/null || sudo apt-get install -y gettext-base
-
 BACKEND_HOST=127.0.0.1
 export DOMAIN REPO_DIR APP_PORT BACKEND_HOST
 envsubst '${DOMAIN} ${REPO_DIR} ${APP_PORT} ${BACKEND_HOST}' \
@@ -123,10 +120,9 @@ echo "  Nginx:   serving on port 80"
 echo "  Domain:  http://$DOMAIN"
 echo ""
 echo "Next steps:"
-echo "  1. Clone or copy your site to: $REPO_DIR"
-echo "     (if not already there — this script assumed it exists)"
-echo "  2. Update resources/java/config.js: set API = ''"
-echo "  3. Set up Cloudflare Tunnel for HTTPS public access"
-echo "  4. Visit http://$DOMAIN/setup.html to create your admin account"
+echo "  1. Set up SSL: run scripts/setup-ssl.ps1 or configure Certbot/Cloudflare Tunnel"
+echo "  2. Visit https://$DOMAIN/setup.html to create your admin account"
+echo "  3. Future deploys: bash ~/MyPortfolioSite/scripts/prod-deploy.sh"
 echo ""
 echo "Test backend: curl http://localhost:$APP_PORT/health"
+echo "Test via nginx: curl http://localhost/api/health"

--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -2,9 +2,10 @@
 # Smart deploy script for andykeys.me
 # Detects what changed and only applies what's needed:
 #   - Always pulls latest code
+#   - Always ensures nginx config is rendered and symlinked (idempotent)
 #   - npm install (if backend/package.json changed)
 #   - psql -f schema.sql (if backend/db/schema.sql changed)
-#   - render + reload nginx (if nginx template changed)
+#   - render + reload nginx (if template changed or config missing)
 #   - pm2 restart (if any backend file changed)
 # Run on the Pi: bash ~/MyPortfolioSite/scripts/prod-deploy.sh
 set -e
@@ -65,9 +66,13 @@ if [ "$SCHEMA_CHANGED" -gt 0 ]; then
     fi
 fi
 
-# Render and reload Nginx if template changed
-if [ "$NGINX_CHANGED" -gt 0 ]; then
-    echo "=== nginx template changed — rendering and reloading ==="
+# ── Nginx — always ensure config is rendered and symlinked ───────────────────
+# Runs if: template changed OR config file is missing OR symlink is missing.
+NGINX_CONF=/etc/nginx/sites-available/portfolio
+NGINX_LINK=/etc/nginx/sites-enabled/portfolio
+
+if [ "$NGINX_CHANGED" -gt 0 ] || [ ! -f "$NGINX_CONF" ] || [ ! -L "$NGINX_LINK" ]; then
+    echo "=== Rendering and applying nginx config ==="
     if [ -f backend/.env ]; then
         DOMAIN=$(grep "^WEBAUTHN_RP_ID=" backend/.env | cut -d= -f2)
         APP_PORT=$(grep "^PORT=" backend/.env | cut -d= -f2)
@@ -84,8 +89,12 @@ if [ "$NGINX_CHANGED" -gt 0 ]; then
                 < "$REPO_DIR/scripts/nginx-portfolio.conf.template" \
                 > /tmp/portfolio.conf
 
-            sudo cp /tmp/portfolio.conf /etc/nginx/sites-available/portfolio
+            sudo cp /tmp/portfolio.conf "$NGINX_CONF"
             rm /tmp/portfolio.conf
+
+            # Idempotent symlink
+            sudo ln -sf "$NGINX_CONF" "$NGINX_LINK"
+            sudo rm -f /etc/nginx/sites-enabled/default
 
             if sudo nginx -t; then
                 sudo systemctl reload nginx
@@ -98,6 +107,8 @@ if [ "$NGINX_CHANGED" -gt 0 ]; then
     else
         echo "  WARN: backend/.env missing — skipping nginx update"
     fi
+else
+    echo "=== Nginx config unchanged and already applied — skipping ==="
 fi
 
 # Restart backend if any backend file changed


### PR DESCRIPTION
Promotes fix from #65 to main.

Fixes #64 — nginx config was never applied on deploy, bare route regex replaced with clean `/api/` proxy block, deploy script now self-heals missing config/symlink.

**After deploying on the Pi, run:**
```bash
bash ~/MyPortfolioSite/scripts/prod-deploy.sh
```
This will render the nginx config, create the symlink, and reload nginx automatically.

Verify with:
```bash
curl http://localhost/api/health
```

Closes #64