### PR TITLE
fix: nginx template includes SSL, deploy preserves HTTPS (#67)

### DIFF
--- a/scripts/nginx-portfolio.conf.template
+++ b/scripts/nginx-portfolio.conf.template
@@ -4,9 +4,27 @@
 # BACKEND_HOST defaults to 127.0.0.1 for production, override to 'backend' for Docker.
 # Used by both scripts/pi-setup.sh (initial setup) and scripts/prod-deploy.sh
 # (continuous deployment).
+#
+# SSL NOTE: Certificate paths are fixed by certbot on first run of pi-setup.sh.
+# Re-rendering this template on deploy does NOT break HTTPS because the cert
+# paths are hardcoded here — certbot manages cert renewal, not nginx config.
+
+# HTTP → HTTPS redirect
 server {
     listen 80;
-    server_name ${DOMAIN} www.${DOMAIN} raspberrypi3.local;
+    server_name ${DOMAIN} www.${DOMAIN};
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS server
+server {
+    listen 443 ssl;
+    server_name ${DOMAIN} www.${DOMAIN};
+
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
 
     root ${REPO_DIR};
     index index.html;

--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -2,12 +2,11 @@
 # Smart deploy script for andykeys.me
 # Detects what changed and only applies what's needed:
 #   - Always pulls latest code
-#   - Always runs npm install (ensures no missing packages after any change)
-#   - Always ensures nginx config is rendered and symlinked (idempotent)
-#   - psql -f schema.sql (if backend/db/schema.sql changed)
-#   - render + reload nginx (if template changed or config missing)
-#   - pm2 restart (if any backend file changed)
-#   - Post-deploy health check (fails loudly if backend won't start)
+#   - Always runs npm install (ensures no missing packages)
+#   - Renders nginx config from template if changed/missing (SSL-aware)
+#   - Applies DB schema if changed
+#   - Restarts PM2 if backend changed
+#   - Post-deploy health check: verifies HTTP, HTTPS, and backend
 # Run on the Pi: bash ~/MyPortfolioSite/scripts/prod-deploy.sh
 set -e
 
@@ -41,15 +40,12 @@ git pull origin main
 mkdir -p "$REPO_DIR/uploads"
 
 # ── npm install (always) ──────────────────────────────────────────────────────
-# Run unconditionally — ensures packages are never missing regardless of what
-# changed. Uses --omit=dev to keep memory footprint small on the Pi.
 echo "=== Installing backend dependencies ==="
 cd "$REPO_DIR/backend"
 npm install --omit=dev --silent
 cd "$REPO_DIR"
 
-# Apply DB schema if it changed
-# Schema is idempotent (CREATE TABLE IF NOT EXISTS, ADD COLUMN IF NOT EXISTS)
+# ── DB schema migration ────────────────────────────────────────────────
 if [ "$SCHEMA_CHANGED" -gt 0 ]; then
     echo "=== schema.sql changed — applying migration ==="
     if [ -f backend/.env ]; then
@@ -67,9 +63,10 @@ if [ "$SCHEMA_CHANGED" -gt 0 ]; then
     fi
 fi
 
-# ── Nginx — always ensure config is rendered and symlinked ───────────────────
+# ── Nginx config ──────────────────────────────────────────────────────
 NGINX_CONF=/etc/nginx/sites-available/portfolio
 NGINX_LINK=/etc/nginx/sites-enabled/portfolio
+CERT_PATH=/etc/letsencrypt/live
 
 if [ "$NGINX_CHANGED" -gt 0 ] || [ ! -f "$NGINX_CONF" ] || [ ! -L "$NGINX_LINK" ]; then
     echo "=== Rendering and applying nginx config ==="
@@ -85,9 +82,52 @@ if [ "$NGINX_CHANGED" -gt 0 ] || [ ! -f "$NGINX_CONF" ] || [ ! -L "$NGINX_LINK" 
 
             BACKEND_HOST=127.0.0.1
             export DOMAIN REPO_DIR APP_PORT BACKEND_HOST
+
+            # Check if SSL cert exists for this domain
+            if [ -f "$CERT_PATH/$DOMAIN/fullchain.pem" ]; then
+                echo "  SSL cert found for $DOMAIN — rendering with HTTPS"
+                TEMPLATE="$REPO_DIR/scripts/nginx-portfolio.conf.template"
+            else
+                echo "  WARN: No SSL cert found at $CERT_PATH/$DOMAIN — rendering HTTP-only"
+                echo "  Run: sudo certbot --nginx -d $DOMAIN -d www.$DOMAIN"
+                # Fall back to HTTP-only template (inline)
+                TEMPLATE=$(mktemp)
+                cat > "$TEMPLATE" <<'HTTPONLY'
+server {
+    listen 80;
+    server_name ${DOMAIN} www.${DOMAIN} raspberrypi3.local;
+    root ${REPO_DIR};
+    index index.html;
+    client_max_body_size 25M;
+    location /api/ {
+        proxy_pass http://${BACKEND_HOST}:${APP_PORT}/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /health {
+        proxy_pass http://${BACKEND_HOST}:${APP_PORT}/health;
+        proxy_set_header Host $host;
+    }
+    location /uploads/ {
+        alias ${REPO_DIR}/uploads/;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+    location / {
+        try_files $uri $uri/ $uri.html =404;
+    }
+}
+HTTPONLY
+            fi
+
             envsubst '${DOMAIN} ${REPO_DIR} ${APP_PORT} ${BACKEND_HOST}' \
-                < "$REPO_DIR/scripts/nginx-portfolio.conf.template" \
-                > /tmp/portfolio.conf
+                < "$TEMPLATE" > /tmp/portfolio.conf
+
+            # Clean up temp template if we created one
+            [ -f "$TEMPLATE" ] && [[ "$TEMPLATE" == /tmp/* ]] && rm -f "$TEMPLATE"
 
             sudo cp /tmp/portfolio.conf "$NGINX_CONF"
             rm /tmp/portfolio.conf
@@ -109,7 +149,7 @@ else
     echo "=== Nginx config unchanged and already applied — skipping ==="
 fi
 
-# ── Restart backend if any backend file changed ───────────────────────────────
+# ── Restart backend ──────────────────────────────────────────────────────────
 if [ "$BACKEND_CHANGED" -gt 0 ]; then
     echo "=== Backend changed — restarting PM2 ==="
     pm2 restart portfolio-backend
@@ -120,27 +160,39 @@ fi
 
 # ── Post-deploy health check ──────────────────────────────────────────────────
 echo ""
-echo "=== Health check ==="
+echo "=== Health checks ==="
+
+# Backend direct
 MAX_WAIT=20
 ELAPSED=0
 until curl -sf http://localhost:8080/health > /dev/null 2>&1; do
     if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
         echo "ERROR: Backend did not respond on :8080 after ${MAX_WAIT}s" >&2
-        echo "--- PM2 logs ---"
         pm2 logs portfolio-backend --lines 30 --nostream
         exit 1
     fi
     sleep 2
     ELAPSED=$((ELAPSED + 2))
 done
-echo "Backend healthy on :8080 ✓"
+echo "  Backend :8080        ✓"
 
-# Nginx proxy check
+# HTTP via nginx
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/health)
 if [ "$HTTP_CODE" = "200" ]; then
-    echo "Nginx proxy healthy (HTTP $HTTP_CODE) ✓"
+    echo "  HTTP nginx proxy     ✓"
 else
-    echo "WARN: Nginx proxy returned HTTP $HTTP_CODE — check nginx config" >&2
+    echo "  WARN: HTTP nginx returned $HTTP_CODE" >&2
+fi
+
+# HTTPS (only check if cert exists)
+DOMAIN=$(grep "^WEBAUTHN_RP_ID=" backend/.env 2>/dev/null | cut -d= -f2)
+if [ -n "$DOMAIN" ] && [ -f "/etc/letsencrypt/live/$DOMAIN/fullchain.pem" ]; then
+    HTTPS_CODE=$(curl -sf -o /dev/null -w "%{http_code}" https://$DOMAIN/health 2>/dev/null || echo "000")
+    if [ "$HTTPS_CODE" = "200" ]; then
+        echo "  HTTPS $DOMAIN ✓"
+    else
+        echo "  WARN: HTTPS returned $HTTPS_CODE — run: sudo certbot --nginx -d $DOMAIN -d www.$DOMAIN" >&2
+    fi
 fi
 
 echo ""
@@ -148,4 +200,4 @@ echo "=== PM2 Status ==="
 pm2 status portfolio-backend
 
 echo ""
-echo "Done! https://andykeys.me"
+echo "Done! https://$DOMAIN"


### PR DESCRIPTION
Closes #67

## Problem

Every deploy that re-rendered the nginx config from the template silently destroyed the SSL configuration injected by `certbot --nginx`, leaving the site HTTP-only.

## Changes

### `scripts/nginx-portfolio.conf.template`
- Now contains the **full SSL server block** with hardcoded certbot certificate paths
- Adds an HTTP → HTTPS redirect server block
- Cert paths (`/etc/letsencrypt/live/${DOMAIN}/fullchain.pem`) are stable after first `pi-setup.sh` run — certbot manages renewal, not nginx config

### `scripts/prod-deploy.sh`
- **Cert-aware rendering**: checks whether an SSL cert exists for the domain before rendering; falls back to HTTP-only template with a clear warning if not (e.g. first run before certbot)
- **HTTPS health check added**: post-deploy check now verifies `https://$DOMAIN/health` returns 200, warns loudly if not
- Backend and HTTP checks unchanged

## How it works now

1. `pi-setup.sh` runs `certbot --nginx` once on initial setup — cert is issued and stored at `/etc/letsencrypt/live/andykeys.me/`
2. All subsequent deploys render the template with SSL paths already included — certbot doesn't need to touch the config again
3. Cert renewal (via `certbot.timer`) only updates the cert files, not the nginx config — so deploys and renewals are fully independent
4. If HTTPS breaks after a deploy, the health check will warn immediately rather than silently failing

## Testing

- [ ] `sudo nginx -t` passes after rendering new template
- [ ] `https://andykeys.me` returns 200
- [ ] `http://andykeys.me` redirects to HTTPS
- [ ] Re-running `prod-deploy.sh` does not break HTTPS