### PR TITLE
fix: API_BASE uses /api prefix on prod, empty string on localhost (#69)

### DIFF
--- a/resources/java/blog.js
+++ b/resources/java/blog.js
@@ -1,4 +1,5 @@
-var API_BASE = '';
+// API base — /api in production (Nginx proxy strips prefix), empty string in dev
+var API_BASE = (location.hostname === 'localhost' || location.hostname === '127.0.0.1') ? '' : '/api';
 
 function escapeHtml(str) {
     return String(str)

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -1,5 +1,5 @@
-// API base — empty string in production (Nginx proxy), backend URL in dev
-var API_BASE = '';
+// API base — /api in production (Nginx proxy strips prefix), empty string in dev
+var API_BASE = (location.hostname === 'localhost' || location.hostname === '127.0.0.1') ? '' : '/api';
 
 // duration of scroll animation
 var scrollDuration = 300;


### PR DESCRIPTION
Closes #69

## Problem

Both `script.js` and `blog.js` had `API_BASE = ''` hardcoded. On production, nginx requires the `/api/` prefix to proxy requests to the Node backend. Without it, calls to `/travel` and `/posts` were being served as static HTML files by nginx instead.

This worked locally because the dev server proxies directly to the backend with no prefix needed.

## Fix

One-line runtime detection in both files:

```js
var API_BASE = (location.hostname === 'localhost' || location.hostname === '127.0.0.1') ? '' : '/api';
```

- No build step required
- No environment variables needed
- Works correctly in both dev and prod
- `/travel` → `/api/travel` on prod ✓
- `/posts` → `/api/posts` on prod ✓
- `/contact` → `/api/contact` on prod ✓

## Testing
- [ ] `https://andykeys.me/travel.html` shows travel posts
- [ ] `https://andykeys.me/blog.html` shows blog posts
- [ ] Both still work on localhost dev