### PR TITLE
fix: mobile responsiveness — hamburger nav, overflow guard, img fix (#16)

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -21,6 +21,10 @@
         <h2>Admin Dashboard</h2>
     </header>
     <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
         <ul class="nav">
             <li><a href="index.html">Home</a></li>
             <li><a href="blog.html" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
@@ -171,6 +175,7 @@
     <!-- Issue #33: dev environment indicator -->
     <script src="./resources/java/dev-env.js"></script>
     <script src="./resources/java/darkmode.js"></script>
+    <script src="./resources/java/nav.js"></script>
     <script src="./resources/java/jquery-3.5.1.min.js"></script>
     <script type="module" src="./resources/java/admin.js"></script>
     <script>

--- a/blog-post.html
+++ b/blog-post.html
@@ -18,6 +18,10 @@
         <h2 id="post-header-title">Loading…</h2>
     </header>
     <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
         <ul class="nav">
             <li><a href="index.html">🏠 Home</a></li>
             <li><a href="index.html#about">👤 About</a></li>
@@ -64,6 +68,7 @@
 
     <script src="./resources/java/dev-env.js"></script>
     <script src="./resources/java/darkmode.js"></script>
+    <script src="./resources/java/nav.js"></script>
     <!-- Pinned to v9 for stable synchronous marked.parse() API -->
     <script src="https://cdn.jsdelivr.net/npm/marked@9/marked.min.js"></script>
     <script src="./resources/java/jquery-3.5.1.min.js"></script>

--- a/blog.html
+++ b/blog.html
@@ -18,6 +18,10 @@
         <h2>Writing</h2>
     </header>
     <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
         <ul class="nav">
             <li><a href="index.html">🏠 Home</a></li>
             <li><a href="index.html#about">👤 About</a></li>
@@ -68,6 +72,7 @@
 
     <script src="./resources/java/dev-env.js"></script>
     <script src="./resources/java/darkmode.js"></script>
+    <script src="./resources/java/nav.js"></script>
     <script src="./resources/java/jquery-3.5.1.min.js"></script>
     <script src="./resources/java/auth-utils.js"></script>
     <!-- script.js must load before blog.js to expose window.buildTimelineItem -->

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
         <h2>Portfolio</h2>
     </header>
     <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
         <ul class="nav">
             <li><a href="#home">🏠 Home</a></li>
             <li><a href="#about">👤 About</a></li>
@@ -342,6 +346,7 @@
 
     <script src="./resources/java/dev-env.js"></script>
     <script src="./resources/java/darkmode.js"></script>
+    <script src="./resources/java/nav.js"></script>
     <script src="./resources/java/jquery-3.5.1.min.js"></script>
     <script src="./resources/java/auth-utils.js"></script>
     <script src="./resources/java/script.js"></script>

--- a/login.html
+++ b/login.html
@@ -18,6 +18,10 @@
         <h2>Admin Login</h2>
     </header>
     <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
         <ul class="nav">
             <li><a href="index.html">🏠 Home</a></li>
             <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
@@ -162,5 +166,6 @@
         });
     </script>
     <script src="./resources/java/darkmode.js"></script>
+    <script src="./resources/java/nav.js"></script>
 </body>
 </html>

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -4,6 +4,15 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
+/* ── Prevent horizontal overflow on all screen sizes ────────────────────── */
+html {
+    overflow-x: hidden;
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
 /* ── CSS custom properties (colour tokens) ──────────────────────────────────── */
 
 :root {
@@ -76,7 +85,8 @@
 
 body {
     font-family: 'Inter', system-ui, sans-serif;
-    margin: 0 10%;
+    /* cap side margins so mid-tablet content isn't over-indented */
+    margin: 0 min(10%, 140px);
     background-color: var(--color-bg);
     color: var(--color-text);
     transition: background-color 0.3s ease, color 0.3s ease;
@@ -162,13 +172,40 @@ strong {
 
 nav {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     width: 100%;
     position: -webkit-sticky;
-    position: sticky;    
+    position: sticky;
     top: 0;
-    overflow: hidden;
     z-index: 99;
+    background-color: var(--color-nav-bg);
+}
+
+/* Hamburger toggle — hidden on desktop, visible on mobile */
+.nav-toggle {
+    display: none;
+    width: 100%;
+    background: var(--color-nav-bg);
+    color: var(--color-nav-text);
+    border: none;
+    border-radius: 0;
+    padding: 14px 1.25rem;
+    font-size: 0.95rem;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-weight: 500;
+    cursor: pointer;
+    align-items: center;
+    justify-content: space-between;
+    height: auto;
+}
+
+.nav-toggle:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.nav-toggle-icon {
+    font-size: 1.25rem;
+    line-height: 1;
 }
 
 ul.nav {
@@ -176,7 +213,7 @@ ul.nav {
     flex-wrap: wrap;
     justify-content: center;
     width: 100%;
-    margin: 0 auto;
+    margin: 0;
     padding: 0;
     list-style: none;
     background-color: var(--color-nav-bg);
@@ -198,21 +235,19 @@ ul.nav {
     display: block;
     font-size: 0.95rem;
     transition: background-color 0.2s ease;
+    white-space: nowrap;
 }
 
-li.nav a:hover {
-    background-color: #111;
-}
-
-li a:hover {
-    background-color: #111;
+.nav a:hover,
+.nav li a:hover {
+    background-color: rgba(255, 255, 255, 0.1);
 }
 
 .sec-cont {
     width: 100%;
-    display: flexbox;
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    align-content: center;
     text-align: center;
 }
 
@@ -300,8 +335,8 @@ li a:hover {
 }
 
 img {
-    height: 100%;
-    width: 100%;
+    max-width: 100%;
+    height: auto;
 }
 
 .hs-wrap {
@@ -896,6 +931,50 @@ footer {
 }
 
 @media screen and (max-width: 768px) {
+    /* ── Hamburger nav ───────────────────────────────────────────────────── */
+    .nav-toggle {
+        display: flex;
+    }
+
+    ul.nav {
+        display: none;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        border-top: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    ul.nav.nav-open {
+        display: flex;
+    }
+
+    .nav li {
+        width: 100%;
+        display: flex;
+    }
+
+    .nav a {
+        text-align: left;
+        padding: 13px 1.5rem;
+        width: 100%;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    /* dark mode toggle in collapsed nav */
+    .nav li #dark-mode-toggle {
+        width: 100%;
+        text-align: left;
+        border-radius: 0;
+        padding: 13px 1.5rem;
+        height: auto;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+        font-size: 0.95rem;
+        background: transparent;
+        border-top: none;
+        border-left: none;
+        border-right: none;
+    }
+
+    /* ── General mobile layout ──────────────────────────────────────────── */
     .cert-card {
         flex-direction: column;
         align-items: flex-start;

--- a/resources/java/nav.js
+++ b/resources/java/nav.js
@@ -1,0 +1,21 @@
+(function () {
+    var toggle = document.querySelector('.nav-toggle');
+    var menu = document.querySelector('ul.nav');
+    if (!toggle || !menu) return;
+
+    toggle.addEventListener('click', function () {
+        var isOpen = menu.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+        toggle.querySelector('.nav-toggle-icon').textContent = isOpen ? '✕' : '☰';
+    });
+
+    // Close the menu when any nav link is clicked (single-page anchor nav)
+    menu.querySelectorAll('a').forEach(function (link) {
+        link.addEventListener('click', function () {
+            menu.classList.remove('nav-open');
+            toggle.setAttribute('aria-expanded', 'false');
+            var icon = toggle.querySelector('.nav-toggle-icon');
+            if (icon) icon.textContent = '☰';
+        });
+    });
+})();

--- a/travel.html
+++ b/travel.html
@@ -20,6 +20,10 @@
         <h2>Travel Blog</h2>
     </header>
     <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
         <ul class="nav">
             <li><a href="index.html">🏠 Home</a></li>
             <li><a href="index.html#about">👤 About</a></li>
@@ -74,6 +78,7 @@
 
     <script src="./resources/java/dev-env.js"></script>
     <script src="./resources/java/darkmode.js"></script>
+    <script src="./resources/java/nav.js"></script>
     <script src="./resources/java/jquery-3.5.1.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>


### PR DESCRIPTION
- Add global overflow-x: hidden on html element to prevent any element
  from widening the viewport on mobile
- Add * { box-sizing: border-box } to avoid padding causing overflow
- Clamp body side margins to min(10%, 140px) so mid-tablet content is
  not over-indented; existing 0-margin at <=768px breakpoint preserved
- Replace invalid display:flexbox with display:flex on .sec-cont
- Fix global img rule: was width:100%;height:100% (can overflow containers
  when images are taller than container); now max-width:100%;height:auto
- Add hamburger/collapsible navigation for mobile (<=768px):
  - .nav-toggle button spans full-width nav bar, hidden on desktop
  - ul.nav collapses to display:none on mobile, toggled via .nav-open class
  - Vertical list layout with 44px-friendly tap targets when open
  - Toggle icon switches ☰ ↔ ✕; closes on link click (single-page nav)
- Create resources/java/nav.js for the toggle logic
- Add hamburger button and nav.js to all six pages (index, travel, blog,
  blog-post, admin, login)

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1