### PR TITLE
feat(#26): geocode button + EXIF GPS warning in admin travel form

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -10,6 +10,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Leaflet for geocode confirmation map -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </head>
 <body>
     <header>
@@ -30,7 +33,7 @@
     <main class="admin-page">
         <section class="sec-cont admin-panel">
 
-            <!-- ── Travel memories ─────────────────────────────────────────────────── -->
+            <!-- ── Travel memories ───────────────────────────────────────────────── -->
             <div class="admin-card">
                 <h2 class="admin-card-title">Travel memories</h2>
                 <form id="travel-form">
@@ -75,6 +78,8 @@
                             </div>
                         </label>
                     </div>
+                    <!-- Geocode confirmation map: hidden until coords are set -->
+                    <div id="geoconfirm-map" class="hidden" style="height:200px;margin-top:0.5rem;border-radius:var(--radius-md);overflow:hidden;"></div>
                     <div class="form-actions">
                         <button type="submit" id="travel-save-btn" class="btn-primary">Save draft</button>
                         <button type="submit" id="travel-publish-btn" class="btn-primary">Publish</button>
@@ -96,7 +101,7 @@
                 </div>
             </div>
 
-            <!-- ── Blog posts ────────────────────────────────────────────────────── -->
+            <!-- ── Blog posts ──────────────────────────────────────────────────── -->
             <div class="admin-card">
                 <h2 class="admin-card-title">Blog posts</h2>
                 <form id="post-form">
@@ -126,7 +131,7 @@
                 </div>
             </div>
 
-            <!-- ── Private notes ───────────────────────────────────────────────────── -->
+            <!-- ── Private notes ─────────────────────────────────────────────────── -->
             <div class="admin-card private-card">
                 <h2 class="admin-card-title">Private coding projects</h2>
                 <label>Private notes
@@ -139,7 +144,7 @@
                 <p class="hint" style="margin-top:0.75rem">Notes are saved locally in your browser.</p>
             </div>
 
-            <!-- ── Passkeys ────────────────────────────────────────────────────────── -->
+            <!-- ── Passkeys ─────────────────────────────────────────────────────── -->
             <div class="admin-card">
                 <h2 class="admin-card-title">Manage passkeys</h2>
                 <p style="color:var(--color-text-secondary);margin-bottom:1rem">Passkeys let you sign in with your device's biometrics or PIN — no password needed.</p>

--- a/admin.html
+++ b/admin.html
@@ -66,14 +66,14 @@
                         <label>Latitude
                             <div class="coord-stepper">
                                 <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="-1" aria-label="Decrease latitude">−</button>
-                                <input id="travel-lat" type="number" step="any" placeholder="e.g. 51.5074" />
+                                <input id="travel-lat" type="number" step="0.000001" placeholder="e.g. 51.5074" />
                                 <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="1" aria-label="Increase latitude">+</button>
                             </div>
                         </label>
                         <label>Longitude
                             <div class="coord-stepper">
                                 <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="-1" aria-label="Decrease longitude">−</button>
-                                <input id="travel-lng" type="number" step="any" placeholder="e.g. -0.1278" />
+                                <input id="travel-lng" type="number" step="0.000001" placeholder="e.g. -0.1278" />
                                 <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="1" aria-label="Increase longitude">+</button>
                             </div>
                         </label>
@@ -195,7 +195,7 @@
 
         // Issue #39: custom coordinate stepper buttons
         (function () {
-            var STEP = 0.0001;
+            var STEP = 0.000001;
             var holdDelay = 400;
             var holdInterval = 80;
 

--- a/admin.html
+++ b/admin.html
@@ -66,14 +66,14 @@
                         <label>Latitude
                             <div class="coord-stepper">
                                 <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="-1" aria-label="Decrease latitude">−</button>
-                                <input id="travel-lat" type="number" step="0.0001" placeholder="e.g. 51.5074" />
+                                <input id="travel-lat" type="number" step="any" placeholder="e.g. 51.5074" />
                                 <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="1" aria-label="Increase latitude">+</button>
                             </div>
                         </label>
                         <label>Longitude
                             <div class="coord-stepper">
                                 <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="-1" aria-label="Decrease longitude">−</button>
-                                <input id="travel-lng" type="number" step="0.0001" placeholder="e.g. -0.1278" />
+                                <input id="travel-lng" type="number" step="any" placeholder="e.g. -0.1278" />
                                 <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="1" aria-label="Increase longitude">+</button>
                             </div>
                         </label>

--- a/admin.html
+++ b/admin.html
@@ -42,7 +42,10 @@
                         <input id="travel-date" type="date" />
                     </label>
                     <label>Location
-                        <input id="travel-location" type="text" placeholder="City, country" />
+                        <div class="location-row">
+                            <input id="travel-location" type="text" placeholder="City, country" />
+                            <button type="button" id="geocode-btn" class="btn-secondary" title="Look up coordinates from location name">Geocode</button>
+                        </div>
                     </label>
                     <label>Notes
                         <textarea id="travel-notes" rows="4" placeholder="Describe the moment…"></textarea>

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -1599,6 +1599,23 @@ footer {
 
 /* ── Admin coord row (Issue #8) ─────────────────────────────────────────────── */
 
+.location-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.location-row input {
+    flex: 1;
+}
+
+.location-row .btn-secondary {
+    flex-shrink: 0;
+    padding: 0 0.75rem;
+    height: 38px;
+    font-size: 0.85rem;
+}
+
 .coord-row {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -269,11 +269,11 @@ async function deleteTravelMemory(id) {
     }
 }
 
-function setTravelMessage(msg, isError = false) {
+function setTravelMessage(msg, isError = false, isHint = false) {
     const el = document.getElementById('travel-message');
     if (!el) return;
     el.textContent = msg;
-    el.style.color = isError ? 'var(--color-error)' : 'var(--color-success)';
+    el.style.color = isError ? 'var(--color-error)' : isHint ? 'var(--color-text-muted)' : 'var(--color-success)';
 }
 
 // Try to read GPS coords from image EXIF and populate the lat/lng inputs.
@@ -285,10 +285,42 @@ async function tryAutofillGpsFromFile(file) {
         if (gps && Number.isFinite(gps.latitude) && Number.isFinite(gps.longitude)) {
             $('#travel-lat').val(gps.latitude.toFixed(6));
             $('#travel-lng').val(gps.longitude.toFixed(6));
-            setTravelMessage('Location auto-filled from photo EXIF.');
+            setTravelMessage('GPS auto-filled from photo EXIF.');
+        } else {
+            setTravelMessage('No GPS data in photo — enter coordinates manually or use Geocode.', false, true);
         }
     } catch {
-        // EXIF parsing failed — not a problem, just continue
+        setTravelMessage('No GPS data in photo — enter coordinates manually or use Geocode.', false, true);
+    }
+}
+
+async function geocodeLocation() {
+    const q = $('#travel-location').val().trim();
+    if (!q) {
+        setTravelMessage('Enter a location name first.', true);
+        return;
+    }
+    const btn = document.getElementById('geocode-btn');
+    btn.disabled = true;
+    btn.textContent = 'Looking up…';
+    setTravelMessage('');
+    try {
+        const url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + encodeURIComponent(q);
+        const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
+        const results = await res.json();
+        if (!results.length) {
+            setTravelMessage('Location not found — try a more specific name.', true);
+            return;
+        }
+        const { lat, lon } = results[0];
+        $('#travel-lat').val(parseFloat(lat).toFixed(6));
+        $('#travel-lng').val(parseFloat(lon).toFixed(6));
+        setTravelMessage('Coordinates filled from location name.');
+    } catch {
+        setTravelMessage('Geocode failed — check your connection and try again.', true);
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Geocode';
     }
 }
 
@@ -313,6 +345,10 @@ async function tryAutofillDateFromFile(file) {
 }
 
 function initTravelForm() {
+    $('#geocode-btn').on('click', function () {
+        geocodeLocation();
+    });
+
     $('#travel-file').on('change', function (event) {
         const file = event.target.files && event.target.files[0];
         if (!file) { currentFile = null; return; }

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -129,7 +129,9 @@ function setPasskeyMessage(msg, isError = false) {
 // ── Travel memories ───────────────────────────────────────────────────────────
 
 let currentFile = null;
-let editingTravelMedia = null; // preserved existing media when editing
+let editingTravelMedia = null;
+let geoconfirmMap = null;
+let geoconfirmMarker = null;
 
 function showPreview(travel) {
     const previewMedia = $('.preview-media');
@@ -161,6 +163,7 @@ function clearTravelForm() {
     currentFile = null;
     editingTravelMedia = null;
     setTravelMessage('');
+    hideGeoconfirmMap();
 }
 
 function buildSavedMemoryRow(memory) {
@@ -227,6 +230,11 @@ async function loadTravelForEdit(memory) {
             $('#travel-preview').addClass('hidden');
         }
 
+        // Show confirmation map if coords already exist on this memory
+        if (full.lat != null && full.lng != null) {
+            updateGeoconfirmMap(parseFloat(full.lat), parseFloat(full.lng));
+        }
+
         $('#travel-cancel-btn').removeClass('hidden');
         setTravelMessage('Editing: ' + full.title);
         document.getElementById('travel-title').scrollIntoView({ behavior: 'smooth' });
@@ -276,16 +284,70 @@ function setTravelMessage(msg, isError = false, isHint = false) {
     el.style.color = isError ? 'var(--color-error)' : isHint ? 'var(--color-text-muted)' : 'var(--color-success)';
 }
 
+// ── Geocode confirmation map ───────────────────────────────────────────────────
+
+function updateGeoconfirmMap(lat, lng) {
+    if (!window.L) return;
+    const mapEl = document.getElementById('geoconfirm-map');
+    if (!mapEl) return;
+
+    mapEl.classList.remove('hidden');
+
+    if (!geoconfirmMap) {
+        geoconfirmMap = L.map('geoconfirm-map', { scrollWheelZoom: false, zoomControl: true });
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 18,
+            attribution: '\u00a9 <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        }).addTo(geoconfirmMap);
+    }
+
+    const latlng = [lat, lng];
+    geoconfirmMap.setView(latlng, 10);
+
+    if (geoconfirmMarker) {
+        geoconfirmMarker.setLatLng(latlng);
+    } else {
+        geoconfirmMarker = L.marker(latlng).addTo(geoconfirmMap);
+    }
+
+    // Leaflet needs a size nudge after becoming visible
+    setTimeout(() => geoconfirmMap.invalidateSize(), 50);
+}
+
+function hideGeoconfirmMap() {
+    const mapEl = document.getElementById('geoconfirm-map');
+    if (mapEl) mapEl.classList.add('hidden');
+    if (geoconfirmMarker && geoconfirmMap) {
+        geoconfirmMap.removeLayer(geoconfirmMarker);
+        geoconfirmMarker = null;
+    }
+}
+
+// ── EXIF GPS autofill ─────────────────────────────────────────────────────────
+
 // Try to read GPS coords from image EXIF and populate the lat/lng inputs.
 async function tryAutofillGpsFromFile(file) {
     if (!file || !file.type || !file.type.startsWith('image/')) return;
-    if ($('#travel-lat').val() || $('#travel-lng').val()) return;
     try {
-        const gps = await exifr.gps(file);
+        // exifr.parse with explicit GPS tags is more reliable across camera/phone formats
+        // than exifr.gps() alone which can miss some makernote-only GPS data.
+        let gps = null;
+        try {
+            const tags = await exifr.parse(file, { gps: true });
+            if (tags && Number.isFinite(tags.latitude) && Number.isFinite(tags.longitude)) {
+                gps = { latitude: tags.latitude, longitude: tags.longitude };
+            }
+        } catch { /* fall through to exifr.gps() */ }
+
+        if (!gps) {
+            gps = await exifr.gps(file);
+        }
+
         if (gps && Number.isFinite(gps.latitude) && Number.isFinite(gps.longitude)) {
             $('#travel-lat').val(gps.latitude.toFixed(6));
             $('#travel-lng').val(gps.longitude.toFixed(6));
             setTravelMessage('GPS auto-filled from photo EXIF.');
+            updateGeoconfirmMap(gps.latitude, gps.longitude);
         } else {
             setTravelMessage('No GPS data in photo — enter coordinates manually or use Geocode.', false, true);
         }
@@ -312,10 +374,13 @@ async function geocodeLocation() {
             setTravelMessage('Location not found — try a more specific name.', true);
             return;
         }
-        const { lat, lon } = results[0];
-        $('#travel-lat').val(parseFloat(lat).toFixed(6));
-        $('#travel-lng').val(parseFloat(lon).toFixed(6));
-        setTravelMessage('Coordinates filled from location name.');
+        const { lat, lon, display_name } = results[0];
+        const parsedLat = parseFloat(lat);
+        const parsedLng = parseFloat(lon);
+        $('#travel-lat').val(parsedLat.toFixed(6));
+        $('#travel-lng').val(parsedLng.toFixed(6));
+        setTravelMessage(`Coordinates set — confirm pin location on the map below (matched: ${display_name.split(',').slice(0, 3).join(',')}).`, false, true);
+        updateGeoconfirmMap(parsedLat, parsedLng);
     } catch {
         setTravelMessage('Geocode failed — check your connection and try again.', true);
     } finally {
@@ -325,7 +390,6 @@ async function geocodeLocation() {
 }
 
 // Try to read DateTimeOriginal from image EXIF and populate the date input.
-// Only fills if the current value is today's default (i.e. not deliberately set).
 async function tryAutofillDateFromFile(file) {
     if (!file || !file.type || !file.type.startsWith('image/')) return;
     const currentVal = $('#travel-date').val();
@@ -347,6 +411,17 @@ async function tryAutofillDateFromFile(file) {
 function initTravelForm() {
     $('#geocode-btn').on('click', function () {
         geocodeLocation();
+    });
+
+    // Update confirmation map when coords are changed manually
+    $('#travel-lat, #travel-lng').on('change input', function () {
+        const lat = parseFloat($('#travel-lat').val());
+        const lng = parseFloat($('#travel-lng').val());
+        if (Number.isFinite(lat) && Number.isFinite(lng)) {
+            updateGeoconfirmMap(lat, lng);
+        } else {
+            hideGeoconfirmMap();
+        }
     });
 
     $('#travel-file').on('change', function (event) {
@@ -518,7 +593,6 @@ async function loadAdminPosts() {
 function loadPostForEdit(post) {
     $('#post-edit-id').val(post.id);
     $('#post-title').val(post.title);
-    // Fetch full body via admin route so drafts (published_at IS NULL) are included
     authFetch(`/posts/admin/${post.id}`).then(async r => {
         if (r.ok) {
             const full = await r.json();

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -331,6 +331,31 @@ function hasValidGps(lat, lng) {
     return Number.isFinite(lat) && Number.isFinite(lng) && !(lat === 0 && lng === 0);
 }
 
+// Reverse geocode lat/lng to a human-readable location string using Nominatim.
+// Only populates the Location field if it is currently empty.
+async function reverseGeocodeToLocation(lat, lng) {
+    if ($('#travel-location').val().trim()) return; // don't overwrite manual input
+    try {
+        const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&zoom=10&addressdetails=1`;
+        const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!data.address) return;
+
+        // Build a compact "City, Country" style string from available address parts
+        const a = data.address;
+        const city = a.city || a.town || a.village || a.hamlet || a.county || a.state_district || a.state || '';
+        const country = a.country || '';
+        const locationStr = [city, country].filter(Boolean).join(', ');
+
+        if (locationStr) {
+            $('#travel-location').val(locationStr);
+        }
+    } catch {
+        // Reverse geocode failure is non-fatal — silently ignore
+    }
+}
+
 // Try to read GPS coords from image EXIF and populate the lat/lng inputs.
 async function tryAutofillGpsFromFile(file) {
     if (!file || !file.type || !file.type.startsWith('image/')) return;
@@ -355,6 +380,7 @@ async function tryAutofillGpsFromFile(file) {
             $('#travel-lng').val(gps.longitude.toFixed(6));
             setTravelMessage('GPS auto-filled from photo EXIF.');
             updateGeoconfirmMap(gps.latitude, gps.longitude);
+            reverseGeocodeToLocation(gps.latitude, gps.longitude);
         } else {
             setTravelMessage('No GPS data in photo — enter coordinates manually or use Geocode.', false, true);
         }

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -325,25 +325,32 @@ function hideGeoconfirmMap() {
 
 // ── EXIF GPS autofill ─────────────────────────────────────────────────────────
 
+// Returns true only if coords are finite numbers and not the null-island 0,0
+// that DJI and some cameras emit when GPS is unavailable.
+function hasValidGps(lat, lng) {
+    return Number.isFinite(lat) && Number.isFinite(lng) && !(lat === 0 && lng === 0);
+}
+
 // Try to read GPS coords from image EXIF and populate the lat/lng inputs.
 async function tryAutofillGpsFromFile(file) {
     if (!file || !file.type || !file.type.startsWith('image/')) return;
     try {
-        // exifr.parse with explicit GPS tags is more reliable across camera/phone formats
-        // than exifr.gps() alone which can miss some makernote-only GPS data.
         let gps = null;
         try {
             const tags = await exifr.parse(file, { gps: true });
-            if (tags && Number.isFinite(tags.latitude) && Number.isFinite(tags.longitude)) {
+            if (tags && hasValidGps(tags.latitude, tags.longitude)) {
                 gps = { latitude: tags.latitude, longitude: tags.longitude };
             }
         } catch { /* fall through to exifr.gps() */ }
 
         if (!gps) {
-            gps = await exifr.gps(file);
+            const raw = await exifr.gps(file);
+            if (raw && hasValidGps(raw.latitude, raw.longitude)) {
+                gps = raw;
+            }
         }
 
-        if (gps && Number.isFinite(gps.latitude) && Number.isFinite(gps.longitude)) {
+        if (gps) {
             $('#travel-lat').val(gps.latitude.toFixed(6));
             $('#travel-lng').val(gps.longitude.toFixed(6));
             setTravelMessage('GPS auto-filled from photo EXIF.');


### PR DESCRIPTION
## Summary

- When a photo is selected and has **no GPS EXIF data**, a muted hint now appears: *"No GPS data in photo — enter coordinates manually or use Geocode."* Previously this failed silently.
- A **Geocode** button is added next to the location text input. Clicking it calls the OpenStreetMap Nominatim API with the typed location name and auto-fills the lat/lng fields.
- `setTravelMessage` gains an `isHint` parameter so the warning renders in muted text (not error red, not success green).
- Branch is rebased on top of `feat/issue-58-unified-posts-model` (the unified posts branch, now merged into `dev`).

## Test plan
- [ ] Upload a photo with GPS EXIF → lat/lng auto-fills, success message shown
- [ ] Upload a photo without GPS EXIF → muted hint appears prompting manual entry or Geocode
- [ ] Type a location name (e.g. "Hanoi, Vietnam") and click Geocode → lat/lng populated from Nominatim
- [ ] Geocode with an unrecognisable name → "Location not found" error shown
- [ ] Geocode button shows "Looking up…" while fetching, re-enables after
- [ ] Non-blocking — form can still be saved without coordinates

Closes #26

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_