### PR TITLE
feat(#4): CV download button in About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,9 @@
                         <p>I'm a data engineer and Chartered Accountant with a background in financial services reporting. Last year I transitioned into a dedicated data engineering role, designing and building cloud data pipelines using Azure Databricks, Apache Spark, and Delta Lake — and recently completed the <a href="https://www.udemy.com/course/azure-databricks-spark-core-for-data-engineers" target="_blank" rel="noopener noreferrer">Azure Databricks &amp; Spark Core for Data Engineers</a> course on Udemy to formalise those skills.</p>
                         <p>The move from accountancy to data engineering gives me an edge few engineers have: I understand the business context behind the data as much as the technical infrastructure that moves it. Earlier in my career I built reporting infrastructure and ETL workflows for an alternative investment platform, which gave me a strong foundation in data modelling, SQL, and stakeholder-facing analytics.</p>
                         <p>Outside of work I enjoy travel and documenting experiences on the road. I'm always looking for the next thing to learn — whether that's a new cloud technology, a side project, or a better way to build the tools I already use.</p>
+                        <div class="about-actions">
+                            <a href="./resources/downloads/cv.pdf" download="Andrew_Keys_CV.pdf" class="btn-download">Download CV</a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -571,6 +571,36 @@ footer a:hover {
     color: var(--color-text);
 }
 
+.about-actions {
+    margin-top: 1.5rem;
+}
+
+.btn-download {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.65rem 1.4rem;
+    background: var(--color-accent);
+    color: #fff;
+    border-radius: 8px;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.btn-download:hover {
+    background: var(--color-accent-hover);
+    transform: translateY(-1px);
+}
+
+.btn-download::before {
+    content: '↓';
+    font-size: 1.1em;
+    line-height: 1;
+}
+
 /* Projects Grid */
 .projects-grid {
     display: grid;


### PR DESCRIPTION
## Summary

- Adds a styled **Download CV** button below the bio text in the About section on `index.html`
- Links to `./resources/downloads/cv.pdf` with `download="Andrew_Keys_CV.pdf"` so the browser prompts a save dialog
- `resources/downloads/` directory created — **place the actual PDF there before deploying**
- `.btn-download` CSS class: accent-colour background, hover lift, download arrow prefix, responsive

## Before deploying
Place your CV PDF at:
```
resources/downloads/cv.pdf
```

## Test plan
- [ ] "Download CV" button appears in the About section
- [ ] Clicking triggers a PDF download (once cv.pdf is in place)
- [ ] Button renders correctly in light and dark mode
- [ ] Layout is not broken on mobile

Closes #4

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_