### PR TITLE
feat(#30): multiple photos/videos per travel post

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -57,14 +57,15 @@
                     <label>Notes
                         <textarea id="travel-notes" rows="4" placeholder="Describe the moment…"></textarea>
                     </label>
-                    <!-- Issue #34: styled file input -->
-                    <label>Photo or video
+                    <!-- Issue #30: multi-file input with preview list -->
+                    <label>Photos / videos
                         <div class="file-input-wrap">
-                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photo or video">Browse…</button>
-                            <span class="file-input-label">No file chosen</span>
-                            <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" />
+                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photos or videos">Add files…</button>
+                            <span class="file-input-label">No files chosen</span>
+                            <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" multiple />
                         </div>
                     </label>
+                    <div id="travel-media-list" class="media-list hidden"></div>
                     <!-- Issue #39: custom coordinate steppers replacing native spinners -->
                     <div class="coord-row">
                         <label>Latitude

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -116,3 +116,24 @@ CREATE TABLE IF NOT EXISTS page_visits (
   count BIGINT NOT NULL DEFAULT 0,
   last_visited_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+-- One-to-many media for travel posts (#30)
+CREATE TABLE IF NOT EXISTS post_media (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  media_url TEXT NOT NULL,
+  media_type VARCHAR(100),
+  order_index INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Migrate existing single-media travel posts into post_media (idempotent)
+INSERT INTO post_media (post_id, media_url, media_type, order_index)
+SELECT id, media_url, media_type, 0
+FROM posts
+WHERE post_type = 'travel'
+  AND media_url IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM post_media pm WHERE pm.post_id = posts.id
+  );
+

--- a/backend/routes/travel.js
+++ b/backend/routes/travel.js
@@ -4,23 +4,53 @@ import { authenticate } from '../middleware/authenticate.js';
 
 const router = Router();
 
-// Shared SELECT columns — aliases keep the frontend field names unchanged
+// Shared SELECT — aliases keep frontend field names; media aggregated from post_media
 const TRAVEL_COLS = `
-  id, title, slug, location,
-  body_markdown AS notes,
-  media_url, media_type, lat, lng,
-  post_date AS visit_date,
-  location_estimated, published_at, created_at
+  p.id, p.title, p.slug, p.location,
+  p.body_markdown AS notes,
+  p.media_url, p.media_type, p.lat, p.lng,
+  p.post_date AS visit_date,
+  p.location_estimated, p.published_at, p.created_at,
+  COALESCE(
+    (SELECT json_agg(
+       json_build_object('id', pm.id, 'url', pm.media_url, 'type', pm.media_type)
+       ORDER BY pm.order_index, pm.created_at
+     )
+     FROM post_media pm WHERE pm.post_id = p.id
+    ), '[]'::json
+  ) AS media
 `;
+
+// Replace all post_media rows for a post and sync posts.media_url/media_type to first item.
+async function replaceMedia(client, postId, mediaItems) {
+  await client.query('DELETE FROM post_media WHERE post_id = $1', [postId]);
+  if (!mediaItems || !mediaItems.length) {
+    await client.query(
+      'UPDATE posts SET media_url = NULL, media_type = NULL WHERE id = $1',
+      [postId]
+    );
+    return;
+  }
+  const vals = mediaItems.map((m, i) => `($1, $${i * 2 + 2}, $${i * 2 + 3}, ${i})`).join(', ');
+  const params = [postId, ...mediaItems.flatMap(m => [m.url, m.type || null])];
+  await client.query(
+    `INSERT INTO post_media (post_id, media_url, media_type, order_index) VALUES ${vals}`,
+    params
+  );
+  await client.query(
+    'UPDATE posts SET media_url = $1, media_type = $2 WHERE id = $3',
+    [mediaItems[0].url, mediaItems[0].type || null, postId]
+  );
+}
 
 // Public: published travel posts
 router.get('/', async (req, res) => {
   try {
     const result = await pool.query(
       `SELECT ${TRAVEL_COLS}
-       FROM posts
-       WHERE post_type = 'travel' AND published_at IS NOT NULL
-       ORDER BY post_date DESC, created_at DESC`
+       FROM posts p
+       WHERE p.post_type = 'travel' AND p.published_at IS NOT NULL
+       ORDER BY p.post_date DESC, p.created_at DESC`
     );
     res.json(result.rows);
   } catch (err) {
@@ -34,9 +64,9 @@ router.get('/all', authenticate, async (req, res) => {
   try {
     const result = await pool.query(
       `SELECT ${TRAVEL_COLS}
-       FROM posts
-       WHERE post_type = 'travel'
-       ORDER BY post_date DESC, created_at DESC`
+       FROM posts p
+       WHERE p.post_type = 'travel'
+       ORDER BY p.post_date DESC, p.created_at DESC`
     );
     res.json(result.rows);
   } catch (err) {
@@ -49,7 +79,7 @@ router.get('/all', authenticate, async (req, res) => {
 router.get('/admin/:id', authenticate, async (req, res) => {
   try {
     const result = await pool.query(
-      `SELECT ${TRAVEL_COLS} FROM posts WHERE id = $1 AND post_type = 'travel'`,
+      `SELECT ${TRAVEL_COLS} FROM posts p WHERE p.id = $1 AND p.post_type = 'travel'`,
       [req.params.id]
     );
     if (!result.rows.length) return res.status(404).json({ error: 'Memory not found' });
@@ -62,8 +92,10 @@ router.get('/admin/:id', authenticate, async (req, res) => {
 
 // Admin: create travel post
 router.post('/', authenticate, async (req, res) => {
+  const client = await pool.connect();
   try {
-    const { title, location, notes, mediaUrl, mediaType, lat, lng, visitDate, publish } = req.body;
+    await client.query('BEGIN');
+    const { title, location, notes, mediaItems, lat, lng, visitDate, publish } = req.body;
     if (!title) return res.status(400).json({ error: 'Title is required' });
 
     const latVal = lat !== undefined && lat !== '' ? parseFloat(lat) : null;
@@ -71,40 +103,57 @@ router.post('/', authenticate, async (req, res) => {
     const postDateVal = visitDate || null;
     const publishedAt = publish ? new Date() : null;
 
-    // Generate a slug from the title
     const baseSlug = title.trim().toLowerCase()
       .replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').slice(0, 90);
     let slug = baseSlug || 'travel';
     let i = 1;
     while (true) {
-      const { rows } = await pool.query('SELECT id FROM posts WHERE slug = $1', [slug]);
+      const { rows } = await client.query('SELECT id FROM posts WHERE slug = $1', [slug]);
       if (!rows.length) break;
       slug = `${baseSlug}-${i++}`;
     }
 
-    const result = await pool.query(
+    const firstMedia = mediaItems && mediaItems.length ? mediaItems[0] : null;
+    const insert = await client.query(
       `INSERT INTO posts
          (post_type, title, slug, body_markdown, post_date, published_at,
           location, media_url, media_type, lat, lng)
        VALUES ('travel', $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-       RETURNING ${TRAVEL_COLS}`,
+       RETURNING id`,
       [title.trim(), slug, notes?.trim() || '', postDateVal, publishedAt,
-       location?.trim() || null, mediaUrl || null, mediaType || null, latVal, lngVal]
+       location?.trim() || null,
+       firstMedia?.url || null, firstMedia?.type || null,
+       latVal, lngVal]
+    );
+    const postId = insert.rows[0].id;
+    if (mediaItems && mediaItems.length) {
+      await replaceMedia(client, postId, mediaItems);
+    }
+
+    await client.query('COMMIT');
+
+    const result = await pool.query(
+      `SELECT ${TRAVEL_COLS} FROM posts p WHERE p.id = $1`, [postId]
     );
     res.status(201).json(result.rows[0]);
   } catch (err) {
+    await client.query('ROLLBACK');
     console.error(err);
     res.status(500).json({ error: 'Database error' });
+  } finally {
+    client.release();
   }
 });
 
 // Admin: update travel post
 router.put('/:id', authenticate, async (req, res) => {
+  const client = await pool.connect();
   try {
-    const { title, location, notes, mediaUrl, mediaType, lat, lng, visitDate, publish } = req.body;
+    await client.query('BEGIN');
+    const { title, location, notes, mediaItems, lat, lng, visitDate, publish } = req.body;
     if (!title) return res.status(400).json({ error: 'Title is required' });
 
-    const existing = await pool.query(
+    const existing = await client.query(
       `SELECT * FROM posts WHERE id = $1 AND post_type = 'travel'`,
       [req.params.id]
     );
@@ -118,25 +167,40 @@ router.put('/:id', authenticate, async (req, res) => {
     if (publish && !published_at) published_at = new Date();
     if (publish === false) published_at = null;
 
-    const result = await pool.query(
+    const firstMedia = mediaItems && mediaItems.length ? mediaItems[0] : null;
+    await client.query(
       `UPDATE posts SET
          title=$1, body_markdown=$2, post_date=$3, published_at=$4,
          location=$5, media_url=$6, media_type=$7, lat=$8, lng=$9,
          updated_at=NOW()
-       WHERE id=$10 AND post_type='travel'
-       RETURNING ${TRAVEL_COLS}`,
+       WHERE id=$10 AND post_type='travel'`,
       [title.trim(), notes?.trim() || '', postDateVal, published_at,
-       location?.trim() || null, mediaUrl || null, mediaType || null, latVal, lngVal,
-       req.params.id]
+       location?.trim() || null,
+       firstMedia?.url || null, firstMedia?.type || null,
+       latVal, lngVal, req.params.id]
+    );
+
+    // If mediaItems provided, replace all media; otherwise leave existing post_media untouched
+    if (mediaItems !== undefined) {
+      await replaceMedia(client, req.params.id, mediaItems);
+    }
+
+    await client.query('COMMIT');
+
+    const result = await pool.query(
+      `SELECT ${TRAVEL_COLS} FROM posts p WHERE p.id = $1`, [req.params.id]
     );
     res.json(result.rows[0]);
   } catch (err) {
+    await client.query('ROLLBACK');
     console.error(err);
     res.status(500).json({ error: 'Database error' });
+  } finally {
+    client.release();
   }
 });
 
-// Admin: delete travel post
+// Admin: delete travel post (CASCADE removes post_media rows)
 router.delete('/:id', authenticate, async (req, res) => {
   try {
     const result = await pool.query(
@@ -144,6 +208,31 @@ router.delete('/:id', authenticate, async (req, res) => {
       [req.params.id]
     );
     if (!result.rows.length) return res.status(404).json({ error: 'Memory not found' });
+    res.json({ deleted: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// Admin: delete a single media item from post_media
+router.delete('/:id/media/:mediaId', authenticate, async (req, res) => {
+  try {
+    const result = await pool.query(
+      `DELETE FROM post_media WHERE id = $1 AND post_id = $2 RETURNING id`,
+      [req.params.mediaId, req.params.id]
+    );
+    if (!result.rows.length) return res.status(404).json({ error: 'Media item not found' });
+
+    // Re-sync posts.media_url to the new first item
+    const first = await pool.query(
+      `SELECT media_url, media_type FROM post_media WHERE post_id = $1 ORDER BY order_index, created_at LIMIT 1`,
+      [req.params.id]
+    );
+    await pool.query(
+      'UPDATE posts SET media_url = $1, media_type = $2 WHERE id = $3',
+      [first.rows[0]?.media_url || null, first.rows[0]?.media_type || null, req.params.id]
+    );
     res.json({ deleted: true });
   } catch (err) {
     console.error(err);

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -915,6 +915,127 @@ footer {
     font-style: italic;
 }
 
+/* ── Travel gallery lightbox (#30) ─────────────────────────────────────────── */
+
+.lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(0, 0, 0, 0.92);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+}
+
+.lightbox.hidden {
+    display: none;
+}
+
+.lightbox-media {
+    max-width: min(90vw, 900px);
+    max-height: 75vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.lightbox-media img,
+.lightbox-media video {
+    max-width: 100%;
+    max-height: 75vh;
+    object-fit: contain;
+    border-radius: 6px;
+}
+
+.lightbox-caption {
+    margin-top: 0.75rem;
+    color: #ddd;
+    font-size: 0.9rem;
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.lightbox-counter {
+    color: #aaa;
+    font-size: 0.82rem;
+}
+
+.lightbox-close,
+.lightbox-prev,
+.lightbox-next {
+    position: absolute;
+    background: rgba(255, 255, 255, 0.12);
+    border: none;
+    color: #fff;
+    font-size: 1.8rem;
+    line-height: 1;
+    cursor: pointer;
+    border-radius: 50%;
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s;
+}
+
+.lightbox-close:hover,
+.lightbox-prev:hover,
+.lightbox-next:hover {
+    background: rgba(255, 255, 255, 0.28);
+}
+
+.lightbox-close {
+    top: 1rem;
+    right: 1rem;
+    font-size: 1.4rem;
+}
+
+.lightbox-prev {
+    left: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.lightbox-next {
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.lightbox-prev.hidden,
+.lightbox-next.hidden {
+    display: none;
+}
+
+/* Make cards with multiple media look clickable */
+.travel-card.has-gallery {
+    cursor: pointer;
+}
+
+.travel-card.has-gallery .media-thumb-wrap::after {
+    content: 'View gallery';
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0);
+    color: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+    font-weight: 600;
+    transition: background 0.2s, color 0.2s;
+    border-radius: 10px 10px 0 0;
+}
+
+.travel-card.has-gallery:hover .media-thumb-wrap::after {
+    background: rgba(0, 0, 0, 0.45);
+    color: #fff;
+}
+
 /* AI Dev section */
 .ai-dev-inner {
     text-align: left;

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -481,6 +481,59 @@ footer a:hover {
     display: block;
 }
 
+.media-thumb-wrap {
+    position: relative;
+    display: block;
+}
+
+.media-extra-badge {
+    position: absolute;
+    bottom: 0.5rem;
+    right: 0.5rem;
+    background: rgba(0, 0, 0, 0.65);
+    color: #fff;
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
+    pointer-events: none;
+}
+
+.media-list {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.media-list-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.6rem;
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    font-size: 0.85rem;
+}
+
+.media-list-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-text-secondary);
+}
+
+.media-remove-btn {
+    flex-shrink: 0;
+    height: 28px;
+    padding: 0 0.5rem;
+    font-size: 0.8rem;
+    color: var(--color-error);
+    border-color: var(--color-error);
+}
+
 .travel-content h3 {
     margin: 0 0 0.35rem 0;
     font-size: 1.1rem;

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -377,9 +377,9 @@ async function reverseGeocodeToLocation(lat, lng) {
     }
 }
 
-// Try to read GPS coords from image EXIF and populate the lat/lng inputs.
-async function tryAutofillGpsFromFile(file) {
-    if (!file || !file.type || !file.type.startsWith('image/')) return;
+// Extract GPS from a single file without setting the form.
+async function extractGpsFromFile(file) {
+    if (!file || !file.type || !file.type.startsWith('image/')) return null;
     try {
         let gps = null;
         try {
@@ -395,19 +395,47 @@ async function tryAutofillGpsFromFile(file) {
                 gps = raw;
             }
         }
+        return gps;
+    } catch {
+        return null;
+    }
+}
 
+// Try to read GPS coords from image EXIF and populate the lat/lng inputs.
+async function tryAutofillGpsFromFile(file) {
+    const gps = await extractGpsFromFile(file);
+    if (gps) {
+        $('#travel-lat').val(gps.latitude.toFixed(6));
+        $('#travel-lng').val(gps.longitude.toFixed(6));
+        setTravelMessage('GPS auto-filled from photo EXIF.');
+        updateGeoconfirmMap(gps.latitude, gps.longitude);
+        reverseGeocodeToLocation(gps.latitude, gps.longitude);
+    } else {
+        setTravelMessage('No GPS data in photo — enter coordinates manually or use Geocode.', false, true);
+    }
+}
+
+// Loop through sorted files to find the first one with valid GPS coords.
+async function tryAutofillGpsFromFileList(files) {
+    // Sort by filename for consistent results across different selection orders
+    const sortedImages = files
+        .filter(f => f.type && f.type.startsWith('image/'))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const file of sortedImages) {
+        const gps = await extractGpsFromFile(file);
         if (gps) {
             $('#travel-lat').val(gps.latitude.toFixed(6));
             $('#travel-lng').val(gps.longitude.toFixed(6));
-            setTravelMessage('GPS auto-filled from photo EXIF.');
+            setTravelMessage(`GPS auto-filled from ${file.name}.`);
             updateGeoconfirmMap(gps.latitude, gps.longitude);
             reverseGeocodeToLocation(gps.latitude, gps.longitude);
-        } else {
-            setTravelMessage('No GPS data in photo — enter coordinates manually or use Geocode.', false, true);
+            return; // Stop after finding the first valid one
         }
-    } catch {
-        setTravelMessage('No GPS data in photo — enter coordinates manually or use Geocode.', false, true);
     }
+
+    // None of the images had valid GPS
+    setTravelMessage('No GPS data in any photo — enter coordinates manually or use Geocode.', false, true);
 }
 
 async function geocodeLocation() {
@@ -482,11 +510,15 @@ function initTravelForm() {
         const files = Array.from(event.target.files || []);
         if (!files.length) return;
 
-        // EXIF auto-fill from first image in the selection
-        const firstImage = files.find(f => f.type.startsWith('image/'));
-        if (firstImage) {
-            tryAutofillGpsFromFile(firstImage);
-            tryAutofillDateFromFile(firstImage);
+        // EXIF auto-fill: loop through sorted images to find first with valid GPS
+        tryAutofillGpsFromFileList(files);
+
+        // Date auto-fill from first image by filename (for consistency)
+        const sortedImages = files
+            .filter(f => f.type && f.type.startsWith('image/'))
+            .sort((a, b) => a.name.localeCompare(b.name));
+        if (sortedImages.length) {
+            tryAutofillDateFromFile(sortedImages[0]);
         }
 
         pendingFiles = pendingFiles.concat(files);

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -128,40 +128,63 @@ function setPasskeyMessage(msg, isError = false) {
 
 // ── Travel memories ───────────────────────────────────────────────────────────
 
-let currentFile = null;
-let editingTravelMedia = null;
-let geoconfirmMap = null;
-let geoconfirmMarker = null;
+let pendingFiles = [];         // File objects queued for upload
+let existingMedia = [];        // {id, url, type} from post_media (on edit)
+let removedMediaIds = [];      // post_media ids to delete on save
 
-function showPreview(travel) {
-    const previewMedia = $('.preview-media');
-    const previewText = $('.preview-text');
-    previewMedia.empty();
-    previewText.empty();
-    if (travel.mediaUrl) {
-        previewMedia.append(
-            travel.mediaType && travel.mediaType.startsWith('video')
-                ? `<video controls src="${travel.mediaUrl}"></video>`
-                : `<img src="${travel.mediaUrl}" alt="Preview image">`
-        );
-    }
-    previewText.append('<p><strong>' + escapeHtml(travel.title || 'Untitled memory') + '</strong></p>');
-    previewText.append('<p>' + escapeHtml(travel.location || 'No location provided') + '</p>');
-    previewText.append('<p>' + escapeHtml(travel.notes || 'No notes yet.') + '</p>');
-    $('#travel-preview').removeClass('hidden');
+function renderMediaList() {
+    const list = $('#travel-media-list');
+    list.empty();
+
+    const allItems = [
+        ...existingMedia.map(m => ({ kind: 'existing', ...m })),
+        ...pendingFiles.map((f, i) => ({ kind: 'pending', index: i, name: f.name, type: f.type })),
+    ];
+
+    if (!allItems.length) { list.addClass('hidden'); return; }
+    list.removeClass('hidden');
+
+    allItems.forEach(item => {
+        const row = $('<div class="media-list-row"></div>');
+        const icon = item.type && item.type.startsWith('video') ? '🎬' : '🖼';
+        const label = item.kind === 'existing'
+            ? `${icon} ${item.url.split('/').pop()}`
+            : `${icon} ${item.name} (pending)`;
+        row.append('<span class="media-list-label">' + escapeHtml(label) + '</span>');
+        const removeBtn = $('<button type="button" class="btn-small media-remove-btn">Remove</button>');
+        if (item.kind === 'existing') {
+            removeBtn.on('click', () => {
+                removedMediaIds.push(item.id);
+                existingMedia = existingMedia.filter(m => m.id !== item.id);
+                renderMediaList();
+            });
+        } else {
+            removeBtn.on('click', () => {
+                pendingFiles.splice(item.index, 1);
+                renderMediaList();
+                if (!pendingFiles.length && !existingMedia.length) {
+                    $('.file-input-label').text('No files chosen');
+                }
+            });
+        }
+        row.append(removeBtn);
+        list.append(row);
+    });
 }
 
 function clearTravelForm() {
     $('#travel-edit-id').val('');
     $('#travel-form')[0].reset();
     $('#travel-cancel-btn').addClass('hidden');
-    $('.file-input-label').text('No file chosen');
+    $('.file-input-label').text('No files chosen');
     $('#travel-date').val(todayIso());
     $('#travel-preview').addClass('hidden');
     $('.preview-media').empty();
     $('.preview-text').empty();
-    currentFile = null;
-    editingTravelMedia = null;
+    pendingFiles = [];
+    existingMedia = [];
+    removedMediaIds = [];
+    renderMediaList();
     setTravelMessage('');
     hideGeoconfirmMap();
 }
@@ -220,21 +243,20 @@ async function loadTravelForEdit(memory) {
         $('#travel-lat').val(full.lat != null ? full.lat : '');
         $('#travel-lng').val(full.lng != null ? full.lng : '');
 
-        editingTravelMedia = full.media_url ? { url: full.media_url, type: full.media_type } : null;
-        currentFile = null;
-        $('.file-input-label').text('No file chosen');
-
-        if (full.media_url) {
-            showPreview({ title: full.title, location: full.location, notes: full.notes, mediaUrl: full.media_url, mediaType: full.media_type });
-        } else {
-            $('#travel-preview').addClass('hidden');
-        }
+        pendingFiles = [];
+        removedMediaIds = [];
+        existingMedia = Array.isArray(full.media) && full.media.length
+            ? full.media.map(m => ({ id: m.id, url: m.url, type: m.type }))
+            : (full.media_url ? [{ id: null, url: full.media_url, type: full.media_type }] : []);
+        $('.file-input-label').text('No files chosen');
+        renderMediaList();
 
         // Show confirmation map if coords already exist on this memory
         if (full.lat != null && full.lng != null) {
             updateGeoconfirmMap(parseFloat(full.lat), parseFloat(full.lng));
         }
 
+        $('#travel-preview').addClass('hidden');
         $('#travel-cancel-btn').removeClass('hidden');
         setTravelMessage('Editing: ' + full.title);
         document.getElementById('travel-title').scrollIntoView({ behavior: 'smooth' });
@@ -252,11 +274,10 @@ async function toggleTravelPublish(memory) {
                 location: memory.location || '',
                 notes: memory.notes || '',
                 visitDate: memory.visit_date || null,
-                mediaUrl: memory.media_url || null,
-                mediaType: memory.media_type || null,
                 lat: memory.lat,
                 lng: memory.lng,
                 publish: !memory.published_at,
+                // mediaItems undefined → backend leaves existing post_media untouched
             }),
         });
         if (!res.ok) throw new Error();
@@ -458,24 +479,21 @@ function initTravelForm() {
     });
 
     $('#travel-file').on('change', function (event) {
-        const file = event.target.files && event.target.files[0];
-        if (!file) { currentFile = null; return; }
-        currentFile = file;
+        const files = Array.from(event.target.files || []);
+        if (!files.length) return;
 
-        tryAutofillGpsFromFile(file);
-        tryAutofillDateFromFile(file);
+        // EXIF auto-fill from first image in the selection
+        const firstImage = files.find(f => f.type.startsWith('image/'));
+        if (firstImage) {
+            tryAutofillGpsFromFile(firstImage);
+            tryAutofillDateFromFile(firstImage);
+        }
 
-        const reader = new FileReader();
-        reader.onload = function (e) {
-            showPreview({
-                title: $('#travel-title').val(),
-                location: $('#travel-location').val(),
-                notes: $('#travel-notes').val(),
-                mediaUrl: e.target.result,
-                mediaType: file.type,
-            });
-        };
-        reader.readAsDataURL(file);
+        pendingFiles = pendingFiles.concat(files);
+        $('.file-input-label').text(pendingFiles.length + ' file' + (pendingFiles.length !== 1 ? 's' : '') + ' selected');
+        // Reset the input so the same file can be re-added if removed
+        event.target.value = '';
+        renderMediaList();
     });
 
     $('#travel-form').on('submit', async function (event) {
@@ -494,19 +512,23 @@ function initTravelForm() {
         }
 
         try {
-            let mediaUrl = editingTravelMedia ? editingTravelMedia.url : null;
-            let mediaType = editingTravelMedia ? editingTravelMedia.type : null;
-
-            if (currentFile) {
-                setTravelMessage('Uploading file…');
+            // Upload all pending files
+            const uploadedItems = [];
+            for (let i = 0; i < pendingFiles.length; i++) {
+                setTravelMessage(`Uploading file ${i + 1} of ${pendingFiles.length}…`);
                 const fd = new FormData();
-                fd.append('file', currentFile);
+                fd.append('file', pendingFiles[i]);
                 const upRes = await authFetchMultipart('/upload', fd);
                 const upData = await upRes.json();
                 if (!upRes.ok) throw new Error(upData.error || 'Upload failed');
-                mediaUrl = upData.url;
-                mediaType = upData.type;
+                uploadedItems.push({ url: upData.url, type: upData.type });
             }
+
+            // Combine: remaining existing media first, then newly uploaded
+            const mediaItems = [
+                ...existingMedia.filter(m => m.id !== null).map(m => ({ url: m.url, type: m.type })),
+                ...uploadedItems,
+            ];
 
             const editId = $('#travel-edit-id').val();
             const travel = {
@@ -514,8 +536,7 @@ function initTravelForm() {
                 location: $('#travel-location').val().trim(),
                 notes: $('#travel-notes').val().trim(),
                 visitDate: $('#travel-date').val() || null,
-                mediaUrl,
-                mediaType,
+                mediaItems,
                 lat: $('#travel-lat').val(),
                 lng: $('#travel-lng').val(),
                 publish,

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -409,7 +409,7 @@ async function tryAutofillGpsFromFile(file) {
         $('#travel-lng').val(gps.longitude.toFixed(6));
         setTravelMessage('GPS auto-filled from photo EXIF.');
         updateGeoconfirmMap(gps.latitude, gps.longitude);
-        reverseGeocodeToLocation(gps.latitude, gps.longitude);
+        await reverseGeocodeToLocation(gps.latitude, gps.longitude);
     } else {
         setTravelMessage('No GPS data in photo — enter coordinates manually or use Geocode.', false, true);
     }
@@ -429,7 +429,7 @@ async function tryAutofillGpsFromFileList(files) {
             $('#travel-lng').val(gps.longitude.toFixed(6));
             setTravelMessage(`GPS auto-filled from ${file.name}.`);
             updateGeoconfirmMap(gps.latitude, gps.longitude);
-            reverseGeocodeToLocation(gps.latitude, gps.longitude);
+            await reverseGeocodeToLocation(gps.latitude, gps.longitude);
             return; // Stop after finding the first valid one
         }
     }

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -131,6 +131,8 @@ function setPasskeyMessage(msg, isError = false) {
 let pendingFiles = [];         // File objects queued for upload
 let existingMedia = [];        // {id, url, type} from post_media (on edit)
 let removedMediaIds = [];      // post_media ids to delete on save
+let geoconfirmMap = null;      // Leaflet map for coordinate confirmation
+let geoconfirmMarker = null;   // Leaflet marker on confirmation map
 
 function renderMediaList() {
     const list = $('#travel-media-list');

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -130,9 +130,18 @@ function buildTimelineItem(opts) {
     }
 
     if (opts.mediaUrl && opts.mediaType && opts.mediaType.indexOf('image') === 0) {
+        var mediaWrap = $('<div class="media-thumb-wrap"></div>');
         var img = $('<img class="timeline-thumb" alt="">').attr('src', opts.mediaUrl);
         img.on('error', function () { $(this).remove(); });
-        content.append(img);
+        mediaWrap.append(img);
+
+        // Show "+N more" badge if multiple media items exist
+        if (opts.mediaCount && opts.mediaCount > 1) {
+            var extraCount = opts.mediaCount - 1;
+            mediaWrap.append('<span class="media-extra-badge">+' + extraCount + '</span>');
+        }
+
+        content.append(mediaWrap);
     }
 
     item.append(content);
@@ -476,6 +485,7 @@ function loadPublicTravelPosts() {
                     notes:     travel.notes,
                     mediaUrl:  mediaUrl,
                     mediaType: mediaType,
+                    mediaCount: allMedia ? allMedia.length : 0,
                 });
 
                 // Wire up lightbox for timeline image if media array exists

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -469,14 +469,25 @@ function loadPublicTravelPosts() {
                 var mediaUrl = (firstMedia && firstMedia.url) || travel.media_url || travel.mediaUrl;
                 var mediaType = (firstMedia && firstMedia.type) || travel.media_type || travel.mediaType;
 
-                timelineEl.append(buildTimelineItem({
+                var item = buildTimelineItem({
                     dateStr:   formatVisitDate(travel.visit_date),
                     title:     travel.title,
                     location:  travel.location,
                     notes:     travel.notes,
                     mediaUrl:  mediaUrl,
                     mediaType: mediaType,
-                }));
+                });
+
+                // Wire up lightbox for timeline image if media array exists
+                if (allMedia && allMedia.length > 0) {
+                    item.find('.timeline-thumb').css('cursor', 'pointer').on('click', function(e) {
+                        e.preventDefault();
+                        var mediaItems = allMedia.map(function(m) { return { url: m.url, type: m.type }; });
+                        openLightbox(mediaItems, 0, travel.title);
+                    });
+                }
+
+                timelineEl.append(item);
             });
 
             // All containers must be populated before initViewToggle wires the buttons.

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -214,15 +214,47 @@ function formatVisitDate(dateStr) {
 }
 
 function buildPublicTravelCard(travel) {
-    return buildPostCard('travel', {
-        id:        travel.id,
-        title:     travel.title,
-        location:  travel.location,
-        date:      formatVisitDate(travel.visit_date),
-        notes:     travel.notes,
-        mediaUrl:  travel.media_url || travel.mediaUrl,
-        mediaType: travel.media_type || travel.mediaType,
-    });
+    var card = $('<article class="travel-card box draft-card"></article>');
+    card.attr('data-memory-id', travel.id);
+    var media = $('<div class="media"></div>');
+
+    // Use first item from post_media array if available, fall back to legacy media_url
+    var allMedia = Array.isArray(travel.media) && travel.media.length ? travel.media : null;
+    var firstMedia = allMedia ? allMedia[0] : null;
+    var mediaUrl = (firstMedia && firstMedia.url) || travel.media_url || travel.mediaUrl;
+    var mediaType = (firstMedia && firstMedia.type) || travel.media_type || travel.mediaType;
+    var extraCount = allMedia ? allMedia.length - 1 : 0;
+
+    var placeholder = './resources/img/placeholder-transparent.png';
+    if (mediaUrl) {
+        var mediaWrap = $('<div class="media-thumb-wrap"></div>');
+        if (mediaType && mediaType.indexOf('video') === 0) {
+            mediaWrap.append('<video controls src="' + mediaUrl + '"></video>');
+        } else {
+            var img = $('<img alt="Travel snapshot">').attr('src', mediaUrl);
+            img.on('error', function () { $(this).attr('src', placeholder); });
+            mediaWrap.append(img);
+        }
+        if (extraCount > 0) {
+            mediaWrap.append('<span class="media-extra-badge">+' + extraCount + '</span>');
+        }
+        media.append(mediaWrap);
+    } else {
+        media.append('<img src="' + placeholder + '" alt="Travel snapshot">');
+    }
+
+    var content = $('<div class="travel-content"></div>');
+    content.append('<h3>' + (travel.title || 'Untitled memory') + '</h3>');
+    var formattedDate = formatVisitDate(travel.visit_date);
+    var locationText = travel.location || 'Location not set';
+    var metaHtml = '<span class="travel-location">' + locationText + '</span>';
+    if (formattedDate) {
+        metaHtml += '<span class="travel-date">' + formattedDate + '</span>';
+    }
+    content.append('<p class="meta">' + metaHtml + '</p>');
+    content.append('<p>' + (travel.notes || 'No notes yet.') + '</p>');
+    card.append(media).append(content);
+    return card;
 }
 
 // ── Travel map (Leaflet) ───────────────────────────────────────────────────────

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -213,16 +213,74 @@ function formatVisitDate(dateStr) {
     return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
 }
 
+// ── Gallery lightbox ─────────────────────────────────────────────────────────
+
+var lightboxItems = [];
+var lightboxIndex = 0;
+
+function openLightbox(items, startIndex, title) {
+    lightboxItems = items;
+    lightboxIndex = startIndex || 0;
+    $('#travel-lightbox .lightbox-title').text(title || '');
+    renderLightboxItem();
+    $('#travel-lightbox').removeClass('hidden');
+    document.body.style.overflow = 'hidden';
+}
+
+function closeLightbox() {
+    $('#travel-lightbox').addClass('hidden');
+    document.body.style.overflow = '';
+    // Stop any playing video
+    $('#travel-lightbox video').each(function () { this.pause(); });
+}
+
+function renderLightboxItem() {
+    var item = lightboxItems[lightboxIndex];
+    var mediaEl;
+    if (item.type && item.type.indexOf('video') === 0) {
+        mediaEl = $('<video controls playsinline></video>').attr('src', item.url);
+    } else {
+        mediaEl = $('<img alt="Gallery image">').attr('src', item.url);
+    }
+    $('#travel-lightbox .lightbox-media').empty().append(mediaEl);
+    $('#travel-lightbox .lightbox-counter').text((lightboxIndex + 1) + ' / ' + lightboxItems.length);
+    $('#travel-lightbox .lightbox-prev').toggleClass('hidden', lightboxIndex === 0);
+    $('#travel-lightbox .lightbox-next').toggleClass('hidden', lightboxIndex === lightboxItems.length - 1);
+}
+
+function initLightbox() {
+    $('#travel-lightbox .lightbox-close').on('click', closeLightbox);
+    $('#travel-lightbox').on('click', function (e) {
+        if ($(e.target).is('#travel-lightbox')) closeLightbox();
+    });
+    $('#travel-lightbox .lightbox-prev').on('click', function () {
+        if (lightboxIndex > 0) { lightboxIndex--; renderLightboxItem(); }
+    });
+    $('#travel-lightbox .lightbox-next').on('click', function () {
+        if (lightboxIndex < lightboxItems.length - 1) { lightboxIndex++; renderLightboxItem(); }
+    });
+    $(document).on('keydown', function (e) {
+        if ($('#travel-lightbox').hasClass('hidden')) return;
+        if (e.key === 'Escape') closeLightbox();
+        if (e.key === 'ArrowLeft' && lightboxIndex > 0) { lightboxIndex--; renderLightboxItem(); }
+        if (e.key === 'ArrowRight' && lightboxIndex < lightboxItems.length - 1) { lightboxIndex++; renderLightboxItem(); }
+    });
+}
+
+// ── Travel cards ─────────────────────────────────────────────────────────────
+
 function buildPublicTravelCard(travel) {
     var card = $('<article class="travel-card box draft-card"></article>');
     card.attr('data-memory-id', travel.id);
     var media = $('<div class="media"></div>');
 
-    // Use first item from post_media array if available, fall back to legacy media_url
-    var allMedia = Array.isArray(travel.media) && travel.media.length ? travel.media : null;
+    // Prefer post_media array; fall back to legacy media_url field
+    var allMedia = Array.isArray(travel.media) && travel.media.length
+        ? travel.media
+        : (travel.media_url ? [{ url: travel.media_url, type: travel.media_type }] : null);
     var firstMedia = allMedia ? allMedia[0] : null;
-    var mediaUrl = (firstMedia && firstMedia.url) || travel.media_url || travel.mediaUrl;
-    var mediaType = (firstMedia && firstMedia.type) || travel.media_type || travel.mediaType;
+    var mediaUrl = firstMedia ? firstMedia.url : null;
+    var mediaType = firstMedia ? firstMedia.type : null;
     var extraCount = allMedia ? allMedia.length - 1 : 0;
 
     var placeholder = './resources/img/placeholder-transparent.png';
@@ -237,17 +295,26 @@ function buildPublicTravelCard(travel) {
         }
         if (extraCount > 0) {
             mediaWrap.append('<span class="media-extra-badge">+' + extraCount + '</span>');
+            card.addClass('has-gallery');
         }
         media.append(mediaWrap);
     } else {
         media.append('<img src="' + placeholder + '" alt="Travel snapshot">');
     }
 
+    // Click on card media opens lightbox when multiple items exist
+    if (allMedia && allMedia.length > 1) {
+        media.on('click', function () {
+            openLightbox(allMedia, 0, travel.title);
+        });
+    }
+
     var content = $('<div class="travel-content"></div>');
     content.append('<h3>' + (travel.title || 'Untitled memory') + '</h3>');
     var formattedDate = formatVisitDate(travel.visit_date);
     var locationText = travel.location || 'Location not set';
-    var metaHtml = '<span class="travel-location">' + locationText + '</span>';
+    var locationPrefix = travel.location_estimated ? '~ ' : '';
+    var metaHtml = '<span class="travel-location">' + locationPrefix + locationText + '</span>';
     if (formattedDate) {
         metaHtml += '<span class="travel-date">' + formattedDate + '</span>';
     }
@@ -545,4 +612,5 @@ $(document).ready(function() {
     loadGithubWidget();
     initContactForm();
     recordVisit('home');
+    if (document.getElementById('travel-lightbox')) initLightbox();
 });

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -463,13 +463,19 @@ function loadPublicTravelPosts() {
             });
             var timelineEl = $('#travel-timeline');
             sorted.forEach(function(travel) {
+                // Use first image from media array if available, fall back to legacy media_url
+                var allMedia = Array.isArray(travel.media) && travel.media.length ? travel.media : null;
+                var firstMedia = allMedia ? allMedia[0] : null;
+                var mediaUrl = (firstMedia && firstMedia.url) || travel.media_url || travel.mediaUrl;
+                var mediaType = (firstMedia && firstMedia.type) || travel.media_type || travel.mediaType;
+
                 timelineEl.append(buildTimelineItem({
                     dateStr:   formatVisitDate(travel.visit_date),
                     title:     travel.title,
                     location:  travel.location,
                     notes:     travel.notes,
-                    mediaUrl:  travel.media_url || travel.mediaUrl,
-                    mediaType: travel.media_type || travel.mediaType,
+                    mediaUrl:  mediaUrl,
+                    mediaType: mediaType,
                 }));
             });
 

--- a/travel.html
+++ b/travel.html
@@ -76,6 +76,18 @@
         </section>
     </footer>
 
+    <!-- Gallery lightbox (#30) -->
+    <div id="travel-lightbox" class="lightbox hidden" role="dialog" aria-modal="true" aria-label="Media gallery">
+        <button type="button" class="lightbox-close" aria-label="Close gallery">&times;</button>
+        <button type="button" class="lightbox-prev" aria-label="Previous">&lsaquo;</button>
+        <button type="button" class="lightbox-next" aria-label="Next">&rsaquo;</button>
+        <div class="lightbox-media"></div>
+        <div class="lightbox-caption">
+            <span class="lightbox-title"></span>
+            <span class="lightbox-counter"></span>
+        </div>
+    </div>
+
     <script src="./resources/java/dev-env.js"></script>
     <script src="./resources/java/darkmode.js"></script>
     <script src="./resources/java/nav.js"></script>


### PR DESCRIPTION
## Summary

Adds full one-to-many media support for travel memories.

### Schema
- New `post_media` table: `post_id` FK, `media_url`, `media_type`, `order_index`
- Idempotent migration moves existing `posts.media_url` values into `post_media`
- `posts.media_url`/`media_type` are kept in sync as the first item (backward compat)

### Backend (`travel.js`)
- `GET /travel` and `GET /travel/all` return a `media` JSON array aggregated from `post_media`
- `POST /travel` and `PUT /travel` accept `mediaItems: [{url, type}]` and replace all post_media rows in a transaction
- New `DELETE /travel/:id/media/:mediaId` removes a single media item and re-syncs the primary
- `toggleTravelPublish` omits `mediaItems` so existing media is left untouched

### Admin (`admin.js` + `admin.html`)
- File input gains `multiple` attribute — select multiple files in one dialog or in batches
- `pendingFiles`, `existingMedia`, `removedMediaIds` state replaces single-file `currentFile`
- `renderMediaList()` shows each item with a Remove button (existing items have their id; pending show filename)
- Multi-file upload loops `authFetchMultipart` once per file
- `loadTravelForEdit` populates `existingMedia` from the `media[]` array returned by the admin endpoint

### Frontend (`script.js`)
- `buildPublicTravelCard` reads `media[]` array, falls back to `media_url`
- Shows first image with a **+N more** badge when additional media exists

## Test plan
- [ ] Schema migration runs cleanly on a DB with existing single-media travel posts
- [ ] Admin: select 3 images → all 3 appear in the media list with Remove buttons
- [ ] Removing a pending file before save removes it from the list
- [ ] Save creates a post with all media; card shows "+2 more" badge if 3 items
- [ ] Edit: existing media shown in list; removing one and saving persists the deletion
- [ ] Single-media posts created before this change still display correctly
- [ ] `DELETE /travel/:id/media/:mediaId` removes one item, updates cover image

Closes #30

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_