### PR TITLE
fix(#93 #95) date field fixes + feat(#101) CV management

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -146,11 +146,15 @@
                 <div style="margin-bottom:1rem">
                     <span id="cv-status-badge" class="cv-status-badge not-uploaded">Checking…</span>
                 </div>
-                <div class="file-input-wrap" style="margin-bottom:0.75rem">
+                <div class="file-input-wrap" style="margin-bottom:0.25rem">
                     <button type="button" id="cv-file-btn" class="btn-secondary" aria-label="Choose CV PDF">Choose PDF…</button>
                     <span id="cv-file-label" class="file-input-label">No file chosen</span>
                     <input id="cv-file-input" type="file" accept="application/pdf" class="file-input-hidden" />
                 </div>
+                <!-- Rename notice: shown when selected file is not already named cv.pdf (#110) -->
+                <p id="cv-rename-notice" class="hint" style="display:none;margin-bottom:0.75rem;color:var(--color-text-secondary)">
+                    ℹ Your file will be saved as <strong>cv.pdf</strong>
+                </p>
                 <div class="form-actions">
                     <button type="button" id="cv-upload-btn" class="btn-primary" disabled>Upload CV</button>
                     <button type="button" id="cv-delete-btn" class="travel-delete-btn" disabled>Delete CV</button>
@@ -268,6 +272,29 @@
                 btn.addEventListener('mouseleave', stopHold);
                 btn.addEventListener('touchend', stopHold);
                 btn.addEventListener('touchcancel', stopHold);
+            });
+        })();
+
+        // Issue #110: CV file input — wire button, show rename notice if not cv.pdf
+        (function () {
+            var fileBtn    = document.getElementById('cv-file-btn');
+            var fileInput  = document.getElementById('cv-file-input');
+            var fileLabel  = document.getElementById('cv-file-label');
+            var renameNote = document.getElementById('cv-rename-notice');
+            if (!fileBtn || !fileInput || !fileLabel || !renameNote) return;
+
+            fileBtn.addEventListener('click', function () { fileInput.click(); });
+
+            fileInput.addEventListener('change', function () {
+                if (fileInput.files.length > 0) {
+                    var name = fileInput.files[0].name;
+                    fileLabel.textContent = name;
+                    // Show rename notice only when the chosen file isn't already cv.pdf
+                    renameNote.style.display = (name.toLowerCase() !== 'cv.pdf') ? '' : 'none';
+                } else {
+                    fileLabel.textContent = 'No file chosen';
+                    renameNote.style.display = 'none';
+                }
             });
         })();
     </script>

--- a/admin.html
+++ b/admin.html
@@ -136,6 +136,28 @@
                 </div>
             </div>
 
+            <!-- ── CV management (#101) ──────────────────────────────────────────── -->
+            <div class="admin-card">
+                <h2 class="admin-card-title">CV</h2>
+                <p class="hint" style="margin-bottom:1rem">
+                    Upload a PDF CV to make it available for download on the site.
+                    The file will be scanned for obvious private information before publishing.
+                </p>
+                <div style="margin-bottom:1rem">
+                    <span id="cv-status-badge" class="cv-status-badge not-uploaded">Checking…</span>
+                </div>
+                <div class="file-input-wrap" style="margin-bottom:0.75rem">
+                    <button type="button" id="cv-file-btn" class="btn-secondary" aria-label="Choose CV PDF">Choose PDF…</button>
+                    <span id="cv-file-label" class="file-input-label">No file chosen</span>
+                    <input id="cv-file-input" type="file" accept="application/pdf" class="file-input-hidden" />
+                </div>
+                <div class="form-actions">
+                    <button type="button" id="cv-upload-btn" class="btn-primary" disabled>Upload CV</button>
+                    <button type="button" id="cv-delete-btn" class="travel-delete-btn" disabled>Delete CV</button>
+                </div>
+                <p id="cv-message" class="admin-message"></p>
+            </div>
+
             <!-- ── Private notes ─────────────────────────────────────────────────── -->
             <div class="admin-card private-card">
                 <h2 class="admin-card-title">Private coding projects</h2>

--- a/backend/app.js
+++ b/backend/app.js
@@ -16,6 +16,7 @@ import contactRoutes from './routes/contact.js';
 import uploadRoutes  from './routes/upload.js';
 import postsRoutes   from './routes/posts.js';
 import statsRoutes   from './routes/stats.js';
+import cvRoutes      from './routes/cv.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -48,6 +49,7 @@ export function createApp() {
   app.use('/upload',  uploadRoutes);
   app.use('/posts',   postsRoutes);
   app.use('/stats',   statsRoutes);
+  app.use('/cv',      cvRoutes);
 
   app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 

--- a/backend/routes/cv.js
+++ b/backend/routes/cv.js
@@ -1,0 +1,111 @@
+/**
+ * CV management routes
+ *
+ * GET  /cv/exists  → { exists: bool }          public
+ * GET  /cv         → streams uploads/cv.pdf    public
+ * POST /cv         → upload a new CV (PDF)     auth required
+ * DELETE /cv       → remove the CV file        auth required
+ */
+import { Router }   from 'express';
+import multer       from 'multer';
+import path         from 'path';
+import fs           from 'fs';
+import { fileURLToPath } from 'url';
+import { authenticate }  from '../middleware/authenticate.js';
+
+const router = Router();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const UPLOADS_DIR = process.env.UPLOADS_DIR || path.join(__dirname, '..', '..', 'uploads');
+const CV_PATH     = path.join(UPLOADS_DIR, 'cv.pdf');
+
+// ── multer: memory storage so we can inspect before writing ──────────────────
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+  fileFilter(_req, file, cb) {
+    if (file.mimetype === 'application/pdf') {
+      cb(null, true);
+    } else {
+      cb(Object.assign(new Error('Only PDF files are accepted'), { status: 400 }));
+    }
+  },
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function cvExists() {
+  return fs.existsSync(CV_PATH);
+}
+
+/**
+ * Lightly scan the PDF buffer for strings that look like private info.
+ * We use a simple regex pass over the raw bytes — no heavy parse needed
+ * for this heuristic check. Returns an array of warning strings.
+ */
+function scanForPrivateInfo(buffer) {
+  const text = buffer.toString('latin1');
+  const warnings = [];
+
+  // Common patterns that shouldn't appear in a public CV
+  const patterns = [
+    { re: /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/, label: 'possible card number' },
+    { re: /\b\d{3}-\d{2}-\d{4}\b/,                        label: 'possible SSN' },
+    { re: /\bpassword[:\s]/i,                              label: 'possible password' },
+    { re: /\bsort\s*code[:\s]/i,                          label: 'possible sort code' },
+    { re: /\bni\s*number[:\s]/i,                          label: 'possible NI number' },
+  ];
+
+  patterns.forEach(({ re, label }) => {
+    if (re.test(text)) warnings.push(label);
+  });
+
+  return warnings;
+}
+
+// ── Routes ────────────────────────────────────────────────────────────────────
+
+// Public: check whether a CV is currently uploaded
+router.get('/exists', (_req, res) => {
+  res.json({ exists: cvExists() });
+});
+
+// Public: download the CV
+router.get('/', (req, res) => {
+  if (!cvExists()) return res.status(404).json({ error: 'No CV uploaded yet' });
+  res.download(CV_PATH, 'Andy_Keys_CV.pdf', (err) => {
+    if (err && !res.headersSent) {
+      res.status(500).json({ error: 'Failed to send CV' });
+    }
+  });
+});
+
+// Admin: upload / replace CV
+router.post('/', authenticate, upload.single('cv'), async (req, res) => {
+  if (!req.file) return res.status(400).json({ error: 'No file provided' });
+
+  const warnings = scanForPrivateInfo(req.file.buffer);
+
+  try {
+    if (!fs.existsSync(UPLOADS_DIR)) fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+    fs.writeFileSync(CV_PATH, req.file.buffer);
+    res.status(200).json({ uploaded: true, warnings });
+  } catch (err) {
+    console.error('CV upload error:', err);
+    res.status(500).json({ error: 'Failed to save CV' });
+  }
+});
+
+// Admin: delete the CV
+router.delete('/', authenticate, (req, res) => {
+  if (!cvExists()) return res.status(404).json({ error: 'No CV to delete' });
+  try {
+    fs.unlinkSync(CV_PATH);
+    res.json({ deleted: true });
+  } catch (err) {
+    console.error('CV delete error:', err);
+    res.status(500).json({ error: 'Failed to delete CV' });
+  }
+});
+
+export default router;

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
                         <div class="about-actions">
                             <!-- CV download: shown only if a CV is available via the API.
                                  Falls back gracefully — no button shown if no CV is uploaded.
-                                 Static href removed to fix #110 (hardcoded path caused 404). -->
+                                 Re-checked on visibilitychange so returning from admin is reactive. -->
                             <button id="cv-download-btn" class="btn-download" style="display:none" type="button">
                                 Download CV
                             </button>
@@ -359,21 +359,35 @@
     <script type="module" src="./resources/java/script.js"></script>
 
     <script>
-        // CV download button — shown only if a CV is available via the API (#110)
+        // CV download button — reactive, no manual reload needed (#110)
+        // checkCvExists() is called on load AND whenever the page regains
+        // visibility (e.g. switching back from the admin tab).
         (function () {
             var btn = document.getElementById('cv-download-btn');
             if (!btn) return;
 
-            fetch('/api/cv/exists')
-                .then(function (r) { return r.json(); })
-                .then(function (data) {
-                    if (data && data.exists) {
-                        btn.style.display = '';
-                    }
-                })
-                .catch(function () {
-                    // API unreachable — silently hide button (no broken UI)
-                });
+            function checkCvExists() {
+                fetch('/api/cv/exists')
+                    .then(function (r) { return r.json(); })
+                    .then(function (data) {
+                        btn.style.display = (data && data.exists) ? '' : 'none';
+                    })
+                    .catch(function () {
+                        btn.style.display = 'none'; // API unreachable — hide safely
+                    });
+            }
+
+            // Initial check on page load
+            checkCvExists();
+
+            // Re-check whenever this tab becomes visible again
+            // (covers navigating back from admin.html in the same tab,
+            //  or switching back from another tab)
+            document.addEventListener('visibilitychange', function () {
+                if (document.visibilityState === 'visible') {
+                    checkCvExists();
+                }
+            });
 
             btn.addEventListener('click', function () {
                 btn.disabled = true;

--- a/index.html
+++ b/index.html
@@ -57,7 +57,12 @@
                         <p>The move from accountancy to data engineering gives me an edge few engineers have: I understand the business context behind the data as much as the technical infrastructure that moves it. Earlier in my career I built reporting infrastructure and ETL workflows for an alternative investment platform, which gave me a strong foundation in data modelling, SQL, and stakeholder-facing analytics.</p>
                         <p>Outside of work I enjoy travel and documenting experiences on the road. I'm always looking for the next thing to learn — whether that's a new cloud technology, a side project, or a better way to build the tools I already use.</p>
                         <div class="about-actions">
-                            <a href="./resources/downloads/cv.pdf" download="Andrew_Keys_CV.pdf" class="btn-download">Download CV</a>
+                            <!-- CV download: shown only if a CV is available via the API.
+                                 Falls back gracefully — no button shown if no CV is uploaded.
+                                 Static href removed to fix #110 (hardcoded path caused 404). -->
+                            <button id="cv-download-btn" class="btn-download" style="display:none" type="button">
+                                Download CV
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -352,6 +357,52 @@
     <!-- jQuery must load before modules so $ is available as a global -->
     <script src="./resources/java/jquery-3.5.1.min.js"></script>
     <script type="module" src="./resources/java/script.js"></script>
+
+    <script>
+        // CV download button — shown only if a CV is available via the API (#110)
+        (function () {
+            var btn = document.getElementById('cv-download-btn');
+            if (!btn) return;
+
+            fetch('/api/cv/exists')
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    if (data && data.exists) {
+                        btn.style.display = '';
+                    }
+                })
+                .catch(function () {
+                    // API unreachable — silently hide button (no broken UI)
+                });
+
+            btn.addEventListener('click', function () {
+                btn.disabled = true;
+                btn.textContent = 'Downloading…';
+                fetch('/api/cv')
+                    .then(function (r) {
+                        if (!r.ok) throw new Error('CV not available');
+                        return r.blob();
+                    })
+                    .then(function (blob) {
+                        var url = URL.createObjectURL(blob);
+                        var a = document.createElement('a');
+                        a.href = url;
+                        a.download = 'Andrew_Keys_CV.pdf';
+                        document.body.appendChild(a);
+                        a.click();
+                        document.body.removeChild(a);
+                        URL.revokeObjectURL(url);
+                    })
+                    .catch(function () {
+                        alert('CV is not currently available. Please try again later.');
+                    })
+                    .finally(function () {
+                        btn.disabled = false;
+                        btn.textContent = 'Download CV';
+                    });
+            });
+        })();
+    </script>
 </body>
 
 </html>

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -2,7 +2,7 @@ import { startRegistration } from 'https://esm.sh/@simplewebauthn/browser@7';
 import exifr from 'https://esm.sh/exifr@7.1.3';
 import { API_BASE } from './config.js';
 
-// ── Auth helpers ──────────────────────────────────────────────────────────────────────────────
+// ── Auth helpers ────────────────────────────────────────────────────────────────────────────────
 
 function getToken() {
     return localStorage.getItem('adminToken');
@@ -54,7 +54,7 @@ function todayIso() {
     return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}-${String(t.getDate()).padStart(2, '0')}`;
 }
 
-// ── Passkey management ──────────────────────────────────────────────────────────────────────
+// ── Passkey management ──────────────────────────────────────────────────────────────────
 
 async function loadPasskeys() {
     const container = document.getElementById('passkey-list');
@@ -126,7 +126,7 @@ function setPasskeyMessage(msg, isError = false) {
     el.style.color = isError ? 'var(--color-error)' : 'var(--color-success)';
 }
 
-// ── Travel memories ─────────────────────────────────────────────────────────────────────────
+// ── Travel memories ─────────────────────────────────────────────────────────────────────
 
 let pendingFiles = [];         // File objects queued for upload
 let existingMedia = [];        // {id, url, type} from post_media (on edit)
@@ -231,6 +231,7 @@ async function loadTravelMemories() {
     }
 }
 
+// #93 fix: slice ISO timestamp to YYYY-MM-DD before setting date input
 async function loadTravelForEdit(memory) {
     try {
         const res = await authFetch(`/travel/admin/${memory.id}`);
@@ -241,7 +242,9 @@ async function loadTravelForEdit(memory) {
         $('#travel-title').val(full.title || '');
         $('#travel-location').val(full.location || '');
         $('#travel-notes').val(full.notes || '');
-        $('#travel-date').val(full.visit_date || todayIso());
+        // Slice to YYYY-MM-DD — full ISO timestamps like 2026-05-04T00:00:00.000Z
+        // are not accepted by <input type="date"> and silently clear the field (#93)
+        $('#travel-date').val(full.visit_date ? String(full.visit_date).slice(0, 10) : todayIso());
         $('#travel-lat').val(full.lat != null ? full.lat : '');
         $('#travel-lng').val(full.lng != null ? full.lng : '');
 
@@ -307,7 +310,7 @@ function setTravelMessage(msg, isError = false, isHint = false) {
     el.style.color = isError ? 'var(--color-error)' : isHint ? 'var(--color-text-muted)' : 'var(--color-success)';
 }
 
-// ── Geocode confirmation map ────────────────────────────────────────────────────────────────────────
+// ── Geocode confirmation map ─────────────────────────────────────────────────────────────────────────
 
 function updateGeoconfirmMap(lat, lng) {
     if (!window.L) return;
@@ -595,7 +598,7 @@ function initTravelForm() {
     $('#travel-clear').on('click', clearTravelForm);
 }
 
-// ── Blog posts ────────────────────────────────────────────────────────────────────────────
+// ── Blog posts ─────────────────────────────────────────────────────────────────────────────────
 
 const POST_TEMPLATE = `_Short tagline or subtitle._
 
@@ -620,7 +623,7 @@ function example() { return 'hello'; }
 
 ## Wrap-up
 
-End with a takeaway, a question, or a link to what’s next.
+End with a takeaway, a question, or a link to what\'s next.
 `;
 
 function setPostMessage(msg, isError = false) {
@@ -634,7 +637,8 @@ function clearPostForm() {
     $('#post-edit-id').val('');
     $('#post-title').val('');
     $('#post-body').val('');
-    $('#post-date').val('');
+    // #93 fix: default to today so the date field is never blank on a new post
+    $('#post-date').val(todayIso());
     $('#post-cancel-btn').addClass('hidden');
     setPostMessage('');
 }
@@ -678,19 +682,26 @@ async function loadAdminPosts() {
     }
 }
 
-function loadPostForEdit(post) {
+// #95 fix: converted to async/await so body_markdown and post_date always
+// populate before the user can interact with the form.
+// #93 fix: slice ISO timestamp to YYYY-MM-DD before setting the date input.
+async function loadPostForEdit(post) {
     $('#post-edit-id').val(post.id);
     $('#post-title').val(post.title);
-    authFetch(`/posts/admin/${post.id}`).then(async r => {
-        if (r.ok) {
-            const full = await r.json();
-            $('#post-body').val(full.body_markdown);
-            $('#post-date').val(full.post_date || '');
-        }
-    });
     $('#post-cancel-btn').removeClass('hidden');
     setPostMessage('Editing: ' + post.title);
     document.getElementById('post-title').scrollIntoView({ behavior: 'smooth' });
+
+    try {
+        const r = await authFetch(`/posts/admin/${post.id}`);
+        if (!r.ok) throw new Error();
+        const full = await r.json();
+        $('#post-body').val(full.body_markdown || '');
+        // Slice to YYYY-MM-DD — full ISO timestamps silently clear <input type="date"> (#93)
+        $('#post-date').val(full.post_date ? String(full.post_date).slice(0, 10) : todayIso());
+    } catch {
+        setPostMessage('Failed to load post body — please try again.', true);
+    }
 }
 
 async function togglePublish(post) {
@@ -772,6 +783,125 @@ function initPostForm() {
     });
 }
 
+// ── CV management (#101) ──────────────────────────────────────────────────────────────────
+
+function setCvMessage(msg, isError = false) {
+    const el = document.getElementById('cv-message');
+    if (!el) return;
+    el.textContent = msg;
+    el.style.color = isError ? 'var(--color-error)' : 'var(--color-success)';
+}
+
+function updateCvStatusBadge(exists) {
+    const badge = document.getElementById('cv-status-badge');
+    if (!badge) return;
+    if (exists) {
+        badge.textContent = '✓ CV uploaded';
+        badge.className = 'cv-status-badge uploaded';
+    } else {
+        badge.textContent = '✕ No CV uploaded';
+        badge.className = 'cv-status-badge not-uploaded';
+    }
+    const deleteBtn = document.getElementById('cv-delete-btn');
+    if (deleteBtn) deleteBtn.disabled = !exists;
+}
+
+async function loadCvStatus() {
+    try {
+        const res = await fetch(`${API_BASE}/cv/exists`);
+        const { exists } = await res.json();
+        updateCvStatusBadge(exists);
+    } catch {
+        setCvMessage('Could not check CV status.', true);
+    }
+}
+
+async function uploadCv(file) {
+    const uploadBtn = document.getElementById('cv-upload-btn');
+    uploadBtn.disabled = true;
+    setCvMessage('Uploading…');
+
+    const fd = new FormData();
+    fd.append('cv', file);
+
+    try {
+        const res = await fetch(`${API_BASE}/cv`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${getToken()}` },
+            body: fd,
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'Upload failed');
+
+        if (data.warnings && data.warnings.length) {
+            // Surface private-info scan warnings before confirming success
+            const warningList = data.warnings.join('\n• ');
+            const proceed = confirm(
+                `The scan found potential private information in this PDF:\n\u2022 ${warningList}\n\nDo you still want to publish it?`
+            );
+            if (!proceed) {
+                // Delete the file we just uploaded so it isn’t accidentally served
+                await authFetch('/cv', { method: 'DELETE' });
+                setCvMessage('Upload cancelled — CV removed from server.', true);
+                await loadCvStatus();
+                return;
+            }
+        }
+
+        setCvMessage('CV uploaded successfully.');
+        await loadCvStatus();
+    } catch (err) {
+        setCvMessage(err.message || 'Upload failed.', true);
+    } finally {
+        uploadBtn.disabled = false;
+        // Reset file input so the same file can be re-selected
+        const input = document.getElementById('cv-file-input');
+        if (input) input.value = '';
+        const label = document.getElementById('cv-file-label');
+        if (label) label.textContent = 'No file chosen';
+    }
+}
+
+async function deleteCv() {
+    if (!confirm('Delete the current CV? It will no longer be available for download.')) return;
+    setCvMessage('');
+    try {
+        const res = await authFetch('/cv', { method: 'DELETE' });
+        if (!res.ok) throw new Error();
+        setCvMessage('CV deleted.');
+        await loadCvStatus();
+    } catch {
+        setCvMessage('Failed to delete CV.', true);
+    }
+}
+
+function initCvSection() {
+    const cvFileInput = document.getElementById('cv-file-input');
+    const cvFileBtn   = document.getElementById('cv-file-btn');
+    const cvFileLabel = document.getElementById('cv-file-label');
+    const cvUploadBtn = document.getElementById('cv-upload-btn');
+    const cvDeleteBtn = document.getElementById('cv-delete-btn');
+
+    if (!cvFileInput) return;
+
+    // Wire styled button to hidden native file input
+    cvFileBtn.addEventListener('click', () => cvFileInput.click());
+    cvFileInput.addEventListener('change', () => {
+        const file = cvFileInput.files[0];
+        cvFileLabel.textContent = file ? file.name : 'No file chosen';
+        cvUploadBtn.disabled = !file;
+    });
+
+    cvUploadBtn.addEventListener('click', () => {
+        const file = cvFileInput.files[0];
+        if (file) uploadCv(file);
+    });
+
+    cvDeleteBtn.addEventListener('click', deleteCv);
+
+    loadCvStatus();
+}
+
 // ── Private notes ───────────────────────────────────────────────────────────────────────────
 
 function initPrivateNotes() {
@@ -795,7 +925,7 @@ function setLogout() {
     });
 }
 
-// ── Site stats ──────────────────────────────────────────────────────────────────────────────
+// ── Site stats ────────────────────────────────────────────────────────────────────────
 
 async function loadStats() {
     const list = document.getElementById('stats-list');
@@ -821,13 +951,14 @@ async function loadStats() {
     }
 }
 
-// ── Bootstrap ──────────────────────────────────────────────────────────────────────────────
+// ── Bootstrap ─────────────────────────────────────────────────────────────────────────────────
 
 requireAuth();
 setLogout();
 initTravelForm();
 initPrivateNotes();
 initPostForm();
+initCvSection();
 loadTravelMemories();
 loadAdminPosts();
 loadPasskeys();

--- a/scripts/tests/Test-PR107.ps1
+++ b/scripts/tests/Test-PR107.ps1
@@ -7,7 +7,7 @@
     Verifies:
       - #93  Travel edit: GET /api/travel/admin/:id returns visit_date as full ISO timestamp
              (admin.js slices to YYYY-MM-DD before setting the date input)
-      - #95  Blog edit: GET /api/posts/:id returns post_date and body_markdown reliably
+      - #95  Blog edit: GET /api/posts/admin/:id returns post_date and body_markdown reliably
       - #101 CV endpoints: exists, upload, download, delete
       - Regression: contact validation, posts create/validate, travel create/validate,
         unknown route 404
@@ -150,11 +150,10 @@ if ($SkipVitest) {
     }
 }
 
-# ── #93 / #95: date fields on edit
+# ── #93: Travel date field
 Write-Host ""
 Write-Host "--- #93 Travel edit: visit_date present in admin response ---" -ForegroundColor White
-# Create a travel post and immediately fetch it back; verify visit_date is in the response
-# so admin.js can slice it to YYYY-MM-DD. Full UI verification is manual (see checklist).
+
 Test-Endpoint `
     -Name         'Travel: create draft for date-field test -> 201' `
     -Method       'POST' `
@@ -164,7 +163,6 @@ Test-Endpoint `
     -ExpectStatus 201 `
     -RequiresAuth $true
 
-# Fetch the most recent travel post and check visit_date is present
 if ($Token) {
     $listRaw = curl.exe -s -H "Authorization: Bearer $Token" "$BaseUrl/api/travel/all"
     try {
@@ -173,12 +171,20 @@ if ($Token) {
         if ($testPost) {
             $detailRaw = curl.exe -s -H "Authorization: Bearer $Token" "$BaseUrl/api/travel/admin/$($testPost.id)"
             $detail = $detailRaw | ConvertFrom-Json
-            if ($detail.visit_date) {
+            if ($null -ne $detail.visit_date) {
                 Write-Host "  [PASS] Travel admin detail: visit_date present ('$($detail.visit_date)')" -ForegroundColor Green
                 $pass++
-                $results += [PSCustomObject]@{ Result = 'PASS'; Name = 'Travel admin: visit_date in response'; Detail = $detail.visit_date }
-                # Verify it starts with YYYY-MM-DD pattern (10 chars)
-                $sliced = $detail.visit_date.ToString().Substring(0, [Math]::Min(10, $detail.visit_date.ToString().Length))
+                $results += [PSCustomObject]@{ Result = 'PASS'; Name = 'Travel admin: visit_date in response'; Detail = "$($detail.visit_date)" }
+
+                # Cast to string first — ConvertFrom-Json auto-converts ISO dates to [DateTime]
+                # which .ToString() renders in locale format (MM/DD/YYYY). We need the raw ISO string.
+                $dateStr = [string]$detail.visit_date
+                # ISO date strings start with YYYY-; [DateTime].ToString() starts with MM/
+                # Re-format [DateTime] objects to ISO if ConvertFrom-Json ate the original string
+                if ($detail.visit_date -is [datetime]) {
+                    $dateStr = $detail.visit_date.ToString('yyyy-MM-dd')
+                }
+                $sliced = $dateStr.Substring(0, [Math]::Min(10, $dateStr.Length))
                 if ($sliced -match '^\d{4}-\d{2}-\d{2}$') {
                     Write-Host "  [PASS] Travel admin: sliced date '$sliced' is valid YYYY-MM-DD" -ForegroundColor Green
                     $pass++
@@ -206,6 +212,7 @@ if ($Token) {
     $skip += 2
 }
 
+# ── #95: Blog date + body fields
 Write-Host ""
 Write-Host "--- #95 Blog edit: post_date and body_markdown present in response ---" -ForegroundColor White
 
@@ -224,10 +231,12 @@ if ($Token) {
         $list = $listRaw | ConvertFrom-Json
         $testPost = $list | Where-Object { $_.title -eq 'Date Field Test Post' } | Select-Object -First 1
         if ($testPost) {
-            $detailRaw = curl.exe -s -H "Authorization: Bearer $Token" "$BaseUrl/api/posts/$($testPost.id)"
+            # Use /api/posts/admin/:id — the public /api/posts/:slug endpoint strips
+            # draft-only fields and requires a slug, not an id.
+            $detailRaw = curl.exe -s -H "Authorization: Bearer $Token" "$BaseUrl/api/posts/admin/$($testPost.id)"
             $detail = $detailRaw | ConvertFrom-Json
             foreach ($field in @('post_date', 'body_markdown')) {
-                if ($detail.$field) {
+                if ($null -ne $detail.$field -and $detail.$field -ne '') {
                     Write-Host "  [PASS] Blog admin detail: '$field' present" -ForegroundColor Green
                     $pass++
                     $results += [PSCustomObject]@{ Result = 'PASS'; Name = "Blog admin: $field in response"; Detail = 'present' }
@@ -254,7 +263,6 @@ if ($Token) {
 Write-Host ""
 Write-Host "--- #101 CV management ---" -ForegroundColor White
 
-# Public: check CV exists (expect false when no CV uploaded)
 Test-Endpoint `
     -Name         'CV: GET /api/cv/exists -> 200 with exists field' `
     -Method       'GET' `
@@ -262,18 +270,14 @@ Test-Endpoint `
     -ExpectStatus 200 `
     -ExpectBody   'exists'
 
-# Public: GET /api/cv -> 404 when no CV present
 Test-Endpoint `
     -Name         'CV: GET /api/cv -> 404 when no CV uploaded' `
     -Method       'GET' `
     -Url          "$BaseUrl/api/cv" `
     -ExpectStatus 404
 
-# Auth: upload a minimal valid PDF
-# Uses a tiny hand-crafted PDF that passes pdf-parse without warnings
 if ($Token) {
     $tempPdf = Join-Path $env:TEMP 'test-cv.pdf'
-    # Minimal valid PDF bytes (no personal info — just enough for pdf-parse to read)
     $pdfContent = "%PDF-1.4`n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R>>endobj`nxref`n0 4`n0000000000 65535 f`n0000000009 00000 n`n0000000058 00000 n`n0000000115 00000 n`ntrailer<</Size 4/Root 1 0 R>>`nstartxref`n190`n%%EOF"
     [System.IO.File]::WriteAllText($tempPdf, $pdfContent)
 
@@ -296,7 +300,6 @@ if ($Token) {
         $results += [PSCustomObject]@{ Result = 'FAIL'; Name = 'CV: upload -> 200'; Detail = "Got $uploadStatus" }
     }
 
-    # After upload: exists should return true
     Test-Endpoint `
         -Name         'CV: GET /api/cv/exists -> exists true after upload' `
         -Method       'GET' `
@@ -304,14 +307,12 @@ if ($Token) {
         -ExpectStatus 200 `
         -ExpectBody   'true'
 
-    # After upload: GET /api/cv should stream the file (200)
     Test-Endpoint `
         -Name         'CV: GET /api/cv -> 200 after upload' `
         -Method       'GET' `
         -Url          "$BaseUrl/api/cv" `
         -ExpectStatus 200
 
-    # Auth: upload without a file -> 400
     Test-Endpoint `
         -Name         'CV: POST /api/cv without file -> 400' `
         -Method       'POST' `
@@ -320,7 +321,6 @@ if ($Token) {
         -ExpectStatus 400 `
         -RequiresAuth $true
 
-    # Auth: delete CV
     Test-Endpoint `
         -Name         'CV: DELETE /api/cv -> 200' `
         -Method       'DELETE' `
@@ -329,7 +329,6 @@ if ($Token) {
         -ExpectStatus 200 `
         -RequiresAuth $true
 
-    # After delete: exists should return false
     Test-Endpoint `
         -Name         'CV: GET /api/cv/exists -> exists false after delete' `
         -Method       'GET' `
@@ -337,7 +336,6 @@ if ($Token) {
         -ExpectStatus 200 `
         -ExpectBody   'false'
 
-    # After delete: GET /api/cv -> 404
     Test-Endpoint `
         -Name         'CV: GET /api/cv -> 404 after delete' `
         -Method       'GET' `
@@ -350,21 +348,19 @@ if ($Token) {
     $skip += 5
 }
 
-# Auth required: unauthenticated upload -> 401
 Test-Endpoint `
     -Name         'CV: POST /api/cv unauthenticated -> 401' `
     -Method       'POST' `
     -Url          "$BaseUrl/api/cv" `
     -ExpectStatus 401
 
-# Auth required: unauthenticated delete -> 401
 Test-Endpoint `
     -Name         'CV: DELETE /api/cv unauthenticated -> 401' `
     -Method       'DELETE' `
     -Url          "$BaseUrl/api/cv" `
     -ExpectStatus 401
 
-# ── Regression: contact validation
+# ── Regression: contact
 Write-Host ""
 Write-Host "--- Regression: contact form ---" -ForegroundColor White
 

--- a/scripts/tests/Test-PR107.ps1
+++ b/scripts/tests/Test-PR107.ps1
@@ -263,6 +263,14 @@ if ($Token) {
 Write-Host ""
 Write-Host "--- #101 CV management ---" -ForegroundColor White
 
+# Ensure clean state before testing empty-CV behaviour.
+# A cv.pdf left on disk from a previous run would cause the 404 assertion to
+# incorrectly receive 200. Silently delete first — no-op if nothing is there.
+if ($Token) {
+    Write-Host "  [INFO] Cleaning up any pre-existing CV..." -ForegroundColor DarkGray
+    curl.exe -s -o NUL -X DELETE -H "Authorization: Bearer $Token" "$BaseUrl/api/cv" | Out-Null
+}
+
 Test-Endpoint `
     -Name         'CV: GET /api/cv/exists -> 200 with exists field' `
     -Method       'GET' `
@@ -465,6 +473,7 @@ Write-Host "  [ ] New blog post — date defaults to today" -ForegroundColor Dar
 Write-Host "  [ ] Upload a PDF — status badge changes to '✓ CV uploaded'" -ForegroundColor DarkGray
 Write-Host "  [ ] Upload PDF with personal info — warnings modal appears; cancel removes file" -ForegroundColor DarkGray
 Write-Host "  [ ] Delete CV — status badge reverts to '✕ No CV uploaded'" -ForegroundColor DarkGray
+Write-Host "  [ ] CV download button on index.html: hidden when no CV, visible after upload, hidden after delete (reactive — no reload needed)" -ForegroundColor DarkGray
 Write-Host ""
 
 Stop-Transcript | Out-Null

--- a/scripts/tests/Test-PR107.ps1
+++ b/scripts/tests/Test-PR107.ps1
@@ -1,0 +1,475 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Smoke tests for PR #107 — date field fixes (#93 #95) + CV management (#101).
+
+.DESCRIPTION
+    Verifies:
+      - #93  Travel edit: GET /api/travel/admin/:id returns visit_date as full ISO timestamp
+             (admin.js slices to YYYY-MM-DD before setting the date input)
+      - #95  Blog edit: GET /api/posts/:id returns post_date and body_markdown reliably
+      - #101 CV endpoints: exists, upload, download, delete
+      - Regression: contact validation, posts create/validate, travel create/validate,
+        unknown route 404
+
+    Output is written to the console AND a timestamped file in test-results\
+
+    Requires the dev stack to be running:
+        . scripts\dev\dev-local.ps1
+
+    Token handling:
+        - If -Token is provided it is used directly.
+        - If omitted, auto-generated from the container JWT_SECRET (no secret hardcoded).
+        - If the container is not running, auth tests are skipped with a clear warning.
+
+.PARAMETER Token
+    Admin JWT. Optional — auto-generated from the container JWT_SECRET if not supplied.
+
+.PARAMETER BaseUrl
+    Base URL of the running stack. Defaults to http://localhost
+
+.PARAMETER SkipVitest
+    Skip the Vitest suite and run HTTP smoke tests only.
+#>
+param(
+    [string]$Token      = '',
+    [string]$BaseUrl    = 'http://localhost',
+    [switch]$SkipVitest
+)
+
+# ── Output capture
+$resultsDir = Join-Path $PSScriptRoot '..' '..' 'test-results'
+if (-not (Test-Path $resultsDir)) { New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null }
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$logFile   = Join-Path $resultsDir "PR107-$timestamp.txt"
+Start-Transcript -Path $logFile -Append | Out-Null
+
+# ── Auto-generate JWT
+if (-not $Token) {
+    Write-Host "  [INFO] No -Token provided — attempting to generate dev JWT from container..." -ForegroundColor DarkGray
+    try {
+        $generated = docker compose exec -T backend node -e @"
+const jwt = require('jsonwebtoken');
+if (!process.env.JWT_SECRET) { process.stderr.write('NO_SECRET'); process.exit(1); }
+console.log(jwt.sign({ userId: 'dev-test-user' }, process.env.JWT_SECRET, { expiresIn: '1h' }));
+"@ 2>&1
+        $generated = $generated | Where-Object { $_ -notmatch '^npm ' } | Select-Object -Last 1
+        $generated = ($generated -join '').Trim()
+        if ($generated -and $generated -notmatch 'NO_SECRET' -and $generated -match '^eyJ') {
+            $Token = $generated
+            Write-Host "  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)" -ForegroundColor DarkGray
+        } else {
+            Write-Host "  [WARN] Could not generate token — auth tests will be skipped" -ForegroundColor DarkYellow
+        }
+    } catch {
+        Write-Host "  [WARN] Token generation failed: $_ — auth tests will be skipped" -ForegroundColor DarkYellow
+    }
+}
+
+$pass    = 0
+$fail    = 0
+$skip    = 0
+$results = @()
+
+function Test-Endpoint {
+    param(
+        [string]$Name,
+        [string]$Method,
+        [string]$Url,
+        [string]$Body       = '',
+        [string[]]$Headers  = @(),
+        [int]$ExpectStatus,
+        [string]$ExpectBody = '',
+        [bool]$RequiresAuth = $false
+    )
+
+    if ($RequiresAuth -and -not $Token) {
+        Write-Host "  [SKIP] $Name (no token available)" -ForegroundColor DarkYellow
+        $script:skip++
+        $script:results += [PSCustomObject]@{ Result = 'SKIP'; Name = $Name; Detail = 'No token' }
+        return
+    }
+
+    $curlArgs = @('-s', '-o', 'tmp_body.txt', '-w', '%{http_code}', '-X', $Method)
+    foreach ($h in $Headers) { $curlArgs += @('-H', $h) }
+    if ($Body) { $curlArgs += @('-d', $Body) }
+    $curlArgs += $Url
+
+    $statusCode = curl.exe @curlArgs
+    $bodyText   = if (Test-Path tmp_body.txt) { Get-Content tmp_body.txt -Raw } else { '' }
+    if (Test-Path tmp_body.txt) { Remove-Item tmp_body.txt -Force }
+
+    $statusOk = ([int]$statusCode -eq $ExpectStatus)
+    $bodyOk   = (-not $ExpectBody) -or ($bodyText -like "*$ExpectBody*")
+    $passed   = $statusOk -and $bodyOk
+
+    if ($passed) {
+        Write-Host "  [PASS] $Name" -ForegroundColor Green
+        $script:pass++
+        $script:results += [PSCustomObject]@{ Result = 'PASS'; Name = $Name; Detail = "$statusCode" }
+    } else {
+        $detail = "Expected $ExpectStatus got $statusCode"
+        if (-not $bodyOk) { $detail += " | body mismatch: $($bodyText.Trim())" }
+        Write-Host "  [FAIL] $Name — $detail" -ForegroundColor Red
+        $script:fail++
+        $script:results += [PSCustomObject]@{ Result = 'FAIL'; Name = $Name; Detail = $detail }
+    }
+}
+
+$jsonHeader = 'Content-Type: application/json'
+$authHeader = "Authorization: Bearer $Token"
+
+Write-Host ""
+Write-Host "══════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host "  PR #107 Test Run — $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Cyan
+Write-Host "  Base URL : $BaseUrl"
+Write-Host "  Token    : $(if ($Token) { 'auto-generated from container' } else { 'not available (auth tests skipped)' })"
+Write-Host "  Log file : $logFile"
+Write-Host "══════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host ""
+
+# ── Vitest suite
+if ($SkipVitest) {
+    Write-Host "--- Vitest suite (skipped via -SkipVitest) ---" -ForegroundColor DarkYellow
+    $skip++
+    $results += [PSCustomObject]@{ Result = 'SKIP'; Name = 'Vitest suite'; Detail = '-SkipVitest flag set' }
+} else {
+    Write-Host "--- Vitest unit + integration suite ---" -ForegroundColor White
+    Write-Host "  Running inside backend container..." -ForegroundColor DarkGray
+    docker compose exec backend npm install --silent 2>&1
+    docker compose exec backend npm test 2>&1
+    $vitestExit = $LASTEXITCODE
+    if ($vitestExit -eq 0) {
+        Write-Host "  [PASS] Vitest suite" -ForegroundColor Green
+        $pass++
+        $results += [PSCustomObject]@{ Result = 'PASS'; Name = 'Vitest suite'; Detail = 'exit 0' }
+    } else {
+        Write-Host "  [FAIL] Vitest suite (exit $vitestExit)" -ForegroundColor Red
+        $fail++
+        $results += [PSCustomObject]@{ Result = 'FAIL'; Name = 'Vitest suite'; Detail = "exit $vitestExit" }
+    }
+}
+
+# ── #93 / #95: date fields on edit
+Write-Host ""
+Write-Host "--- #93 Travel edit: visit_date present in admin response ---" -ForegroundColor White
+# Create a travel post and immediately fetch it back; verify visit_date is in the response
+# so admin.js can slice it to YYYY-MM-DD. Full UI verification is manual (see checklist).
+Test-Endpoint `
+    -Name         'Travel: create draft for date-field test -> 201' `
+    -Method       'POST' `
+    -Url          "$BaseUrl/api/travel" `
+    -Headers      @($jsonHeader, $authHeader) `
+    -Body         '{"title":"Date Field Test","location":"Test City","visitDate":"2026-03-01","lat":51.5,"lng":-0.1,"publish":false}' `
+    -ExpectStatus 201 `
+    -RequiresAuth $true
+
+# Fetch the most recent travel post and check visit_date is present
+if ($Token) {
+    $listRaw = curl.exe -s -H "Authorization: Bearer $Token" "$BaseUrl/api/travel/all"
+    try {
+        $list = $listRaw | ConvertFrom-Json
+        $testPost = $list | Where-Object { $_.title -eq 'Date Field Test' } | Select-Object -First 1
+        if ($testPost) {
+            $detailRaw = curl.exe -s -H "Authorization: Bearer $Token" "$BaseUrl/api/travel/admin/$($testPost.id)"
+            $detail = $detailRaw | ConvertFrom-Json
+            if ($detail.visit_date) {
+                Write-Host "  [PASS] Travel admin detail: visit_date present ('$($detail.visit_date)')" -ForegroundColor Green
+                $pass++
+                $results += [PSCustomObject]@{ Result = 'PASS'; Name = 'Travel admin: visit_date in response'; Detail = $detail.visit_date }
+                # Verify it starts with YYYY-MM-DD pattern (10 chars)
+                $sliced = $detail.visit_date.ToString().Substring(0, [Math]::Min(10, $detail.visit_date.ToString().Length))
+                if ($sliced -match '^\d{4}-\d{2}-\d{2}$') {
+                    Write-Host "  [PASS] Travel admin: sliced date '$sliced' is valid YYYY-MM-DD" -ForegroundColor Green
+                    $pass++
+                    $results += [PSCustomObject]@{ Result = 'PASS'; Name = 'Travel admin: visit_date sliceable to YYYY-MM-DD'; Detail = $sliced }
+                } else {
+                    Write-Host "  [FAIL] Travel admin: sliced date '$sliced' is not YYYY-MM-DD" -ForegroundColor Red
+                    $fail++
+                    $results += [PSCustomObject]@{ Result = 'FAIL'; Name = 'Travel admin: visit_date sliceable to YYYY-MM-DD'; Detail = $sliced }
+                }
+            } else {
+                Write-Host "  [FAIL] Travel admin detail: visit_date missing from response" -ForegroundColor Red
+                $fail++
+                $results += [PSCustomObject]@{ Result = 'FAIL'; Name = 'Travel admin: visit_date in response'; Detail = 'field absent' }
+            }
+        } else {
+            Write-Host "  [SKIP] Travel admin date test — test post not found in list" -ForegroundColor DarkYellow
+            $skip++
+        }
+    } catch {
+        Write-Host "  [FAIL] Travel admin date test — could not parse response: $_" -ForegroundColor Red
+        $fail++
+    }
+} else {
+    Write-Host "  [SKIP] Travel admin date tests (no token)" -ForegroundColor DarkYellow
+    $skip += 2
+}
+
+Write-Host ""
+Write-Host "--- #95 Blog edit: post_date and body_markdown present in response ---" -ForegroundColor White
+
+Test-Endpoint `
+    -Name         'Posts: create draft for date-field test -> 201' `
+    -Method       'POST' `
+    -Url          "$BaseUrl/api/posts" `
+    -Headers      @($jsonHeader, $authHeader) `
+    -Body         '{"title":"Date Field Test Post","body_markdown":"## Hello","post_date":"2026-03-01","publish":false}' `
+    -ExpectStatus 201 `
+    -RequiresAuth $true
+
+if ($Token) {
+    $listRaw = curl.exe -s -H "Authorization: Bearer $Token" "$BaseUrl/api/posts/all"
+    try {
+        $list = $listRaw | ConvertFrom-Json
+        $testPost = $list | Where-Object { $_.title -eq 'Date Field Test Post' } | Select-Object -First 1
+        if ($testPost) {
+            $detailRaw = curl.exe -s -H "Authorization: Bearer $Token" "$BaseUrl/api/posts/$($testPost.id)"
+            $detail = $detailRaw | ConvertFrom-Json
+            foreach ($field in @('post_date', 'body_markdown')) {
+                if ($detail.$field) {
+                    Write-Host "  [PASS] Blog admin detail: '$field' present" -ForegroundColor Green
+                    $pass++
+                    $results += [PSCustomObject]@{ Result = 'PASS'; Name = "Blog admin: $field in response"; Detail = 'present' }
+                } else {
+                    Write-Host "  [FAIL] Blog admin detail: '$field' missing" -ForegroundColor Red
+                    $fail++
+                    $results += [PSCustomObject]@{ Result = 'FAIL'; Name = "Blog admin: $field in response"; Detail = 'absent' }
+                }
+            }
+        } else {
+            Write-Host "  [SKIP] Blog admin date test — test post not found in list" -ForegroundColor DarkYellow
+            $skip++
+        }
+    } catch {
+        Write-Host "  [FAIL] Blog admin date test — could not parse response: $_" -ForegroundColor Red
+        $fail++
+    }
+} else {
+    Write-Host "  [SKIP] Blog admin date tests (no token)" -ForegroundColor DarkYellow
+    $skip += 2
+}
+
+# ── #101: CV endpoints
+Write-Host ""
+Write-Host "--- #101 CV management ---" -ForegroundColor White
+
+# Public: check CV exists (expect false when no CV uploaded)
+Test-Endpoint `
+    -Name         'CV: GET /api/cv/exists -> 200 with exists field' `
+    -Method       'GET' `
+    -Url          "$BaseUrl/api/cv/exists" `
+    -ExpectStatus 200 `
+    -ExpectBody   'exists'
+
+# Public: GET /api/cv -> 404 when no CV present
+Test-Endpoint `
+    -Name         'CV: GET /api/cv -> 404 when no CV uploaded' `
+    -Method       'GET' `
+    -Url          "$BaseUrl/api/cv" `
+    -ExpectStatus 404
+
+# Auth: upload a minimal valid PDF
+# Uses a tiny hand-crafted PDF that passes pdf-parse without warnings
+if ($Token) {
+    $tempPdf = Join-Path $env:TEMP 'test-cv.pdf'
+    # Minimal valid PDF bytes (no personal info — just enough for pdf-parse to read)
+    $pdfContent = "%PDF-1.4`n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R>>endobj`nxref`n0 4`n0000000000 65535 f`n0000000009 00000 n`n0000000058 00000 n`n0000000115 00000 n`ntrailer<</Size 4/Root 1 0 R>>`nstartxref`n190`n%%EOF"
+    [System.IO.File]::WriteAllText($tempPdf, $pdfContent)
+
+    Write-Host "  Uploading test CV..." -ForegroundColor DarkGray
+    $uploadStatus = curl.exe -s -o tmp_body.txt -w '%{http_code}' `
+        -X POST `
+        -H "Authorization: Bearer $Token" `
+        -F "cv=@$tempPdf;type=application/pdf" `
+        "$BaseUrl/api/cv"
+    $uploadBody = if (Test-Path tmp_body.txt) { Get-Content tmp_body.txt -Raw } else { '' }
+    if (Test-Path tmp_body.txt) { Remove-Item tmp_body.txt -Force }
+
+    if ([int]$uploadStatus -eq 200) {
+        Write-Host "  [PASS] CV: POST /api/cv -> 200" -ForegroundColor Green
+        $pass++
+        $results += [PSCustomObject]@{ Result = 'PASS'; Name = 'CV: upload -> 200'; Detail = $uploadBody.Trim() }
+    } else {
+        Write-Host "  [FAIL] CV: POST /api/cv -> expected 200, got $uploadStatus | $($uploadBody.Trim())" -ForegroundColor Red
+        $fail++
+        $results += [PSCustomObject]@{ Result = 'FAIL'; Name = 'CV: upload -> 200'; Detail = "Got $uploadStatus" }
+    }
+
+    # After upload: exists should return true
+    Test-Endpoint `
+        -Name         'CV: GET /api/cv/exists -> exists true after upload' `
+        -Method       'GET' `
+        -Url          "$BaseUrl/api/cv/exists" `
+        -ExpectStatus 200 `
+        -ExpectBody   'true'
+
+    # After upload: GET /api/cv should stream the file (200)
+    Test-Endpoint `
+        -Name         'CV: GET /api/cv -> 200 after upload' `
+        -Method       'GET' `
+        -Url          "$BaseUrl/api/cv" `
+        -ExpectStatus 200
+
+    # Auth: upload without a file -> 400
+    Test-Endpoint `
+        -Name         'CV: POST /api/cv without file -> 400' `
+        -Method       'POST' `
+        -Url          "$BaseUrl/api/cv" `
+        -Headers      @($authHeader) `
+        -ExpectStatus 400 `
+        -RequiresAuth $true
+
+    # Auth: delete CV
+    Test-Endpoint `
+        -Name         'CV: DELETE /api/cv -> 200' `
+        -Method       'DELETE' `
+        -Url          "$BaseUrl/api/cv" `
+        -Headers      @($authHeader) `
+        -ExpectStatus 200 `
+        -RequiresAuth $true
+
+    # After delete: exists should return false
+    Test-Endpoint `
+        -Name         'CV: GET /api/cv/exists -> exists false after delete' `
+        -Method       'GET' `
+        -Url          "$BaseUrl/api/cv/exists" `
+        -ExpectStatus 200 `
+        -ExpectBody   'false'
+
+    # After delete: GET /api/cv -> 404
+    Test-Endpoint `
+        -Name         'CV: GET /api/cv -> 404 after delete' `
+        -Method       'GET' `
+        -Url          "$BaseUrl/api/cv" `
+        -ExpectStatus 404
+
+    if (Test-Path $tempPdf) { Remove-Item $tempPdf -Force }
+} else {
+    Write-Host "  [SKIP] CV upload/download/delete tests (no token)" -ForegroundColor DarkYellow
+    $skip += 5
+}
+
+# Auth required: unauthenticated upload -> 401
+Test-Endpoint `
+    -Name         'CV: POST /api/cv unauthenticated -> 401' `
+    -Method       'POST' `
+    -Url          "$BaseUrl/api/cv" `
+    -ExpectStatus 401
+
+# Auth required: unauthenticated delete -> 401
+Test-Endpoint `
+    -Name         'CV: DELETE /api/cv unauthenticated -> 401' `
+    -Method       'DELETE' `
+    -Url          "$BaseUrl/api/cv" `
+    -ExpectStatus 401
+
+# ── Regression: contact validation
+Write-Host ""
+Write-Host "--- Regression: contact form ---" -ForegroundColor White
+
+Test-Endpoint `
+    -Name         'Contact: valid request reaches handler (known 500 — see #100)' `
+    -Method       'POST' `
+    -Url          "$BaseUrl/api/contact" `
+    -Headers      @($jsonHeader) `
+    -Body         '{"name":"Test","email":"test@example.com","message":"Hello"}' `
+    -ExpectStatus 500
+
+Test-Endpoint `
+    -Name         'Contact: missing name -> 400' `
+    -Method       'POST' `
+    -Url          "$BaseUrl/api/contact" `
+    -Headers      @($jsonHeader) `
+    -Body         '{"name":"","email":"test@example.com","message":"Hello"}' `
+    -ExpectStatus 400 `
+    -ExpectBody   'name'
+
+Test-Endpoint `
+    -Name         'Contact: invalid email -> 400' `
+    -Method       'POST' `
+    -Url          "$BaseUrl/api/contact" `
+    -Headers      @($jsonHeader) `
+    -Body         '{"name":"Test","email":"not-an-email","message":"Hello"}' `
+    -ExpectStatus 400 `
+    -ExpectBody   'email'
+
+# ── Regression: posts
+Write-Host ""
+Write-Host "--- Regression: blog posts ---" -ForegroundColor White
+
+Test-Endpoint `
+    -Name         'Posts: missing title -> 400' `
+    -Method       'POST' `
+    -Url          "$BaseUrl/api/posts" `
+    -Headers      @($jsonHeader, $authHeader) `
+    -Body         '{"body_markdown":"## Hello"}' `
+    -ExpectStatus 400 `
+    -ExpectBody   'title' `
+    -RequiresAuth $true
+
+Test-Endpoint `
+    -Name         'Posts: invalid date format -> 400' `
+    -Method       'POST' `
+    -Url          "$BaseUrl/api/posts" `
+    -Headers      @($jsonHeader, $authHeader) `
+    -Body         '{"title":"Test","post_date":"04-05-2026"}' `
+    -ExpectStatus 400 `
+    -ExpectBody   'YYYY-MM-DD' `
+    -RequiresAuth $true
+
+# ── Regression: travel
+Write-Host ""
+Write-Host "--- Regression: travel posts ---" -ForegroundColor White
+
+Test-Endpoint `
+    -Name         'Travel: missing title -> 400' `
+    -Method       'POST' `
+    -Url          "$BaseUrl/api/travel" `
+    -Headers      @($jsonHeader, $authHeader) `
+    -Body         '{"location":"Auckland"}' `
+    -ExpectStatus 400 `
+    -ExpectBody   'title' `
+    -RequiresAuth $true
+
+# ── Error handler
+Write-Host ""
+Write-Host "--- Error handler ---" -ForegroundColor White
+
+$unknownStatus = curl.exe -s -o NUL -w '%{http_code}' "$BaseUrl/api/doesnotexist"
+if ([int]$unknownStatus -eq 404) {
+    Write-Host "  [PASS] Unknown route -> 404" -ForegroundColor Green
+    $pass++
+    $results += [PSCustomObject]@{ Result = 'PASS'; Name = 'Unknown route -> 404'; Detail = '404' }
+} else {
+    Write-Host "  [FAIL] Unknown route -> expected 404, got $unknownStatus" -ForegroundColor Red
+    $fail++
+    $results += [PSCustomObject]@{ Result = 'FAIL'; Name = 'Unknown route -> 404'; Detail = "Got $unknownStatus" }
+}
+
+# ── Summary
+Write-Host ""
+Write-Host "══════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host "  PASSED : $pass" -ForegroundColor Green
+if ($skip -gt 0) { Write-Host "  SKIPPED: $skip" -ForegroundColor DarkYellow }
+if ($fail -gt 0) {
+    Write-Host "  FAILED : $fail" -ForegroundColor Red
+} else {
+    Write-Host "  FAILED : $fail" -ForegroundColor Green
+}
+Write-Host "══════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host "  Full log: $logFile" -ForegroundColor DarkGray
+Write-Host ""
+
+# ── Manual checklist reminder
+Write-Host "Manual checks (UI — not automated):" -ForegroundColor White
+Write-Host "  [ ] Edit a travel memory — date field pre-populates correctly (YYYY-MM-DD)" -ForegroundColor DarkGray
+Write-Host "  [ ] Edit a blog post — date and body both pre-populate before first interaction" -ForegroundColor DarkGray
+Write-Host "  [ ] New blog post — date defaults to today" -ForegroundColor DarkGray
+Write-Host "  [ ] Upload a PDF — status badge changes to '✓ CV uploaded'" -ForegroundColor DarkGray
+Write-Host "  [ ] Upload PDF with personal info — warnings modal appears; cancel removes file" -ForegroundColor DarkGray
+Write-Host "  [ ] Delete CV — status badge reverts to '✕ No CV uploaded'" -ForegroundColor DarkGray
+Write-Host ""
+
+Stop-Transcript | Out-Null
+if ($fail -gt 0) { exit 1 } else { exit 0 }

--- a/test-results/PR107-20260504-223045.txt
+++ b/test-results/PR107-20260504-223045.txt
@@ -1,0 +1,95 @@
+**********************
+PowerShell transcript start
+Start time: 20260504223045
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.1.0_x64__8wekyb3d8bbwe\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260504T201035\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-32620-214504.json' -FeatureFlags @() 
+Process ID: 20668
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+══════════════════════════════════════════════════════
+  PR #107 Test Run — 2026-05-04 22:30:45
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-223045.txt
+══════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+  [PASS] Vitest suite
+
+--- #93 Travel edit: visit_date present in admin response ---
+  [PASS] Travel: create draft for date-field test -> 201
+  [PASS] Travel admin detail: visit_date present ('03/01/2026 00:00:00')
+  [FAIL] Travel admin: sliced date '01/03/2026' is not YYYY-MM-DD
+
+--- #95 Blog edit: post_date and body_markdown present in response ---
+  [PASS] Posts: create draft for date-field test -> 201
+  [FAIL] Blog admin detail: 'post_date' missing
+  [FAIL] Blog admin detail: 'body_markdown' missing
+
+--- #101 CV management ---
+  [PASS] CV: GET /api/cv/exists -> 200 with exists field
+  [PASS] CV: GET /api/cv -> 404 when no CV uploaded
+  Uploading test CV...
+  [PASS] CV: POST /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists true after upload
+  [PASS] CV: GET /api/cv -> 200 after upload
+  [PASS] CV: POST /api/cv without file -> 400
+  [PASS] CV: DELETE /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists false after delete
+  [PASS] CV: GET /api/cv -> 404 after delete
+  [PASS] CV: POST /api/cv unauthenticated -> 401
+  [PASS] CV: DELETE /api/cv unauthenticated -> 401
+
+--- Regression: contact form ---
+  [PASS] Contact: valid request reaches handler (known 500 — see #100)
+  [PASS] Contact: missing name -> 400
+  [PASS] Contact: invalid email -> 400
+
+--- Regression: blog posts ---
+  [PASS] Posts: missing title -> 400
+  [PASS] Posts: invalid date format -> 400
+
+--- Regression: travel posts ---
+  [PASS] Travel: missing title -> 400
+
+--- Error handler ---
+  [PASS] Unknown route -> 404
+
+══════════════════════════════════════════════════════
+  PASSED : 22
+  FAILED : 3
+══════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-223045.txt
+
+Manual checks (UI — not automated):
+  [ ] Edit a travel memory — date field pre-populates correctly (YYYY-MM-DD)
+  [ ] Edit a blog post — date and body both pre-populate before first interaction
+  [ ] New blog post — date defaults to today
+  [ ] Upload a PDF — status badge changes to '✓ CV uploaded'
+  [ ] Upload PDF with personal info — warnings modal appears; cancel removes file
+  [ ] Delete CV — status badge reverts to '✕ No CV uploaded'
+
+**********************
+PowerShell transcript end
+End time: 20260504223050
+**********************

--- a/test-results/PR107-20260504-223553.txt
+++ b/test-results/PR107-20260504-223553.txt
@@ -1,0 +1,95 @@
+**********************
+PowerShell transcript start
+Start time: 20260504223553
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.1.0_x64__8wekyb3d8bbwe\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260504T201035\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-32620-214504.json' -FeatureFlags @() 
+Process ID: 20668
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+══════════════════════════════════════════════════════
+  PR #107 Test Run — 2026-05-04 22:35:53
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-223553.txt
+══════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+  [PASS] Vitest suite
+
+--- #93 Travel edit: visit_date present in admin response ---
+  [PASS] Travel: create draft for date-field test -> 201
+  [PASS] Travel admin detail: visit_date present ('03/01/2026 00:00:00')
+  [PASS] Travel admin: sliced date '2026-03-01' is valid YYYY-MM-DD
+
+--- #95 Blog edit: post_date and body_markdown present in response ---
+  [PASS] Posts: create draft for date-field test -> 201
+  [PASS] Blog admin detail: 'post_date' present
+  [PASS] Blog admin detail: 'body_markdown' present
+
+--- #101 CV management ---
+  [PASS] CV: GET /api/cv/exists -> 200 with exists field
+  [PASS] CV: GET /api/cv -> 404 when no CV uploaded
+  Uploading test CV...
+  [PASS] CV: POST /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists true after upload
+  [PASS] CV: GET /api/cv -> 200 after upload
+  [PASS] CV: POST /api/cv without file -> 400
+  [PASS] CV: DELETE /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists false after delete
+  [PASS] CV: GET /api/cv -> 404 after delete
+  [PASS] CV: POST /api/cv unauthenticated -> 401
+  [PASS] CV: DELETE /api/cv unauthenticated -> 401
+
+--- Regression: contact form ---
+  [PASS] Contact: valid request reaches handler (known 500 — see #100)
+  [PASS] Contact: missing name -> 400
+  [PASS] Contact: invalid email -> 400
+
+--- Regression: blog posts ---
+  [PASS] Posts: missing title -> 400
+  [PASS] Posts: invalid date format -> 400
+
+--- Regression: travel posts ---
+  [PASS] Travel: missing title -> 400
+
+--- Error handler ---
+  [PASS] Unknown route -> 404
+
+══════════════════════════════════════════════════════
+  PASSED : 25
+  FAILED : 0
+══════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-223553.txt
+
+Manual checks (UI — not automated):
+  [ ] Edit a travel memory — date field pre-populates correctly (YYYY-MM-DD)
+  [ ] Edit a blog post — date and body both pre-populate before first interaction
+  [ ] New blog post — date defaults to today
+  [ ] Upload a PDF — status badge changes to '✓ CV uploaded'
+  [ ] Upload PDF with personal info — warnings modal appears; cancel removes file
+  [ ] Delete CV — status badge reverts to '✕ No CV uploaded'
+
+**********************
+PowerShell transcript end
+End time: 20260504223558
+**********************

--- a/test-results/PR107-20260504-225316.txt
+++ b/test-results/PR107-20260504-225316.txt
@@ -1,0 +1,95 @@
+**********************
+PowerShell transcript start
+Start time: 20260504225316
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.1.0_x64__8wekyb3d8bbwe\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260504T201035\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-32620-214504.json' -FeatureFlags @() 
+Process ID: 20668
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+══════════════════════════════════════════════════════
+  PR #107 Test Run — 2026-05-04 22:53:16
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-225316.txt
+══════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+  [PASS] Vitest suite
+
+--- #93 Travel edit: visit_date present in admin response ---
+  [PASS] Travel: create draft for date-field test -> 201
+  [PASS] Travel admin detail: visit_date present ('03/01/2026 00:00:00')
+  [PASS] Travel admin: sliced date '2026-03-01' is valid YYYY-MM-DD
+
+--- #95 Blog edit: post_date and body_markdown present in response ---
+  [PASS] Posts: create draft for date-field test -> 201
+  [PASS] Blog admin detail: 'post_date' present
+  [PASS] Blog admin detail: 'body_markdown' present
+
+--- #101 CV management ---
+  [PASS] CV: GET /api/cv/exists -> 200 with exists field
+  [PASS] CV: GET /api/cv -> 404 when no CV uploaded
+  Uploading test CV...
+  [PASS] CV: POST /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists true after upload
+  [PASS] CV: GET /api/cv -> 200 after upload
+  [PASS] CV: POST /api/cv without file -> 400
+  [PASS] CV: DELETE /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists false after delete
+  [PASS] CV: GET /api/cv -> 404 after delete
+  [PASS] CV: POST /api/cv unauthenticated -> 401
+  [PASS] CV: DELETE /api/cv unauthenticated -> 401
+
+--- Regression: contact form ---
+  [PASS] Contact: valid request reaches handler (known 500 — see #100)
+  [PASS] Contact: missing name -> 400
+  [PASS] Contact: invalid email -> 400
+
+--- Regression: blog posts ---
+  [PASS] Posts: missing title -> 400
+  [PASS] Posts: invalid date format -> 400
+
+--- Regression: travel posts ---
+  [PASS] Travel: missing title -> 400
+
+--- Error handler ---
+  [PASS] Unknown route -> 404
+
+══════════════════════════════════════════════════════
+  PASSED : 25
+  FAILED : 0
+══════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-225316.txt
+
+Manual checks (UI — not automated):
+  [ ] Edit a travel memory — date field pre-populates correctly (YYYY-MM-DD)
+  [ ] Edit a blog post — date and body both pre-populate before first interaction
+  [ ] New blog post — date defaults to today
+  [ ] Upload a PDF — status badge changes to '✓ CV uploaded'
+  [ ] Upload PDF with personal info — warnings modal appears; cancel removes file
+  [ ] Delete CV — status badge reverts to '✕ No CV uploaded'
+
+**********************
+PowerShell transcript end
+End time: 20260504225321
+**********************

--- a/test-results/PR107-20260504-230317.txt
+++ b/test-results/PR107-20260504-230317.txt
@@ -1,0 +1,95 @@
+**********************
+PowerShell transcript start
+Start time: 20260504230317
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.1.0_x64__8wekyb3d8bbwe\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260504T201035\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-32620-214504.json' -FeatureFlags @() 
+Process ID: 20668
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+══════════════════════════════════════════════════════
+  PR #107 Test Run — 2026-05-04 23:03:17
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-230317.txt
+══════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+  [PASS] Vitest suite
+
+--- #93 Travel edit: visit_date present in admin response ---
+  [PASS] Travel: create draft for date-field test -> 201
+  [PASS] Travel admin detail: visit_date present ('03/01/2026 00:00:00')
+  [PASS] Travel admin: sliced date '2026-03-01' is valid YYYY-MM-DD
+
+--- #95 Blog edit: post_date and body_markdown present in response ---
+  [PASS] Posts: create draft for date-field test -> 201
+  [PASS] Blog admin detail: 'post_date' present
+  [PASS] Blog admin detail: 'body_markdown' present
+
+--- #101 CV management ---
+  [PASS] CV: GET /api/cv/exists -> 200 with exists field
+  [FAIL] CV: GET /api/cv -> 404 when no CV uploaded — Expected 404 got 200
+  Uploading test CV...
+  [PASS] CV: POST /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists true after upload
+  [PASS] CV: GET /api/cv -> 200 after upload
+  [PASS] CV: POST /api/cv without file -> 400
+  [PASS] CV: DELETE /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists false after delete
+  [PASS] CV: GET /api/cv -> 404 after delete
+  [PASS] CV: POST /api/cv unauthenticated -> 401
+  [PASS] CV: DELETE /api/cv unauthenticated -> 401
+
+--- Regression: contact form ---
+  [PASS] Contact: valid request reaches handler (known 500 — see #100)
+  [PASS] Contact: missing name -> 400
+  [PASS] Contact: invalid email -> 400
+
+--- Regression: blog posts ---
+  [PASS] Posts: missing title -> 400
+  [PASS] Posts: invalid date format -> 400
+
+--- Regression: travel posts ---
+  [PASS] Travel: missing title -> 400
+
+--- Error handler ---
+  [PASS] Unknown route -> 404
+
+══════════════════════════════════════════════════════
+  PASSED : 24
+  FAILED : 1
+══════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-230317.txt
+
+Manual checks (UI — not automated):
+  [ ] Edit a travel memory — date field pre-populates correctly (YYYY-MM-DD)
+  [ ] Edit a blog post — date and body both pre-populate before first interaction
+  [ ] New blog post — date defaults to today
+  [ ] Upload a PDF — status badge changes to '✓ CV uploaded'
+  [ ] Upload PDF with personal info — warnings modal appears; cancel removes file
+  [ ] Delete CV — status badge reverts to '✕ No CV uploaded'
+
+**********************
+PowerShell transcript end
+End time: 20260504230322
+**********************

--- a/test-results/PR107-20260504-230754.txt
+++ b/test-results/PR107-20260504-230754.txt
@@ -1,0 +1,97 @@
+**********************
+PowerShell transcript start
+Start time: 20260504230754
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.1.0_x64__8wekyb3d8bbwe\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260504T201035\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-32620-214504.json' -FeatureFlags @() 
+Process ID: 20668
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+══════════════════════════════════════════════════════
+  PR #107 Test Run — 2026-05-04 23:07:54
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-230754.txt
+══════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+  [PASS] Vitest suite
+
+--- #93 Travel edit: visit_date present in admin response ---
+  [PASS] Travel: create draft for date-field test -> 201
+  [PASS] Travel admin detail: visit_date present ('03/01/2026 00:00:00')
+  [PASS] Travel admin: sliced date '2026-03-01' is valid YYYY-MM-DD
+
+--- #95 Blog edit: post_date and body_markdown present in response ---
+  [PASS] Posts: create draft for date-field test -> 201
+  [PASS] Blog admin detail: 'post_date' present
+  [PASS] Blog admin detail: 'body_markdown' present
+
+--- #101 CV management ---
+  [INFO] Cleaning up any pre-existing CV...
+  [PASS] CV: GET /api/cv/exists -> 200 with exists field
+  [PASS] CV: GET /api/cv -> 404 when no CV uploaded
+  Uploading test CV...
+  [PASS] CV: POST /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists true after upload
+  [PASS] CV: GET /api/cv -> 200 after upload
+  [PASS] CV: POST /api/cv without file -> 400
+  [PASS] CV: DELETE /api/cv -> 200
+  [PASS] CV: GET /api/cv/exists -> exists false after delete
+  [PASS] CV: GET /api/cv -> 404 after delete
+  [PASS] CV: POST /api/cv unauthenticated -> 401
+  [PASS] CV: DELETE /api/cv unauthenticated -> 401
+
+--- Regression: contact form ---
+  [PASS] Contact: valid request reaches handler (known 500 — see #100)
+  [PASS] Contact: missing name -> 400
+  [PASS] Contact: invalid email -> 400
+
+--- Regression: blog posts ---
+  [PASS] Posts: missing title -> 400
+  [PASS] Posts: invalid date format -> 400
+
+--- Regression: travel posts ---
+  [PASS] Travel: missing title -> 400
+
+--- Error handler ---
+  [PASS] Unknown route -> 404
+
+══════════════════════════════════════════════════════
+  PASSED : 25
+  FAILED : 0
+══════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR107-20260504-230754.txt
+
+Manual checks (UI — not automated):
+  [ ] Edit a travel memory — date field pre-populates correctly (YYYY-MM-DD)
+  [ ] Edit a blog post — date and body both pre-populate before first interaction
+  [ ] New blog post — date defaults to today
+  [ ] Upload a PDF — status badge changes to '✓ CV uploaded'
+  [ ] Upload PDF with personal info — warnings modal appears; cancel removes file
+  [ ] Delete CV — status badge reverts to '✕ No CV uploaded'
+  [ ] CV download button on index.html: hidden when no CV, visible after upload, hidden after delete (reactive — no reload needed)
+
+**********************
+PowerShell transcript end
+End time: 20260504230758
+**********************


### PR DESCRIPTION
## Summary

Three issues resolved in one branch — two bug fixes and one new feature.

---

## #93 — Date fields silently clear on edit (travel & blog)

**Root cause:** `full.visit_date` and `full.post_date` arrive from the backend as full ISO timestamps (`2026-05-04T00:00:00.000Z`). Setting these directly on `<input type="date">` silently fails — the browser expects `YYYY-MM-DD` only.

**Fix:**
- `loadTravelForEdit`: `.slice(0, 10)` applied to `visit_date` before setting the input
- `loadPostForEdit`: `.slice(0, 10)` applied to `post_date` before setting the input
- `clearPostForm`: now defaults `#post-date` to `todayIso()` to match travel form behaviour

---

## #95 — Blog post body / date unreliable on edit

**Root cause:** `loadPostForEdit` used a floating `.then()` chain — the title and edit-id were set synchronously, but `body_markdown` and `post_date` arrived asynchronously after the function had returned, making the form appear blank until the promise resolved.

**Fix:** Converted `loadPostForEdit` to `async/await` so `body_markdown` and `post_date` always populate before the user can interact with the form. Error state now surfaces a readable message instead of silently failing.

---

## #101 — CV management

**Backend (`backend/routes/cv.js`):**
- `GET /cv/exists` — public, returns `{ exists: bool }`
- `GET /cv` — public, streams `uploads/cv.pdf`
- `POST /cv` — auth required, multer PDF-only upload (5 MB cap), `pdf-parse` scans for obvious private info, returns `{ warnings[] }` if found
- `DELETE /cv` — auth required, removes the file
- Mounted at `/cv` in `app.js`; `pdf-parse` added as a dependency

**Admin JS (`resources/java/admin.js`):**
- `initCvSection()` — wires file picker, upload, delete
- `loadCvStatus()` — checks `/cv/exists` on page load, updates badge
- `uploadCv()` — uploads, shows warnings modal if private info detected, user must confirm or upload is rolled back
- `deleteCv()` — confirms then deletes
- `setCvMessage()` / `updateCvStatusBadge()` — feedback helpers

**Admin HTML (`admin.html`):**
- New CV card between Blog posts and Private notes
- Status badge (`✓ CV uploaded` / `✕ No CV uploaded`)
- Styled file picker (hidden native input + visible button + label)
- Upload button (disabled until file selected)
- Delete button (disabled when no CV present)
- `#cv-message` feedback element

---

## Files changed

- `backend/routes/cv.js` — new
- `backend/app.js` — mounts `/cv` route
- `backend/package.json` — adds `pdf-parse`
- `resources/java/admin.js` — date fixes + CV section
- `admin.html` — CV management section

## Testing

- [ ] Edit a travel memory — date field pre-populates correctly
- [ ] Edit a blog post — date and body both pre-populate correctly
- [ ] New blog post — date defaults to today
- [ ] Upload a PDF CV — status badge updates to uploaded
- [ ] Upload a PDF with sensitive content — warnings modal appears, cancel removes file
- [ ] Delete CV — status badge reverts to not uploaded
- [ ] `GET /cv/exists` returns correct state with no CV present
- [ ] `GET /cv` streams the file when present, 404 when not

Closes #93, #95, #101