### PR TITLE
fix(#111): extend CV scan to detect phone numbers and UK postcodes

### DIFF
--- a/backend/routes/cv.js
+++ b/backend/routes/cv.js
@@ -55,6 +55,12 @@ function scanForPrivateInfo(buffer) {
     { re: /\bpassword[:\s]/i,                              label: 'possible password' },
     { re: /\bsort\s*code[:\s]/i,                          label: 'possible sort code' },
     { re: /\bni\s*number[:\s]/i,                          label: 'possible NI number' },
+    // Phone numbers — UK mobile, +44 international prefix, UK landline area codes
+    { re: /\b07\d{3}[\s-]?\d{3}[\s-]?\d{3}\b/,           label: 'possible UK mobile number' },
+    { re: /\+44[\s.-]?\(?\d/,                             label: 'possible +44 phone number' },
+    { re: /\b0[1-9]\d{2,4}[\s-]\d{4,7}\b/,               label: 'possible UK phone number' },
+    // UK postcodes — standard format (e.g. SW1A 1AA, GY1 1AA)
+    { re: /\b[A-Z]{1,2}\d[0-9A-Z]?\s?\d[A-Z]{2}\b/,      label: 'possible UK postcode / home address' },
   ];
 
   patterns.forEach(({ re, label }) => {


### PR DESCRIPTION
## Summary

Extends the CV private-content scanner (`scanForPrivateInfo()` in `backend/routes/cv.js`) to catch phone numbers and UK postcodes — the two patterns identified in issue #111 that slipped through during PR #107 testing.

### New patterns added

| Pattern | Example | Notes |
|---------|---------|-------|
| UK mobile | `07xxx xxx xxx` | Space or dash separator |
| +44 international | `+44 7911 123456` | Any digit following `+44` |
| UK landline | `01481 256789` | Requires space/dash between area code and number — prevents false matches on dates/versions |
| UK postcode | `SW1A 1AA`, `GY1 1AA` | Standard UK format including Guernsey |

The landline regex requires an explicit space or dash separator (`\b0[1-9]\d{2,4}[\s-]\d{4,7}\b`) specifically to avoid false positives on things like `01/2024` or version strings — a continuous run of digits without a separator is not matched.

All new patterns feed into the existing warning modal flow: the admin is shown the warning list and can cancel (which removes the uploaded file from the server) or proceed.

### Files changed

| File | Change |
|------|--------|
| `backend/routes/cv.js` | 4 new entries in `patterns` array in `scanForPrivateInfo()` |

## Test plan

- [ ] Upload a PDF containing `07911 123456` → warning modal includes "possible UK mobile number"
- [ ] Upload a PDF containing `+44 1481 256789` → warning modal includes "possible +44 phone number"
- [ ] Upload a PDF containing `01481 256789` (with space) → warning modal includes "possible UK phone number"
- [ ] Upload a PDF containing `01/2024` or `v0.1.2` → no phone number warning triggered (false positive check)
- [ ] Upload a PDF containing `SW1A 1AA` → warning modal includes "possible UK postcode / home address"
- [ ] Upload a PDF containing `GY1 1AA` → warning modal includes "possible UK postcode / home address"
- [ ] Upload a clean CV with no personal data → no warning modal (no false positives)
- [ ] Existing detections (card numbers, NI number, etc.) still trigger correctly
- [ ] Clicking Cancel on warning modal deletes the file from the server and shows "Upload cancelled" message

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_