### PR TITLE
fix(#100): add dev-mode stub for contact form when SMTP not configured

### DIFF
--- a/backend/routes/contact.js
+++ b/backend/routes/contact.js
@@ -40,6 +40,10 @@ async function checkRateLimit(ip) {
   }
 }
 
+function isSmtpConfigured() {
+  return !!(process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS);
+}
+
 function getTransporter() {
   return nodemailer.createTransport({
     host:   process.env.SMTP_HOST,
@@ -65,6 +69,18 @@ router.post('/', validate(ContactSchema), async (req, res) => {
 
   const { name, email, message } = req.body;
   // Field presence and email format are now guaranteed by validate(ContactSchema)
+
+  // Dev stub: when SMTP is not configured, log to console so the form is testable locally
+  if (!isSmtpConfigured()) {
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({ error: 'Email service is not configured on this server.' });
+    }
+    console.log('[DEV] Contact form submission (SMTP not configured — not sent):');
+    console.log(`  Name:    ${name}`);
+    console.log(`  Email:   ${email}`);
+    console.log(`  Message: ${message}`);
+    return res.json({ success: true });
+  }
 
   try {
     await getTransporter().sendMail({

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -231,6 +231,7 @@ Mounts each router against the full Express app via Supertest with the `pg` pool
 |---|---|
 | WebAuthn passkey registration/login | Requires a real browser authenticator; the `@simplewebauthn/server` library call is mocked at the boundary |
 | Email delivery (nodemailer) | Requires real SMTP credentials; nodemailer is mocked — the send path is covered by the contact route tests |
+| Contact form in local dev | When `SMTP_HOST`/`SMTP_USER`/`SMTP_PASS` are not set, the route logs the submission to the backend console and returns `{ success: true }` — no email is sent. This is the expected behaviour in the Docker dev environment; the form UI will appear to succeed. Check the backend container logs (`docker compose logs backend`) to see the submitted values. |
 | Database queries | Integration tests mock the pg pool; real DB behaviour is covered by manual smoke testing against the dev Docker DB |
 | Frontend JavaScript | Out of scope for the backend suite; covered by manual browser testing |
 


### PR DESCRIPTION
## Summary

Investigates and resolves issue #100 — contact form returning a send failure in local dev.

**Root cause confirmed:** the failure is entirely due to missing SMTP env vars in the Docker dev environment. The route code itself is correct. No production bug.

### Changes

**`backend/routes/contact.js`** — adds `isSmtpConfigured()` check before attempting to send:
- **Dev (non-production) with no SMTP:** logs the submission to the backend console and returns `{ success: true }` so the form is fully testable without real credentials
- **Production with no SMTP:** returns a clear `503` with a human-readable message instead of the confusing nodemailer connection error
- **Production with SMTP configured:** unchanged behaviour

**`docs/TESTING.md`** — adds a row to the "What Is Intentionally Not Tested" table documenting the expected local dev contact form behaviour, so it is never mistaken for a bug.

### Files changed

| File | Change |
|------|--------|
| `backend/routes/contact.js` | `isSmtpConfigured()` helper + dev stub + production 503 path |
| `docs/TESTING.md` | Documents expected local dev email behaviour |

## Test plan

- [ ] In local dev (no SMTP env vars): submit the contact form → form shows success, backend container logs show `[DEV] Contact form submission` with name, email, and message
- [ ] In local dev: no email is actually sent (verify via lack of any outbound connection in Docker logs)
- [ ] If `SMTP_HOST`/`SMTP_USER`/`SMTP_PASS` are set in `.env`, form sends normally (existing path unchanged)
- [ ] Simulate production with missing SMTP: set `NODE_ENV=production` and remove SMTP vars → form returns 503 with "Email service is not configured on this server."
- [ ] Magic link / auth email route is unaffected (different route, different transport call)
- [ ] Rate limiting still applies in dev (honeypot and rate limit checks run before the SMTP check)

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_