### PR TITLE
fix(#108/#93/#95): style fixes, date slicing, and missing visit counters

### DIFF
--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -6,6 +6,8 @@ import { validate, CreatePostSchema, UpdatePostSchema } from '../middleware/vali
 
 const router = Router();
 
+// ── Helpers
+
 async function tryInsertPost(post_type, title, body_markdown, post_date, published_at, attempt = 0, maxAttempts = 100) {
   const baseSlug = slugify(title);
   const slug     = attempt === 0 ? baseSlug : `${baseSlug}-${attempt}`;
@@ -33,6 +35,8 @@ async function tryInsertPost(post_type, title, body_markdown, post_date, publish
     throw err;
   }
 }
+
+// ── Routes
 
 // Public: list published blog posts
 router.get('/', async (req, res) => {

--- a/backend/routes/stats.js
+++ b/backend/routes/stats.js
@@ -4,11 +4,13 @@ import { authenticate } from '../middleware/authenticate.js';
 
 const router = Router();
 
-// Increment visit count for a page and return the new total.
-// Public — no auth required. Page names are whitelisted to prevent injection.
+// Page names are whitelisted to prevent arbitrary values being written to the DB
 const ALLOWED_PAGES = new Set(['home', 'blog', 'travel']);
 
-router.post('/visit', async (req, res) => {
+// ── Routes
+
+// Public: increment visit count for a page and return the new total
+router.post('/visit', async (req, res, next) => {
   const page = req.query.page;
   if (!page || !ALLOWED_PAGES.has(page)) {
     return res.status(400).json({ error: 'Invalid page' });
@@ -25,21 +27,19 @@ router.post('/visit', async (req, res) => {
     );
     res.json({ page, count: Number(result.rows[0].count) });
   } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Database error' });
+    next(Object.assign(new Error('Database error'), { status: 500, cause: err }));
   }
 });
 
-// Return all page visit counts — admin only.
-router.get('/visits', authenticate, async (_req, res) => {
+// Admin: return all page visit counts
+router.get('/visits', authenticate, async (_req, res, next) => {
   try {
     const result = await pool.query(
       'SELECT page, count, last_visited_at FROM page_visits ORDER BY count DESC'
     );
     res.json(result.rows.map(r => ({ ...r, count: Number(r.count) })));
   } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Database error' });
+    next(Object.assign(new Error('Database error'), { status: 500, cause: err }));
   }
 });
 

--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -22,9 +22,11 @@ const ALLOWED_MIME = new Set([
   'video/mp4', 'video/webm', 'video/quicktime',
 ]);
 
+const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
+
 const upload = multer({
   storage,
-  limits: { fileSize: 20 * 1024 * 1024 }, // 20 MB
+  limits: { fileSize: MAX_FILE_SIZE },
   fileFilter: (_req, file, cb) => {
     ALLOWED_MIME.has(file.mimetype)
       ? cb(null, true)

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -278,7 +278,8 @@ async function toggleTravelPublish(memory) {
                 title: memory.title,
                 location: memory.location || '',
                 notes: memory.notes || '',
-                visitDate: memory.visit_date || null,
+                // Slice to YYYY-MM-DD — list response returns full ISO timestamp (#93)
+                visitDate: memory.visit_date ? String(memory.visit_date).slice(0, 10) : null,
                 lat: memory.lat,
                 lng: memory.lng,
                 publish: !memory.published_at,
@@ -711,6 +712,8 @@ async function togglePublish(post) {
             body: JSON.stringify({
                 title: post.title,
                 body_markdown: post.body_markdown || '',
+                // Slice to YYYY-MM-DD — list response returns full ISO timestamp (#93)
+                post_date: post.post_date ? String(post.post_date).slice(0, 10) : null,
                 publish: !post.published_at,
             }),
         });
@@ -840,7 +843,7 @@ async function uploadCv(file) {
                 `The scan found potential private information in this PDF:\n\u2022 ${warningList}\n\nDo you still want to publish it?`
             );
             if (!proceed) {
-                // Delete the file we just uploaded so it isn’t accidentally served
+                // Delete the file we just uploaded so it isn't accidentally served
                 await authFetch('/cv', { method: 'DELETE' });
                 setCvMessage('Upload cancelled — CV removed from server.', true);
                 await loadCvStatus();

--- a/resources/java/blog.js
+++ b/resources/java/blog.js
@@ -16,7 +16,7 @@ function buildBlogPostCard(post) {
     });
 }
 
-// ── Blog view toggle ────────────────────────────────────────────────────────────────
+// ── Blog view toggle ──────────────────────────────────────────────────────────────────────────
 function applyBlogView(view) {
     if (view === 'timeline') {
         $('#posts-list').addClass('hidden');
@@ -81,6 +81,9 @@ function loadPosts() {
             $('#posts-list').html('<p class="hint" style="color:var(--color-error)">Could not load posts.</p>');
         });
 }
+
+// Fire-and-forget visit counter — swallow errors so stats never break the page
+fetch(API_BASE + '/stats/visit?page=blog', { method: 'POST' }).catch(function () {});
 
 // Modules are deferred by default — DOM is ready and jQuery is available.
 loadPosts();

--- a/resources/java/travel-post.js
+++ b/resources/java/travel-post.js
@@ -1,6 +1,6 @@
 import { API_BASE } from './config.js';
 
-// ── Lightbox state ────────────────────────────────────────────────────────────
+// ── Lightbox state ──────────────────────────────────────────────────────────────────────────────
 var lightboxItems = [];
 var lightboxIndex = 0;
 
@@ -85,7 +85,7 @@ function initLightbox() {
     });
 }
 
-// ── Page loader ───────────────────────────────────────────────────────────────
+// ── Page loader ─────────────────────────────────────────────────────────────────────────────
 function getId() {
     var params = new URLSearchParams(window.location.search);
     return params.get('id');
@@ -110,7 +110,12 @@ function loadTravelPost() {
             if (!res.ok) throw new Error('not found');
             return res.json();
         })
-        .then(renderTravelPost)
+        .then(function (travel) {
+            renderTravelPost(travel);
+            // Fire-and-forget visit counter — only on a successful post load,
+            // not on 404s or network errors. Swallow errors so stats never break the page.
+            fetch(API_BASE + '/stats/visit?page=travel', { method: 'POST' }).catch(function () {});
+        })
         .catch(function () { showError(); });
 }
 
@@ -175,7 +180,7 @@ function showError() {
     document.getElementById('post-error').classList.remove('hidden');
 }
 
-// Modules are deferred by default — DOM is ready and jQuery/$  is available
+// Modules are deferred by default — DOM is ready and jQuery/$ is available
 // because the jQuery <script> tag runs before this module.
 initLightbox();
 loadTravelPost();

--- a/scripts/deploy/prod-deploy.ps1
+++ b/scripts/deploy/prod-deploy.ps1
@@ -1,4 +1,4 @@
 # Trigger a production deploy from Windows via SSH.
 # Connects to the Pi and runs scripts/deploy/prod-deploy.sh remotely.
-param([string]$Host = 'raspberrypi3.local')
-ssh $Host "bash ~/MyPortfolioSite/scripts/deploy/prod-deploy.sh"
+param([string]$Hostname = 'raspberrypi3')
+ssh $Hostname "bash ~/MyPortfolioSite/scripts/deploy/prod-deploy.sh"

--- a/scripts/dev/dev-local.ps1
+++ b/scripts/dev/dev-local.ps1
@@ -1,24 +1,52 @@
-# Local development helper for andykeys.me (Windows PowerShell wrapper)
-# Delegates all commands to scripts/dev/dev-local.sh via bash.
-#
-# Commands:
-#   up             — build & start all containers; auto-migrates schema
-#   down           — stop containers (DB volume is preserved)
-#   reset          — full teardown including DB volume, then rebuild
-#   logs           — tail backend container logs
-#   db             — open a psql shell into the dev DB
-#   test           — run the automated test suite inside the backend container
-#   test:coverage  — run tests with coverage report
-#
-# Usage: . scripts\dev\dev-local.ps1 <command>
-param([string]$Command = '')
+<#
+.SYNOPSIS
+  Windows wrapper for scripts/dev/dev-local.sh.
+  Passes all arguments through to the bash script via Git Bash.
 
-$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '../..')
-Set-Location $repoRoot
+.DESCRIPTION
+  The `test` and `test:coverage` commands are handled directly via
+  `docker compose exec` to avoid WSL/bash path issues on Windows.
 
-if (-not $Command) {
-    Write-Host "Usage: . scripts\dev\dev-local.ps1 [up|down|reset|logs|db|test|test:coverage]"
-    exit 1
+.EXAMPLE
+  .\scripts\dev\dev-local.ps1 up
+  .\scripts\dev\dev-local.ps1 down
+  .\scripts\dev\dev-local.ps1 reset
+  .\scripts\dev\dev-local.ps1 logs
+  .\scripts\dev\dev-local.ps1 db
+  .\scripts\dev\dev-local.ps1 test
+  .\scripts\dev\dev-local.ps1 test:coverage
+#>
+param(
+  [Parameter(Position = 0)]
+  [string]$Command = 'up'
+)
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+
+switch ($Command) {
+
+  'test' {
+    Write-Host '=== Installing devDependencies inside backend container ===' -ForegroundColor Cyan
+    docker compose --project-directory $RepoRoot exec backend npm install --silent
+    Write-Host '=== Running test suite ===' -ForegroundColor Cyan
+    docker compose --project-directory $RepoRoot exec backend npm test
+  }
+
+  'test:coverage' {
+    Write-Host '=== Installing devDependencies inside backend container ===' -ForegroundColor Cyan
+    docker compose --project-directory $RepoRoot exec backend npm install --silent
+    Write-Host '=== Running tests with coverage ===' -ForegroundColor Cyan
+    docker compose --project-directory $RepoRoot exec backend npm run test:coverage
+  }
+
+  default {
+    # All other commands (up, down, reset, logs, db) delegate to the bash script via Git Bash
+    $BashExe = 'C:\Program Files\Git\bin\bash.exe'
+    if (-not (Test-Path $BashExe)) {
+      Write-Error "Git Bash not found at $BashExe. Install Git for Windows or run dev-local.sh directly in WSL."
+      exit 1
+    }
+    & $BashExe -c "bash '$RepoRoot/scripts/dev/dev-local.sh' $Command"
+  }
+
 }
-
-bash scripts/dev/dev-local.sh $Command

--- a/scripts/tests/Test-PR122.ps1
+++ b/scripts/tests/Test-PR122.ps1
@@ -1,0 +1,182 @@
+#Requires -Version 5.1
+param(
+    [string]$Token      = '',
+    [string]$BaseUrl    = 'http://localhost',
+    [switch]$SkipVitest
+)
+
+# Output capture — console AND timestamped file
+$resultsDir = Join-Path $PSScriptRoot '..' '..' 'test-results'
+if (-not (Test-Path $resultsDir)) {
+    New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+}
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$logFile   = Join-Path $resultsDir "PR122-$timestamp.txt"
+Start-Transcript -Path $logFile -Append | Out-Null
+
+# Auto-generate JWT if not provided
+if (-not $Token) {
+    try {
+        Write-Host "  [INFO] No -Token provided — attempting to generate dev JWT from container..." -ForegroundColor DarkGray
+        $generated = docker compose exec -T backend node -e @"
+const jwt = require('jsonwebtoken');
+if (!process.env.JWT_SECRET) { process.stderr.write('NO_SECRET'); process.exit(1); }
+console.log(jwt.sign({ userId: 'dev-test-user' }, process.env.JWT_SECRET, { expiresIn: '1h' }));
+"@ 2>&1
+        $generated = ($generated | Where-Object { $_ -notmatch '^npm ' } | Select-Object -Last 1).Trim()
+        if ($generated -match '^eyJ') {
+            $Token = $generated
+            Write-Host "  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)" -ForegroundColor DarkGray
+        }
+    } catch {}
+}
+
+$pass = 0; $fail = 0; $skip = 0; $results = @()
+
+function Test-Endpoint {
+    param(
+        [string]$Name,
+        [string]$Method,
+        [string]$Url,
+        [string]$Body       = '',
+        [string[]]$Headers  = @(),
+        [int]$ExpectStatus,
+        [string]$ExpectBody = '',
+        [bool]$RequiresAuth = $false
+    )
+    if ($RequiresAuth -and -not $Token) {
+        Write-Host "  [SKIP] $Name (no token available)" -ForegroundColor DarkYellow
+        $script:skip++
+        $script:results += [PSCustomObject]@{ Result = 'SKIP'; Name = $Name; Detail = 'No token' }
+        return
+    }
+    $curlArgs = @('-s', '-o', 'tmp_body.txt', '-w', '%{http_code}', '-X', $Method)
+    foreach ($h in $Headers) { $curlArgs += @('-H', $h) }
+    if ($Body) { $curlArgs += @('-d', $Body) }
+    $curlArgs += $Url
+    $statusCode = curl.exe @curlArgs
+    $bodyText   = if (Test-Path tmp_body.txt) { Get-Content tmp_body.txt -Raw } else { '' }
+    if (Test-Path tmp_body.txt) { Remove-Item tmp_body.txt -Force }
+    $passed = ([int]$statusCode -eq $ExpectStatus) -and ((-not $ExpectBody) -or ($bodyText -like "*$ExpectBody*"))
+    if ($passed) {
+        Write-Host "  [PASS] $Name" -ForegroundColor Green
+        $script:pass++
+        $script:results += [PSCustomObject]@{ Result = 'PASS'; Name = $Name; Detail = "$statusCode" }
+    } else {
+        $detail = "Expected $ExpectStatus got $statusCode"
+        if ($bodyText -notlike "*$ExpectBody*") { $detail += " | body: $($bodyText.Trim())" }
+        Write-Host "  [FAIL] $Name — $detail" -ForegroundColor Red
+        $script:fail++
+        $script:results += [PSCustomObject]@{ Result = 'FAIL'; Name = $Name; Detail = $detail }
+    }
+}
+
+Write-Host ""
+Write-Host ("═" * 54) -ForegroundColor Cyan
+Write-Host "  PR #122 Test Run — $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Cyan
+Write-Host "  Base URL : $BaseUrl"
+Write-Host "  Token    : $(if ($Token) { 'auto-generated from container' } else { 'not provided — auth tests skipped' })"
+Write-Host "  Log file : $logFile"
+Write-Host ("═" * 54) -ForegroundColor Cyan
+Write-Host ""
+
+# ── Vitest suite
+if (-not $SkipVitest) {
+    Write-Host "--- Vitest unit + integration suite ---" -ForegroundColor Yellow
+    Write-Host "  Running inside backend container..."
+    $vitestExit = 0
+    docker compose exec -T backend npm test 2>&1 | ForEach-Object { Write-Host "  $_" }
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  [PASS] Vitest suite" -ForegroundColor Green
+        $pass++
+    } else {
+        Write-Host "  [FAIL] Vitest suite" -ForegroundColor Red
+        $fail++
+    }
+    Write-Host ""
+}
+
+# ── #108 stats.js: error handling via next(err)
+Write-Host "--- #108 stats.js: error routing through central handler ---" -ForegroundColor Yellow
+
+Test-Endpoint -Name "POST /api/stats/visit?page=home returns { page, count }" `
+    -Method "POST" -Url "$BaseUrl/api/stats/visit?page=home" `
+    -ExpectStatus 200 -ExpectBody "count"
+
+Test-Endpoint -Name "POST /api/stats/visit?page=unknown returns 400 Invalid page" `
+    -Method "POST" -Url "$BaseUrl/api/stats/visit?page=unknown" `
+    -ExpectStatus 400 -ExpectBody "Invalid page"
+
+Test-Endpoint -Name "GET /api/stats/visits with auth returns visit array" `
+    -Method "GET" -Url "$BaseUrl/api/stats/visits" `
+    -Headers @("Authorization: Bearer $Token") `
+    -ExpectStatus 200 -ExpectBody "count" -RequiresAuth $true
+
+Test-Endpoint -Name "GET /api/stats/visits without auth returns 401" `
+    -Method "GET" -Url "$BaseUrl/api/stats/visits" `
+    -ExpectStatus 401
+
+Write-Host ""
+
+# ── #108 upload.js: MAX_FILE_SIZE constant (behaviour unchanged)
+Write-Host "--- #108 upload.js: file upload behaviour unchanged ---" -ForegroundColor Yellow
+
+Test-Endpoint -Name "POST /api/upload without file returns 400" `
+    -Method "POST" -Url "$BaseUrl/api/upload" `
+    -Headers @("Authorization: Bearer $Token") `
+    -ExpectStatus 400 -RequiresAuth $true
+
+Write-Host ""
+
+# ── #108 posts.js: blog CRUD still works (section headers only — no behaviour change)
+Write-Host "--- #108 posts.js: blog CRUD regression ---" -ForegroundColor Yellow
+
+Test-Endpoint -Name "GET /api/posts returns 200" `
+    -Method "GET" -Url "$BaseUrl/api/posts" `
+    -ExpectStatus 200
+
+Test-Endpoint -Name "POST /api/posts with valid body creates post" `
+    -Method "POST" -Url "$BaseUrl/api/posts" `
+    -Headers @("Authorization: Bearer $Token", "Content-Type: application/json") `
+    -Body "{\"title\":\"PR122 test post\",\"body_markdown\":\"test\",\"post_date\":\"$(Get-Date -Format 'yyyy-MM-dd')\",\"post_type\":\"blog\"}" `
+    -ExpectStatus 201 -RequiresAuth $true
+
+Test-Endpoint -Name "POST /api/posts missing title returns 400" `
+    -Method "POST" -Url "$BaseUrl/api/posts" `
+    -Headers @("Authorization: Bearer $Token", "Content-Type: application/json") `
+    -Body '{"body_markdown":"test","post_date":"2026-05-05","post_type":"blog"}' `
+    -ExpectStatus 400 -RequiresAuth $true
+
+Test-Endpoint -Name "POST /api/posts invalid date format returns 400" `
+    -Method "POST" -Url "$BaseUrl/api/posts" `
+    -Headers @("Authorization: Bearer $Token", "Content-Type: application/json") `
+    -Body '{"title":"test","body_markdown":"test","post_date":"not-a-date","post_type":"blog"}' `
+    -ExpectStatus 400 -RequiresAuth $true
+
+Write-Host ""
+
+# ── Regression: error handler
+Write-Host "--- Regression: error handler ---" -ForegroundColor Yellow
+
+Test-Endpoint -Name "Unknown route -> 404" `
+    -Method "GET" -Url "$BaseUrl/api/does-not-exist" `
+    -ExpectStatus 404
+
+Write-Host ""
+Write-Host ("═" * 54) -ForegroundColor Cyan
+Write-Host "  PASSED : $pass" -ForegroundColor Green
+if ($skip -gt 0) { Write-Host "  SKIPPED: $skip" -ForegroundColor DarkYellow }
+Write-Host "  FAILED : $fail" -ForegroundColor $(if ($fail -gt 0) { 'Red' } else { 'Green' })
+Write-Host ("═" * 54) -ForegroundColor Cyan
+Write-Host "  Full log: $logFile" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host "Manual checks (UI — not automated):" -ForegroundColor Yellow
+Write-Host "  [ ] Visit home/blog/travel pages — visit counter increments as expected"
+Write-Host "  [ ] Trigger a forced DB error (e.g. stop DB) — client receives JSON error, NOT a raw pg stack trace"
+Write-Host "  [ ] Upload a file via travel memory form — succeeds as before"
+Write-Host "  [ ] Attempt to upload a file over 20 MB — returns 400 with multer error"
+Write-Host "  [ ] Blog post CRUD (create, edit, delete) — all work correctly"
+Write-Host ""
+
+Stop-Transcript | Out-Null
+if ($fail -gt 0) { exit 1 } else { exit 0 }

--- a/scripts/tests/Test-PR122.ps1
+++ b/scripts/tests/Test-PR122.ps1
@@ -84,7 +84,6 @@ Write-Host ""
 if (-not $SkipVitest) {
     Write-Host "--- Vitest unit + integration suite ---" -ForegroundColor Yellow
     Write-Host "  Running inside backend container..."
-    $vitestExit = 0
     docker compose exec -T backend npm test 2>&1 | ForEach-Object { Write-Host "  $_" }
     if ($LASTEXITCODE -eq 0) {
         Write-Host "  [PASS] Vitest suite" -ForegroundColor Green
@@ -135,22 +134,43 @@ Test-Endpoint -Name "GET /api/posts returns 200" `
     -Method "GET" -Url "$BaseUrl/api/posts" `
     -ExpectStatus 200
 
+# Build JSON body via ConvertTo-Json to avoid PowerShell/curl escaping issues
+$createPostBody = @{
+    title         = 'PR122 test post'
+    body_markdown = 'test'
+    post_date     = (Get-Date -Format 'yyyy-MM-dd')
+    post_type     = 'blog'
+} | ConvertTo-Json -Compress
+
 Test-Endpoint -Name "POST /api/posts with valid body creates post" `
     -Method "POST" -Url "$BaseUrl/api/posts" `
     -Headers @("Authorization: Bearer $Token", "Content-Type: application/json") `
-    -Body "{\"title\":\"PR122 test post\",\"body_markdown\":\"test\",\"post_date\":\"$(Get-Date -Format 'yyyy-MM-dd')\",\"post_type\":\"blog\"}" `
+    -Body $createPostBody `
     -ExpectStatus 201 -RequiresAuth $true
+
+$missingTitleBody = @{
+    body_markdown = 'test'
+    post_date     = '2026-05-05'
+    post_type     = 'blog'
+} | ConvertTo-Json -Compress
 
 Test-Endpoint -Name "POST /api/posts missing title returns 400" `
     -Method "POST" -Url "$BaseUrl/api/posts" `
     -Headers @("Authorization: Bearer $Token", "Content-Type: application/json") `
-    -Body '{"body_markdown":"test","post_date":"2026-05-05","post_type":"blog"}' `
+    -Body $missingTitleBody `
     -ExpectStatus 400 -RequiresAuth $true
+
+$badDateBody = @{
+    title         = 'test'
+    body_markdown = 'test'
+    post_date     = 'not-a-date'
+    post_type     = 'blog'
+} | ConvertTo-Json -Compress
 
 Test-Endpoint -Name "POST /api/posts invalid date format returns 400" `
     -Method "POST" -Url "$BaseUrl/api/posts" `
     -Headers @("Authorization: Bearer $Token", "Content-Type: application/json") `
-    -Body '{"title":"test","body_markdown":"test","post_date":"not-a-date","post_type":"blog"}' `
+    -Body $badDateBody `
     -ExpectStatus 400 -RequiresAuth $true
 
 Write-Host ""

--- a/test-results/PR122-20260505-200716.txt
+++ b/test-results/PR122-20260505-200716.txt
@@ -1,0 +1,91 @@
+**********************
+PowerShell transcript start
+Start time: 20260505200716
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.1.0_x64__8wekyb3d8bbwe\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260505T122808\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-18648-174048.json' -FeatureFlags @() 
+Process ID: 28488
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+══════════════════════════════════════════════════════
+  PR #122 Test Run — 2026-05-05 20:07:17
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR122-20260505-200716.txt
+══════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+
+  > ak-portfolio-backend@1.0.0 test
+  > vitest run
+
+
+   RUN  v2.1.9 /app
+
+   Ô£ô tests/middleware/errorHandler.test.js (7 tests) 6ms
+   Ô£ô tests/middleware/validate.test.js (25 tests) 13ms
+   Ô£ô tests/routes/contact.test.js (3 tests) 29ms
+   Ô£ô tests/routes/travel.test.js (4 tests) 37ms
+   Ô£ô tests/routes/posts.test.js (5 tests) 42ms
+
+   Test Files  5 passed (5)
+        Tests  44 passed (44)
+     Start at  19:07:17
+     Duration  863ms (transform 516ms, setup 0ms, collect 2.19s, tests 128ms, environment 1ms, prepare 343ms)
+
+  [PASS] Vitest suite
+
+--- #108 stats.js: error routing through central handler ---
+  [PASS] POST /api/stats/visit?page=home returns { page, count }
+  [PASS] POST /api/stats/visit?page=unknown returns 400 Invalid page
+  [PASS] GET /api/stats/visits with auth returns visit array
+  [PASS] GET /api/stats/visits without auth returns 401
+
+--- #108 upload.js: file upload behaviour unchanged ---
+  [PASS] POST /api/upload without file returns 400
+
+--- #108 posts.js: blog CRUD regression ---
+  [PASS] GET /api/posts returns 200
+  [PASS] POST /api/posts with valid body creates post
+  [PASS] POST /api/posts missing title returns 400
+  [PASS] POST /api/posts invalid date format returns 400
+
+--- Regression: error handler ---
+  [PASS] Unknown route -> 404
+
+══════════════════════════════════════════════════════
+  PASSED : 11
+  FAILED : 0
+══════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR122-20260505-200716.txt
+
+Manual checks (UI — not automated):
+  [ ] Visit home/blog/travel pages — visit counter increments as expected
+  [ ] Trigger a forced DB error (e.g. stop DB) — client receives JSON error, NOT a raw pg stack trace
+  [ ] Upload a file via travel memory form — succeeds as before
+  [ ] Attempt to upload a file over 20 MB — returns 400 with multer error
+  [ ] Blog post CRUD (create, edit, delete) — all work correctly
+
+**********************
+PowerShell transcript end
+End time: 20260505200719
+**********************

--- a/test-results/PR122-20260505-204219.txt
+++ b/test-results/PR122-20260505-204219.txt
@@ -1,0 +1,91 @@
+**********************
+PowerShell transcript start
+Start time: 20260505204219
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.1.0_x64__8wekyb3d8bbwe\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260505T122808\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-18648-174048.json' -FeatureFlags @() 
+Process ID: 28488
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+══════════════════════════════════════════════════════
+  PR #122 Test Run — 2026-05-05 20:42:19
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR122-20260505-204219.txt
+══════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+
+  > ak-portfolio-backend@1.0.0 test
+  > vitest run
+
+
+   RUN  v2.1.9 /app
+
+   Ô£ô tests/middleware/errorHandler.test.js (7 tests) 5ms
+   Ô£ô tests/middleware/validate.test.js (25 tests) 11ms
+   Ô£ô tests/routes/contact.test.js (3 tests) 28ms
+   Ô£ô tests/routes/travel.test.js (4 tests) 36ms
+   Ô£ô tests/routes/posts.test.js (5 tests) 40ms
+
+   Test Files  5 passed (5)
+        Tests  44 passed (44)
+     Start at  19:42:20
+     Duration  938ms (transform 487ms, setup 0ms, collect 2.25s, tests 121ms, environment 1ms, prepare 344ms)
+
+  [PASS] Vitest suite
+
+--- #108 stats.js: error routing through central handler ---
+  [PASS] POST /api/stats/visit?page=home returns { page, count }
+  [PASS] POST /api/stats/visit?page=unknown returns 400 Invalid page
+  [PASS] GET /api/stats/visits with auth returns visit array
+  [PASS] GET /api/stats/visits without auth returns 401
+
+--- #108 upload.js: file upload behaviour unchanged ---
+  [PASS] POST /api/upload without file returns 400
+
+--- #108 posts.js: blog CRUD regression ---
+  [PASS] GET /api/posts returns 200
+  [PASS] POST /api/posts with valid body creates post
+  [PASS] POST /api/posts missing title returns 400
+  [PASS] POST /api/posts invalid date format returns 400
+
+--- Regression: error handler ---
+  [PASS] Unknown route -> 404
+
+══════════════════════════════════════════════════════
+  PASSED : 11
+  FAILED : 0
+══════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\PR122-20260505-204219.txt
+
+Manual checks (UI — not automated):
+  [ ] Visit home/blog/travel pages — visit counter increments as expected
+  [ ] Trigger a forced DB error (e.g. stop DB) — client receives JSON error, NOT a raw pg stack trace
+  [ ] Upload a file via travel memory form — succeeds as before
+  [ ] Attempt to upload a file over 20 MB — returns 400 with multer error
+  [ ] Blog post CRUD (create, edit, delete) — all work correctly
+
+**********************
+PowerShell transcript end
+End time: 20260505204221
+**********************


### PR DESCRIPTION
## Summary

Combines the original #108 style audit fixes with four bug fixes surfaced during the same audit pass.

---

### Style fixes (#108)

| File | Fix |
|------|-----|
| `backend/routes/posts.js` | Added `// ── Helpers` and `// ── Routes` section headers |
| `backend/routes/upload.js` | Extracted `20 * 1024 * 1024` magic number into `MAX_FILE_SIZE` constant |
| `backend/routes/stats.js` | Added `// ── Routes` section header; converted inline `res.status(500)` responses to `next(err)` per style guide |

### Bug fixes

| File | Fix | Issue |
|------|-----|-------|
| `resources/java/admin.js` | `toggleTravelPublish` — slice `memory.visit_date` to `YYYY-MM-DD` before sending as `visitDate`; full ISO timestamps were being passed straight to the backend, which Postgres rejected silently | #93 |
| `resources/java/admin.js` | `togglePublish` (blog) — `post_date` was missing from the PUT body entirely, causing the backend to receive `post_date=undefined → null` and silently clear the date on every publish/unpublish toggle | #93 |
| `resources/java/blog.js` | Add missing `POST /stats/visit?page=blog` call on page load — fire-and-forget, errors swallowed so stats never break the page | #108 |
| `resources/java/travel-post.js` | Add missing `POST /stats/visit?page=travel` call after a successful post load only (not on 404s or network errors) — same fire-and-forget pattern | #108 |

### What was intentionally left out

- **posts.js inline DB errors (7 occurrences)** — the same `next(err)` conversion as stats.js, but across 7 route handlers. Left for a follow-up PR to keep this diff reviewable.
- **errorHandler.js JSDoc format** — minor, cosmetic, no functional impact.
- **contact.js inline 500** — touched separately in PR #121 (issue #100).

---

## Test plan

- [ ] Run full test suite (`docker compose exec backend npm test`) — all tests pass
- [ ] `POST /api/stats/visit?page=home` — returns `{ page, count }` as before
- [ ] `POST /api/stats/visit?page=blog` — counter increments (was broken before this PR)
- [ ] `POST /api/stats/visit?page=travel` — counter increments on successful travel post load (was broken before this PR)
- [ ] `POST /api/stats/visit?page=unknown` — returns 400 `{ error: 'Invalid page' }`
- [ ] `GET /api/stats/visits` with valid JWT — returns visit array including blog and travel rows
- [ ] `GET /api/stats/visits` without JWT — returns 401
- [ ] Upload a file via the travel memory form — succeeds as before
- [ ] Attempting to upload a file over 20 MB — returns 400 with multer error message
- [ ] Blog post CRUD — create, publish, unpublish, update, delete all work; `post_date` is preserved on publish/unpublish toggle
- [ ] Travel memory CRUD — create, publish, unpublish, update, delete all work; `visit_date` is preserved on publish/unpublish toggle