### PR TITLE
chore(tests): add Test-Regression.ps1 baseline script (#130)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,10 +42,10 @@ Closes #<!-- issue number -->
 
 ## Smoke Test
 
-<!-- PRs that touch backend code must include a smoke test script.
-     Create scripts/tests/Test-PR<N>.ps1 and run it before requesting review.
-     See docs/TESTING.md for the template and instructions. -->
+<!-- PRs that touch backend code must run both scripts before requesting review.
+     See docs/TESTING.md for full instructions. -->
 
+- [ ] `scripts/tests/Test-Regression.ps1` run and passing
 - [ ] `scripts/tests/Test-PR<!-- N -->.ps1` created and passing
 - [ ] N/A — no backend changes in this PR
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -55,12 +55,14 @@ Pipe any command through `Tee-Object` to write output to a timestamped file **an
 
 ### PR validation scripts — use `Start-Transcript` (built in)
 
-All `scripts/tests/Test-PR*.ps1` scripts use `Start-Transcript` internally, so output is captured automatically — no extra flags needed. Token generation is also automatic:
+All scripts in `scripts/tests/` use `Start-Transcript` internally, so output is captured automatically — no extra flags needed. Token generation is also automatic:
 
 ```powershell
-# Output goes to console AND test-results\PR104-<timestamp>.txt automatically
-# JWT is auto-generated from the container — no -Token flag required
-.\scripts\tests\Test-PR104.ps1
+# Output goes to console AND test-results\Regression-<timestamp>.txt automatically
+.\scripts\tests\Test-Regression.ps1
+
+# Output goes to console AND test-results\PR<N>-<timestamp>.txt automatically
+.\scripts\tests\Test-PR<N>.ps1
 ```
 
 The log file path is printed in the script header and footer so you always know where to find it.
@@ -75,20 +77,36 @@ New-Item -ItemType Directory -Force -Path test-results
 
 ---
 
-## PR Smoke Test Scripts
+## PR Smoke Tests — Two-Tier Process
 
-Every PR that touches backend code must include a `scripts/tests/Test-PR<N>.ps1` script (where N is the PR number). The PR template's **Smoke Test** section (`.github/pull_request_template.md`) requires this to be ticked before requesting review.
+Every PR that touches backend code requires **two scripts** to be run before requesting review:
 
-- Run after `dev-local.ps1 up`: `.\scripts\tests\Test-PRN.ps1`
-- Scripts use `docker compose exec` directly — no bash or WSL dependency
-- Output is captured automatically via `Start-Transcript` — no extra flags needed
+```powershell
+# Step 1 — always run the regression baseline first
+. scripts\tests\Test-Regression.ps1
 
-### Script template
+# Step 2 — run the PR-specific tests on top
+. scripts\tests\Test-PR<N>.ps1
+```
+
+Both must pass. The regression script ensures that existing stable behaviour has not regressed. The PR-specific script covers the new or changed endpoints introduced by the PR.
+
+The PR template's **Smoke Test** section requires both to be ticked before requesting review.
+
+### What each script covers
+
+| Script | Purpose |
+|---|---|
+| `Test-Regression.ps1` | Stable always-run baseline: Vitest suite, core public endpoints, key auth checks, 404 handler |
+| `Test-PR<N>.ps1` | Endpoints and behaviour introduced or changed by PR #N only |
+
+### Script template — Test-PR\<N\>.ps1
 
 When creating a `Test-PR<N>.ps1` script for a new PR, place it in `scripts/tests/` and use this as the starting point. The key requirements are:
 1. **`Start-Transcript` / `Stop-Transcript`** — output always captured without the caller needing flags
 2. **Auto-generate JWT** from the container — no hardcoded secrets, no manual token passing
 3. **`$PSScriptRoot '../..' 'test-results'`** path — resolves correctly from `scripts/tests/`
+4. **All POST bodies** use `@{} | ConvertTo-Json -Compress` — avoids PowerShell/curl escaping failures on Windows
 
 ```powershell
 #Requires -Version 5.1
@@ -161,21 +179,22 @@ function Test-Endpoint {
 }
 
 Write-Host ""
-Write-Host "═" * 54 -ForegroundColor Cyan
+Write-Host ("═" * 54) -ForegroundColor Cyan
 Write-Host "  PR #<N> Test Run — $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Cyan
 Write-Host "  Base URL : $BaseUrl"
 Write-Host "  Token    : $(if ($Token) { 'auto-generated from container' } else { 'not available (auth tests skipped)' })"
 Write-Host "  Log file : $logFile"
-Write-Host "═" * 54 -ForegroundColor Cyan
+Write-Host ("═" * 54) -ForegroundColor Cyan
 
-# --- add Test-Endpoint calls here ---
+# --- add Test-Endpoint calls here (new/changed endpoints for this PR only) ---
+# Do NOT duplicate checks already covered by Test-Regression.ps1
 
 Write-Host ""
-Write-Host "═" * 54 -ForegroundColor Cyan
+Write-Host ("═" * 54) -ForegroundColor Cyan
 Write-Host "  PASSED : $pass" -ForegroundColor Green
 if ($skip -gt 0) { Write-Host "  SKIPPED: $skip" -ForegroundColor DarkYellow }
 Write-Host "  FAILED : $fail" -ForegroundColor $(if ($fail -gt 0) { 'Red' } else { 'Green' })
-Write-Host "═" * 54 -ForegroundColor Cyan
+Write-Host ("═" * 54) -ForegroundColor Cyan
 Write-Host "  Full log: $logFile" -ForegroundColor DarkGray
 Write-Host ""
 

--- a/scripts/tests/Test-Regression.ps1
+++ b/scripts/tests/Test-Regression.ps1
@@ -1,0 +1,217 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Baseline regression test suite — run on every PR that touches backend code.
+
+.DESCRIPTION
+    Covers the stable, always-run checks extracted from the PR-specific test
+    scripts. Run this first, then run the PR-specific Test-PR<N>.ps1 on top.
+
+.PARAMETER Token
+    JWT bearer token. If omitted, the script auto-generates one from the
+    running backend container using the container's JWT_SECRET.
+
+.PARAMETER BaseUrl
+    Base URL of the running dev server. Defaults to http://localhost.
+
+.PARAMETER SkipVitest
+    Skip the Vitest unit/integration suite (useful for quick smoke runs).
+
+.EXAMPLE
+    # Standard run — Vitest + all regression checks
+    . scripts\tests\Test-Regression.ps1
+
+    # Skip Vitest (faster)
+    . scripts\tests\Test-Regression.ps1 -SkipVitest
+#>
+param(
+    [string]$Token      = '',
+    [string]$BaseUrl    = 'http://localhost',
+    [switch]$SkipVitest
+)
+
+# ── Output capture — console AND timestamped file ─────────────────────────────
+$resultsDir = Join-Path $PSScriptRoot '..' '..' 'test-results'
+if (-not (Test-Path $resultsDir)) {
+    New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+}
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$logFile   = Join-Path $resultsDir "Regression-$timestamp.txt"
+Start-Transcript -Path $logFile -Append | Out-Null
+
+# ── Auto-generate JWT if not provided ────────────────────────────────────────
+if (-not $Token) {
+    try {
+        Write-Host "  [INFO] No -Token provided — attempting to generate dev JWT from container..." -ForegroundColor DarkGray
+        $generated = docker compose exec -T backend node -e @"
+const jwt = require('jsonwebtoken');
+if (!process.env.JWT_SECRET) { process.stderr.write('NO_SECRET'); process.exit(1); }
+console.log(jwt.sign({ userId: 'dev-test-user' }, process.env.JWT_SECRET, { expiresIn: '1h' }));
+"@ 2>&1
+        $generated = ($generated | Where-Object { $_ -notmatch '^npm ' } | Select-Object -Last 1).Trim()
+        if ($generated -match '^eyJ') {
+            $Token = $generated
+            Write-Host "  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)" -ForegroundColor DarkGray
+        }
+    } catch {}
+}
+
+$pass = 0; $fail = 0; $skip = 0; $results = @()
+
+# ── Test-Endpoint helper ──────────────────────────────────────────────────────
+function Test-Endpoint {
+    param(
+        [string]$Name,
+        [string]$Method,
+        [string]$Url,
+        [string]$Body       = '',
+        [string[]]$Headers  = @(),
+        [int]$ExpectStatus,
+        [string]$ExpectBody = '',
+        [bool]$RequiresAuth = $false
+    )
+    if ($RequiresAuth -and -not $Token) {
+        Write-Host "  [SKIP] $Name (no token available)" -ForegroundColor DarkYellow
+        $script:skip++
+        $script:results += [PSCustomObject]@{ Result = 'SKIP'; Name = $Name; Detail = 'No token' }
+        return
+    }
+    $curlArgs = @('-s', '-o', 'tmp_body.txt', '-w', '%{http_code}', '-X', $Method)
+    foreach ($h in $Headers) { $curlArgs += @('-H', $h) }
+    if ($Body) { $curlArgs += @('-d', $Body) }
+    $curlArgs += $Url
+    $statusCode = curl.exe @curlArgs
+    $bodyText   = if (Test-Path tmp_body.txt) { Get-Content tmp_body.txt -Raw } else { '' }
+    if (Test-Path tmp_body.txt) { Remove-Item tmp_body.txt -Force }
+    $passed = ([int]$statusCode -eq $ExpectStatus) -and ((-not $ExpectBody) -or ($bodyText -like "*$ExpectBody*"))
+    if ($passed) {
+        Write-Host "  [PASS] $Name" -ForegroundColor Green
+        $script:pass++
+        $script:results += [PSCustomObject]@{ Result = 'PASS'; Name = $Name; Detail = "$statusCode" }
+    } else {
+        $detail = "Expected $ExpectStatus got $statusCode"
+        if ($bodyText -notlike "*$ExpectBody*") { $detail += " | body: $($bodyText.Trim())" }
+        Write-Host "  [FAIL] $Name — $detail" -ForegroundColor Red
+        $script:fail++
+        $script:results += [PSCustomObject]@{ Result = 'FAIL'; Name = $Name; Detail = $detail }
+    }
+}
+
+# ── Header ────────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host ("═" * 60) -ForegroundColor Cyan
+Write-Host "  Regression Test Run — $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Cyan
+Write-Host "  Base URL : $BaseUrl"
+Write-Host "  Token    : $(if ($Token) { 'auto-generated from container' } else { 'not provided — auth tests skipped' })"
+Write-Host "  Log file : $logFile"
+Write-Host ("═" * 60) -ForegroundColor Cyan
+Write-Host ""
+
+# ── Vitest unit + integration suite ──────────────────────────────────────────
+if (-not $SkipVitest) {
+    Write-Host "--- Vitest unit + integration suite ---" -ForegroundColor Yellow
+    Write-Host "  Running inside backend container..."
+    docker compose exec -T backend npm test 2>&1 | ForEach-Object { Write-Host "  $_" }
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  [PASS] Vitest suite" -ForegroundColor Green
+        $pass++
+    } else {
+        Write-Host "  [FAIL] Vitest suite" -ForegroundColor Red
+        $fail++
+    }
+    Write-Host ""
+}
+
+# ── No-auth baseline checks ───────────────────────────────────────────────────
+Write-Host "--- No-auth baseline ---" -ForegroundColor Yellow
+
+Test-Endpoint -Name "GET /api/posts returns 200" `
+    -Method "GET" -Url "$BaseUrl/api/posts" `
+    -ExpectStatus 200
+
+$missingNameBody = @{ email = 'test@example.com'; message = 'hello' } | ConvertTo-Json -Compress
+Test-Endpoint -Name "POST /api/contact missing name returns 400" `
+    -Method "POST" -Url "$BaseUrl/api/contact" `
+    -Headers @('Content-Type: application/json') `
+    -Body $missingNameBody `
+    -ExpectStatus 400
+
+$invalidEmailBody = @{ name = 'Test'; email = 'not-an-email'; message = 'hello' } | ConvertTo-Json -Compress
+Test-Endpoint -Name "POST /api/contact invalid email returns 400" `
+    -Method "POST" -Url "$BaseUrl/api/contact" `
+    -Headers @('Content-Type: application/json') `
+    -Body $invalidEmailBody `
+    -ExpectStatus 400
+
+Test-Endpoint -Name "GET /api/cv/exists returns 200 with 'exists' field" `
+    -Method "GET" -Url "$BaseUrl/api/cv/exists" `
+    -ExpectStatus 200 -ExpectBody "exists"
+
+Test-Endpoint -Name "POST /api/stats/visit?page=unknown returns 400" `
+    -Method "POST" -Url "$BaseUrl/api/stats/visit?page=unknown" `
+    -ExpectStatus 400
+
+Test-Endpoint -Name "Unknown route returns 404" `
+    -Method "GET" -Url "$BaseUrl/api/does-not-exist" `
+    -ExpectStatus 404
+
+Write-Host ""
+
+# ── Auth-required baseline checks ────────────────────────────────────────────
+Write-Host "--- Auth-required baseline ---" -ForegroundColor Yellow
+
+$missingTitleBody = @{
+    body_markdown = 'test'
+    post_date     = '2026-01-01'
+    post_type     = 'blog'
+} | ConvertTo-Json -Compress
+Test-Endpoint -Name "POST /api/posts missing title returns 400" `
+    -Method "POST" -Url "$BaseUrl/api/posts" `
+    -Headers @("Authorization: Bearer $Token", 'Content-Type: application/json') `
+    -Body $missingTitleBody `
+    -ExpectStatus 400 -RequiresAuth $true
+
+$badDateBody = @{
+    title         = 'test'
+    body_markdown = 'test'
+    post_date     = 'not-a-date'
+    post_type     = 'blog'
+} | ConvertTo-Json -Compress
+Test-Endpoint -Name "POST /api/posts invalid date format returns 400" `
+    -Method "POST" -Url "$BaseUrl/api/posts" `
+    -Headers @("Authorization: Bearer $Token", 'Content-Type: application/json') `
+    -Body $badDateBody `
+    -ExpectStatus 400 -RequiresAuth $true
+
+$missingTravelTitleBody = @{
+    location = 'Test'
+    visit_date = '2026-01-01'
+} | ConvertTo-Json -Compress
+Test-Endpoint -Name "POST /api/travel missing title returns 400" `
+    -Method "POST" -Url "$BaseUrl/api/travel" `
+    -Headers @("Authorization: Bearer $Token", 'Content-Type: application/json') `
+    -Body $missingTravelTitleBody `
+    -ExpectStatus 400 -RequiresAuth $true
+
+Test-Endpoint -Name "GET /api/stats/visits with auth returns 200" `
+    -Method "GET" -Url "$BaseUrl/api/stats/visits" `
+    -Headers @("Authorization: Bearer $Token") `
+    -ExpectStatus 200 -ExpectBody "count" -RequiresAuth $true
+
+Test-Endpoint -Name "GET /api/stats/visits without auth returns 401" `
+    -Method "GET" -Url "$BaseUrl/api/stats/visits" `
+    -ExpectStatus 401
+
+Write-Host ""
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+Write-Host ("═" * 60) -ForegroundColor Cyan
+Write-Host "  PASSED : $pass" -ForegroundColor Green
+if ($skip -gt 0) { Write-Host "  SKIPPED: $skip" -ForegroundColor DarkYellow }
+Write-Host "  FAILED : $fail" -ForegroundColor $(if ($fail -gt 0) { 'Red' } else { 'Green' })
+Write-Host ("═" * 60) -ForegroundColor Cyan
+Write-Host "  Full log: $logFile" -ForegroundColor DarkGray
+Write-Host ""
+
+Stop-Transcript | Out-Null
+if ($fail -gt 0) { exit 1 } else { exit 0 }

--- a/test-results/Regression-20260505-223521.txt
+++ b/test-results/Regression-20260505-223521.txt
@@ -1,0 +1,81 @@
+**********************
+PowerShell transcript start
+Start time: 20260505223521
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.1.0_x64__8wekyb3d8bbwe\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260505T122808\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-18648-174048.json' -FeatureFlags @() 
+Process ID: 28488
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+════════════════════════════════════════════════════════════
+  Regression Test Run — 2026-05-05 22:35:21
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\Regression-20260505-223521.txt
+════════════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+
+  > ak-portfolio-backend@1.0.0 test
+  > vitest run
+
+
+   RUN  v2.1.9 /app
+
+   Ô£ô tests/middleware/errorHandler.test.js (7 tests) 5ms
+   Ô£ô tests/middleware/validate.test.js (25 tests) 12ms
+   Ô£ô tests/routes/travel.test.js (4 tests) 31ms
+   Ô£ô tests/routes/contact.test.js (3 tests) 35ms
+   Ô£ô tests/routes/posts.test.js (5 tests) 39ms
+
+   Test Files  5 passed (5)
+        Tests  44 passed (44)
+     Start at  21:35:22
+     Duration  903ms (transform 534ms, setup 0ms, collect 2.29s, tests 122ms, environment 1ms, prepare 377ms)
+
+  [PASS] Vitest suite
+
+--- No-auth baseline ---
+  [PASS] GET /api/posts returns 200
+  [PASS] POST /api/contact missing name returns 400
+  [PASS] POST /api/contact invalid email returns 400
+  [PASS] GET /api/cv/exists returns 200 with 'exists' field
+  [PASS] POST /api/stats/visit?page=unknown returns 400
+  [PASS] Unknown route returns 404
+
+--- Auth-required baseline ---
+  [PASS] POST /api/posts missing title returns 400
+  [PASS] POST /api/posts invalid date format returns 400
+  [PASS] POST /api/travel missing title returns 400
+  [PASS] GET /api/stats/visits with auth returns 200
+  [PASS] GET /api/stats/visits without auth returns 401
+
+════════════════════════════════════════════════════════════
+  PASSED : 12
+  FAILED : 0
+════════════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\Regression-20260505-223521.txt
+
+**********************
+PowerShell transcript end
+End time: 20260505223524
+**********************


### PR DESCRIPTION
## Summary

Completes the final outstanding task from #130 — creates the regression baseline test script and updates the testing documentation and PR template to reference the new two-tier smoke test process.

Closes #130

## Changes

- `scripts/tests/Test-Regression.ps1` — new baseline script covering all stable always-run checks
- `docs/TESTING.md` — new "PR Smoke Tests — Two-Tier Process" section replacing the old single-script section; script template comment updated to note regression checks should not be duplicated in PR scripts
- `.github/pull_request_template.md` — Smoke Test checklist updated to require both `Test-Regression.ps1` and `Test-PR<N>.ps1`

## Test Plan

### Happy path

1. Start dev environment: `. scripts\dev\dev-local.ps1 up`
2. Run `. scripts\tests\Test-Regression.ps1` — all checks pass, log written to `test-results\Regression-<timestamp>.txt`
3. Run with `-SkipVitest` flag — Vitest block skipped, HTTP checks still run

### Edge cases

- [ ] Run without a container running — script exits cleanly with FAIL on each endpoint
- [ ] Run with no JWT_SECRET in container — auth tests show `[SKIP]` rather than erroring

### Regression checks

- [ ] Existing `Test-PR*.ps1` scripts unaffected
- [ ] `docs/TESTING.md` renders correctly in GitHub

### Setup required before testing

- None

## Smoke Test

- [ ] `scripts/tests/Test-Regression.ps1` run and passing
- [ ] N/A — this PR introduces the regression script itself

## Documentation

- [ ] `docs/CHANGELOG.md` updated with a entry under `[Unreleased]`
- [x] `docs/TESTING.md` updated with two-tier run instructions

## Notes for Reviewer

The regression script is a direct extraction of the stable baseline checks that were previously duplicated across the PR-specific scripts. No new test logic — only consolidation.
