### PR TITLE
hotfix: restore missing deployment section in admin.html

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -184,6 +184,34 @@
                 </div>
             </div>
 
+            <!-- ── Deployment (#98 / #117 / #129) ───────────────────────────────── -->
+            <div class="admin-card" id="deploy-section">
+                <h2 class="admin-card-title">Deployment</h2>
+                <div id="deploy-status-row" class="deploy-status-row">
+                    <span class="hint">Loading…</span>
+                </div>
+                <div class="form-actions" style="margin-top:1rem">
+                    <button type="button" id="fetch-btn" class="btn-secondary" disabled>Fetch</button>
+                    <button type="button" id="deploy-btn" class="btn-primary" disabled>Deploy latest</button>
+                    <button type="button" id="rollback-btn" class="btn-secondary" disabled>Rollback…</button>
+                </div>
+                <div id="rollback-picker" class="hidden" style="margin-top:0.75rem">
+                    <label>Roll back to
+                        <select id="rollback-sha-select"></select>
+                    </label>
+                    <div class="form-actions" style="margin-top:0.5rem">
+                        <button type="button" id="rollback-confirm-btn" class="travel-delete-btn">Confirm rollback</button>
+                        <button type="button" id="rollback-cancel-btn" class="btn-secondary">Cancel</button>
+                    </div>
+                </div>
+                <pre id="deploy-output" class="deploy-output hidden"></pre>
+                <p id="deploy-message" class="admin-message"></p>
+                <div id="deploy-log-section" style="margin-top:1.5rem">
+                    <h3 style="font-size:0.9rem;color:var(--color-text-muted);margin-bottom:0.5rem">Deploy history</h3>
+                    <div id="deploy-log-list"><p class="hint">Loading…</p></div>
+                </div>
+            </div>
+
             <!-- ── Passkeys ─────────────────────────────────────────────────────── -->
             <div class="admin-card">
                 <h2 class="admin-card-title">Manage passkeys</h2>


### PR DESCRIPTION
## Summary

Restores the deployment card HTML that was accidentally dropped from `admin.html` during conflict resolution in PR #139.

### Root cause

The `initDeploySection()` function in `admin.js` was correctly included in the release, but the corresponding DOM — `#deploy-section`, `#fetch-btn`, `#deploy-btn`, `#rollback-btn`, `#rollback-picker`, `#deploy-output`, `#deploy-message`, `#deploy-log-list` — was lost during merge conflict resolution. The JS had nothing to bind to, so the panel silently never rendered.

### Fix

Single change — restores the deployment `<div class="admin-card" id="deploy-section">` block to `admin.html`, between the Site Visits card and the Passkeys card, matching `dev` exactly.

### Verification

- `admin.html` on this branch is now byte-for-byte identical to `dev`
- No other files changed
- No backend changes — `Test-Regression.ps1` not required

## Smoke Test

- [x] N/A — no backend changes in this PR

## Documentation

- [x] N/A — no doc changes needed

## Notes for Reviewer

One file, one missing block restored. Safe to merge immediately.