### PR TITLE
fix(#137): add .btn-danger variant; apply to delete buttons

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -158,7 +158,7 @@
                 </p>
                 <div class="form-actions">
                     <button type="button" id="cv-upload-btn" class="btn-primary" disabled>Upload CV</button>
-                    <button type="button" id="cv-delete-btn" class="travel-delete-btn" disabled>Delete CV</button>
+                    <button type="button" id="cv-delete-btn" class="btn-small btn-danger" disabled>Delete CV</button>
                 </div>
                 <p id="cv-message" class="admin-message"></p>
             </div>
@@ -200,7 +200,7 @@
                         <select id="rollback-sha-select"></select>
                     </label>
                     <div class="form-actions" style="margin-top:0.5rem">
-                        <button type="button" id="rollback-confirm-btn" class="travel-delete-btn">Confirm rollback</button>
+                        <button type="button" id="rollback-confirm-btn" class="btn-small btn-danger">Confirm rollback</button>
                         <button type="button" id="rollback-cancel-btn" class="btn-secondary">Cancel</button>
                     </div>
                 </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 
 ## [Unreleased] — on `dev`, not yet in production
 
+### Fixed
+- Delete button size/shape inconsistency — add `.btn-danger` variant to button system; `.travel-delete-btn` now composes from it, removing `!important` overrides (#137)
+
 ### Added
 - Travel post detail page (`travel-post.html`) with media gallery, Leaflet map, and lightbox (#78)
 - Public `GET /api/travel/:id` route for individual travel memories (#78)

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -1691,10 +1691,6 @@ footer {
     color: var(--color-text-muted);
 }
 
-.travel-delete-btn {
-    flex-shrink: 0;
-}
-
 /* ── Blog (Issue #7) ──────────────────────────────────────────────────────── */
 
 .posts-list {

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -1692,15 +1692,6 @@ footer {
 }
 
 .travel-delete-btn {
-    background: var(--color-error) !important;
-    color: white !important;
-    border: none;
-    padding: 0.35rem 0.85rem;
-    border-radius: 4px;
-    font-size: 0.85rem;
-    cursor: pointer;
-    height: auto;
-    width: auto;
     flex-shrink: 0;
 }
 
@@ -1954,6 +1945,20 @@ footer {
 }
 
 .btn-small:hover { opacity: 0.85; }
+
+.btn-danger {
+    background: var(--color-error);
+    color: #fff;
+    border: none;
+    padding: 0.35rem 0.85rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    height: auto;
+    width: auto;
+}
+
+.btn-danger:hover { opacity: 0.85; }
 
 /* ── Travel map (Issue #8) ───────────────────────────────────────────────────── */
 
@@ -2262,7 +2267,7 @@ footer {
     }
 
     .post-admin-actions .btn-small,
-    .post-admin-actions .travel-delete-btn {
+    .post-admin-actions .btn-danger {
         flex: 1;
         min-height: 38px;
         padding: 0.5rem;

--- a/resources/java/admin.js
+++ b/resources/java/admin.js
@@ -208,7 +208,7 @@ function buildSavedMemoryRow(memory) {
     const toggleBtn = $('<button type="button" class="btn-small">' + (memory.published_at ? 'Unpublish' : 'Publish') + '</button>');
     toggleBtn.on('click', () => toggleTravelPublish(memory));
 
-    const delBtn = $('<button type="button" class="travel-delete-btn">Delete</button>');
+    const delBtn = $('<button type="button" class="btn-small btn-danger">Delete</button>');
     delBtn.on('click', () => deleteTravelMemory(memory.id));
 
     actions.append(editBtn).append(toggleBtn).append(delBtn);
@@ -665,7 +665,7 @@ function buildPostAdminRow(post) {
     const toggleBtn = $('<button type="button" class="btn-small">' + (post.published_at ? 'Unpublish' : 'Publish') + '</button>');
     toggleBtn.on('click', () => togglePublish(post));
 
-    const delBtn = $('<button type="button" class="travel-delete-btn">Delete</button>');
+    const delBtn = $('<button type="button" class="btn-small btn-danger">Delete</button>');
     delBtn.on('click', () => deletePost(post.id));
 
     actions.append(editBtn).append(toggleBtn).append(delBtn);


### PR DESCRIPTION
## Summary

Closes #137

- Adds `.btn-danger` CSS class to the button variant block in `styles.css` — geometry matches `.btn-small`, colour uses `--color-error` with white text
- Replaces ad-hoc `.travel-delete-btn` colour overrides (with `!important`) with `class="btn-small btn-danger"` on both delete buttons in `admin.js`
- `.travel-delete-btn` rule reduced to `flex-shrink: 0` (layout only); mobile media query updated to target `.btn-danger` instead

## Test plan

- [ ] Run `Test-Regression.ps1` — no regressions
- [ ] Admin travel panel: delete buttons render with red background, consistent size with other small action buttons
- [ ] Admin blog panel: delete buttons same appearance
- [ ] Confirm no `!important` overrides in computed styles for delete buttons
- [ ] Mobile viewport: delete button does not overflow its container

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_