### PR TITLE
refactor(#133): extract travel listing logic into travel.js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,319 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+---
+
+## Quick Orientation (2 minutes)
+
+**What is this?** A personal portfolio site at andykeys.me — blog, travel posts, admin console for managing content, and AI lab experiments. Hosted on a Raspberry Pi (moving to Ubuntu Server gaming PC).
+
+**Tech stack:**
+- Frontend: vanilla JS/HTML/CSS (no build step), jQuery for legacy compatibility
+- Backend: Node.js/Express (ES modules), WebAuthn + JWT auth
+- Database: PostgreSQL
+- Web server: Nginx (reverse proxy + static files)
+- Dev: Docker Compose (backend + postgres + nginx all containerised)
+- AI pair programmer: Claude Sonnet via Anthropic API
+
+**Key files:**
+- `backend/server.js` — Express app entry point, middleware, route registration
+- `backend/routes/` — API endpoints (auth, posts, travel, deploy, etc.)
+- `backend/db/schema.sql` — PostgreSQL schema (idempotent, uses IF NOT EXISTS)
+- `resources/java/` — frontend ES modules (one per feature: script.js, blog.js, travel.js, admin.js, etc.)
+- `docs/AI.md` — your working instructions (scope, commits, documentation, code style)
+- `docker-compose.yml` — local dev setup; prod uses same file with .env.prod overrides
+
+---
+
+## Before You Start
+
+1. **Read the onboarding docs in this order:**
+   - README.md — architecture, local setup, branching, deployment
+   - docs/AI.md — working instructions, scope discipline, commit conventions
+   - docs/STYLE_GUIDE.md — naming, code patterns, button variants
+   - docs/TESTING.md — test suite, how to run, PR smoke tests
+   - docs/DATABASE.md — schema reference
+   - docs/SECURITY.md — auth model, JWT, threat model
+   - docs/DEPENDENCIES.md — dependency rules
+
+2. **Project orientation:**
+   - Branching: `main` (prod) ← `dev` (integration) ← `feature/issue-N-*` (your work)
+   - Code style: ES modules on frontend, parameterised queries always, imperative commit messages
+   - No build step — frontend is vanilla JS with imports; Nginx serves directly
+   - All tests run in Docker: `docker compose exec backend npm test` or use dev-local.ps1
+
+3. **Current state:** See `PROJECT_ASSESSMENT.md` and `ROADMAP.md` for what's working, what's fragile, and what's planned.
+
+---
+
+## Common Commands
+
+### Local Development (Docker — Recommended)
+
+```powershell
+# Start all services (backend, postgres, nginx)
+. scripts\dev\dev-local.ps1 up
+
+# Run tests
+. scripts\dev\dev-local.ps1 test
+
+# Stop services (DB persists)
+. scripts\dev\dev-local.ps1 down
+
+# Full reset (wipes local DB)
+. scripts\dev\dev-local.ps1 reset
+
+# View backend logs
+. scripts\dev\dev-local.ps1 logs
+
+# Open psql shell into dev DB
+. scripts\dev\dev-local.ps1 db
+
+# Run tests with coverage
+. scripts\dev\dev-local.ps1 test:coverage
+```
+
+### Testing
+
+```bash
+# Inside the running backend container:
+npm test                          # Full suite
+npm test -- tests/routes/posts    # Single file
+npm test -- --reporter=verbose    # Verbose output
+
+# From Windows (runs inside container):
+. scripts\dev\dev-local.ps1 test
+
+# Smoke tests for a PR:
+.\scripts\tests\Test-Regression.ps1
+.\scripts\tests\Test-PR148.ps1     # Example for PR #148
+```
+
+### Git Workflow
+
+```bash
+# Start new work
+git checkout dev
+git pull origin dev
+git checkout -b fix/issue-N-short-description
+
+# Commit (follow style: imperative, short summary, Co-Authored-By footer)
+git add <files>
+git commit -m "fix: correct nginx template path
+
+The volume mount in docker-compose.yml pointed to a non-existent path.
+Files moved to scripts/config/ in #130 but compose file wasn't updated.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
+# Push and create PR
+git push -u origin fix/issue-N-short-description
+gh pr create --base dev --title "Title" --body "Description. Closes #N"
+
+# After review, merge to dev (user does this, not you)
+# User will then create a release PR: dev → main for deploy
+```
+
+### Deployment (From Windows)
+
+```powershell
+# (Not for agents — user triggers this, we just ensure code is ready)
+.\scripts\deploy\prod-deploy.ps1
+```
+
+---
+
+## Architecture & Key Concepts
+
+### Frontend Architecture
+
+No build step. HTML pages load ES modules directly via `<script type="module">`.
+
+**Frontend JS structure:**
+- `resources/java/config.js` — exports `API_BASE` (empty string for same-origin, auto-detects localhost in dev)
+- `resources/java/script.js` — homepage only: GitHub widget, contact form, home visit counter
+- `resources/java/blog.js` — blog listing page
+- `resources/java/travel.js` — travel listing page (map, cards, timeline, lightbox)
+- `resources/java/admin.js` — admin panel (18KB, monolithic, highest-risk file to modify)
+- `resources/java/utils/` — shared utilities (escapeHtml, formatVisitDate, buildTimelineItem, etc.)
+
+**Key pattern:** jQuery used only for legacy compatibility (DOM queries, $.ajax for API calls). New code uses vanilla DOM APIs and fetch.
+
+**Shared utilities are intentional tech debt paydown** — they exist because earlier sessions paid down this debt. Reuse them.
+
+### Backend Architecture
+
+Express app in `backend/server.js`. Routes are well-separated by concern.
+
+**Key routes:**
+- `backend/routes/auth.js` (12KB) — WebAuthn registration/auth, JWT issuance, email magic links, passkey verification. Highest-risk route to modify.
+- `backend/routes/posts.js` — blog and travel CRUD
+- `backend/routes/travel.js` — travel listing + detail
+- `backend/routes/deploy.js` — deployment triggers (gated by auth), rollback, status
+- `backend/routes/upload.js` — CV + photo upload with validation
+- `backend/routes/contact.js` — contact form with nodemailer
+
+**Middleware:**
+- `backend/middleware/errorHandler.js` — catches and formats errors
+- `backend/middleware/validate.js` — schema validation for request bodies
+- JWT auth check: routes check for valid JWT before running
+
+**Database:**
+- `schema.sql` is idempotent (IF NOT EXISTS throughout) — safe to re-run
+- Tables: users, passkeys, email_tokens, posts (blog and travel unified), uploads, audit_log (coming), stats
+- No migration tool yet — uses raw SQL applied at boot
+
+### Request Flow
+
+1. **Public page load** → Nginx serves static HTML/CSS/JS → Browser runs ES module
+2. **API call (public)** → Browser fetch → Nginx reverse-proxies `/api/*` to backend (port 8080 in docker-compose)
+3. **API call (auth)** → Browser includes JWT in Authorization header → Backend validates JWT → Route executes
+
+### Auth Model
+
+- **Signup:** User visits `/setup.html` → creates account → registers FIDO2 passkey via WebAuthn
+- **Login:** User visits `/login.html` → chooses passkey or email magic link → WebAuthn ceremony or email click → JWT issued
+- **Protected routes:** Check `Authorization: Bearer <JWT>` header; JWT contains user ID + issued-at timestamp
+
+**JWT structure:**
+- Signed with `JWT_SECRET` (backend only)
+- 7-day expiry (configurable)
+- Contains userId
+- Verified on every protected route
+
+**Email magic links:**
+- User requests link at `/api/auth/email/send`
+- Backend generates random token, stores bcrypt hash in email_tokens table
+- Email contains `/login.html?token=<raw-token>`
+- On click: verify via `crypt(raw, stored_hash) = stored_hash` (constant-time comparison)
+- Sets JWT, marks token as used
+
+### Admin Panel
+
+Single HTML file (`admin.html`) with inline JS (`admin.js`). Handles:
+- Blog post CRUD
+- Travel memory CRUD
+- CV upload + file browser
+- Deployment console (show status, trigger deploy, rollback)
+- Stats (visit counts, error counts)
+
+**Highest-risk file to touch.** Modifying it risks breaking multiple features. Read the full file before making changes. Test thoroughly.
+
+---
+
+## Common Patterns & Conventions
+
+### Code style
+
+**Naming:**
+- Camel case for JS variables and functions
+- Kebab case for HTML IDs, CSS classes
+- Underscore case for database columns (post_date, user_id, etc.)
+
+**Button variants (CSS):**
+- `.btn-primary` — large blue (0.8rem padding, 1.5rem horizontal)
+- `.btn-secondary` — large outlined (same padding, transparent bg, border)
+- `.btn-small` — compact dark (0.35rem padding, 0.85rem horizontal)
+- `.btn-danger` — red modifier (use with size class: `class="btn-small btn-danger"`)
+
+**Section headers (JS comments):**
+```js
+// ── Section name (two em-dashes, space, label, NO trailing fill)
+function doSomething() { ... }
+```
+
+**Database:** Always parameterised queries. Never string concatenation.
+```js
+// Good
+const result = await pool.query('SELECT * FROM posts WHERE id = $1', [postId]);
+// Never
+const result = await pool.query(`SELECT * FROM posts WHERE id = ${postId}`);
+```
+
+### Testing
+
+**Vitest suite:**
+- `tests/` folder mirrors `backend/` structure
+- Tests for middleware, validators, route handlers
+- Run via `npm test` inside the backend container
+- Coverage tracked; aim for routes and middleware, not 100% everywhere
+
+**Smoke tests (per-PR):**
+- `scripts/tests/Test-Regression.ps1` — baseline (all basic flows)
+- `scripts/tests/Test-PRNNN.ps1` — specific PR tests (created as needed)
+- Run on your machine to verify no regressions before merging
+
+### Documentation
+
+**When to write docs:**
+- Adding a new database table → update `docs/DATABASE.md`
+- Changing auth → update `docs/SECURITY.md`
+- Adding a dependency → update `docs/DEPENDENCIES.md`
+- New feature in deployment → update README or `docs/INFRASTRUCTURE.md` (coming)
+
+**When NOT to add docs:**
+- Generic "what this function does" — good naming is better than comments
+- Obvious code patterns
+- Implementation details that don't affect future work
+
+**Commit messages:**
+- Imperative present tense: "fix", "add", "refactor", not "fixed", "added", "refactored"
+- Short summary (50 chars), blank line, optional explanation
+- Always include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` footer
+
+---
+
+## High-Risk Areas
+
+| File | Why | Mitigation |
+|------|-----|-----------|
+| `admin.html` (18KB) | Monolithic, handles blog + travel + CV + deploy; one mistake breaks multiple features | Read full file before edits; test admin flows thoroughly |
+| `backend/routes/auth.js` (12KB) | WebAuthn state machine is complex; JWT + magic links state must be correct | High test coverage; read full file; don't eyeball auth logic |
+| `resources/java/admin.js` | Mirrors admin.html complexity; form logic for multiple post types | Test CRUD flows for blog + travel; check date field handling |
+| `docker-compose.yml` | Volume mounts, env vars, networking — errors break the entire dev environment | Test `docker compose up/down/reset` after changes |
+| `backend/db/schema.sql` | Idempotent, no migration tool — altering existing columns requires careful planning | Always use IF NOT EXISTS / IF NOT; test schema changes on a clean DB |
+
+---
+
+## Fragile / Incomplete Areas (from PROJECT_ASSESSMENT.md)
+
+- **No backups:** Database and uploads have no automated backup. (#164)
+- **No structured logging:** `console.log` used throughout; no severity levels or request context. (#152)
+- **Admin.html monolithic:** 18KB single file; refactoring needed. (No issue yet; low priority)
+- **No schema migration tool:** schema.sql is idempotent but has no version tracking. (#169)
+- **PM2 in prod, Docker in dev:** Structural difference; moving prod to Docker is next big task. (#165)
+
+---
+
+## What's Not Here (But Is Documented Elsewhere)
+
+- **Full test suite guide** → `docs/TESTING.md`
+- **Database schema** → `docs/DATABASE.md`
+- **Auth deep-dive** → `docs/SECURITY.md`
+- **Naming & code patterns** → `docs/STYLE_GUIDE.md`
+- **Branching rules** → README.md
+- **Dependency rules** → `docs/DEPENDENCIES.md`
+- **AI working instructions** → `docs/AI.md` (scope discipline, commit hygiene, workflow)
+
+---
+
+## Questions to Clarify Before Starting
+
+- **Branching:** Are you working from `dev`? (Always. Only hotfix/* branches from main.)
+- **Scope:** Is this a small bug fix, a feature, or refactoring? (Affects test strategy and commit style.)
+- **Downtime:** Is some downtime acceptable? (For hobby project, yes. Affects deployment approach.)
+- **Data:** Is any existing data being migrated, or is this a fresh setup? (Affects schema/backup concerns.)
+
+---
+
+## TL;DR — Just Starting Work?
+
+1. Pull latest `dev`: `git fetch origin dev && git checkout dev && git pull`
+2. Create branch: `git checkout -b fix/issue-N-short-desc`
+3. Start Docker: `. scripts\dev\dev-local.ps1 up`
+4. Make changes, test: `. scripts\dev\dev-local.ps1 test`
+5. Commit: `git commit -m "imperative summary" && git add Co-Authored-By line`
+6. Push and PR: `git push -u origin fix/issue-N-...` then `gh pr create --base dev`
+
+Ask if anything is unclear.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -96,6 +96,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Blog and travel post detail pages unified with consistent `.post-meta` date styling
 - Travel post section order changed to: map → gallery → notes
 - All cross-references in docs updated to new `docs/` paths (#130)
+- Extract travel listing logic from `script.js` into dedicated `travel.js` (#133); fixes travel page visit counter not firing
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -99,6 +99,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Blog and travel post detail pages unified with consistent `.post-meta` date styling
 - Travel post section order changed to: map → gallery → notes
 - All cross-references in docs updated to new `docs/` paths (#130)
+- Extract travel listing logic from `script.js` into dedicated `travel.js` (#133); fixes travel page visit counter not firing
 
 ---
 

--- a/resources/java/script.js
+++ b/resources/java/script.js
@@ -1,8 +1,6 @@
 import { API_BASE } from './config.js';
 import { isAdminSession } from './auth-utils.js';
-import { escapeHtml } from './utils/html.js';
-import { formatVisitDate, formatRelativeDate } from './utils/date.js';
-import { buildTimelineItem, buildPostCard, buildPublicTravelCard, buildRepoCard } from './utils/dom.js';
+import { buildRepoCard } from './utils/dom.js';
 
 // duration of scroll animation
 var scrollDuration = 300;
@@ -76,226 +74,7 @@ function setHeight(div, height) {
     div.style.height = height + 'px';
 }
 
-// ── Travel map (Leaflet) ─────────────────────────────────────────────────────────────
-
-var travelMap = null;
-
-function buildPopupHtml(memory) {
-    var mediaUrl = memory.media_url || memory.mediaUrl;
-    var mediaType = memory.media_type || memory.mediaType;
-    var thumb = '';
-    if (mediaUrl && mediaType && mediaType.indexOf('image') === 0) {
-        thumb = '<img class="popup-thumb" src="' + escapeHtml(mediaUrl) + '" alt="">';
-    }
-    return (
-        '<div class="popup-content">' +
-        thumb +
-        '<strong>' + escapeHtml(memory.title) + '</strong>' +
-        (memory.location ? '<div class="popup-location">' + escapeHtml(memory.location) + '</div>' : '') +
-        '</div>'
-    );
-}
-
-function initTravelMap(memories) {
-    if (typeof L === 'undefined') return;
-    var mapEl = document.getElementById('travel-map');
-    if (!mapEl) return;
-
-    var withCoords = memories.filter(function (m) {
-        return m.lat !== null && m.lng !== null && m.lat !== undefined && m.lng !== undefined;
-    });
-
-    if (!withCoords.length) {
-        mapEl.classList.add('hidden');
-        $('.travel-view-toggle').addClass('hidden');
-        return;
-    }
-
-    travelMap = L.map('travel-map', { scrollWheelZoom: false }).setView([20, 0], 2);
-
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        maxZoom: 18,
-        attribution: '\u00a9 <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-    }).addTo(travelMap);
-
-    var markers = [];
-    withCoords.forEach(function (m) {
-        var lat = parseFloat(m.lat);
-        var lng = parseFloat(m.lng);
-        if (Number.isNaN(lat) || Number.isNaN(lng)) return;
-        var marker = L.marker([lat, lng]).addTo(travelMap).bindPopup(buildPopupHtml(m));
-        markers.push(marker);
-    });
-
-    if (markers.length === 1) {
-        travelMap.setView(markers[0].getLatLng(), 6);
-    } else if (markers.length > 1) {
-        var group = L.featureGroup(markers);
-        travelMap.fitBounds(group.getBounds().pad(0.2));
-    }
-}
-
-function applyTravelView(view) {
-    var mapEl = $('#travel-map');
-    var grid = $('#travel-grid');
-    var timeline = $('#travel-timeline');
-
-    mapEl.addClass('hidden');
-    grid.addClass('hidden');
-    timeline.addClass('hidden');
-
-    if (view === 'map-timeline') {
-        mapEl.removeClass('hidden');
-        timeline.removeClass('hidden');
-    } else if (view === 'both') {
-        mapEl.removeClass('hidden');
-        grid.removeClass('hidden');
-    } else if (view === 'map') {
-        mapEl.removeClass('hidden');
-    } else if (view === 'cards') {
-        grid.removeClass('hidden');
-    } else if (view === 'timeline') {
-        timeline.removeClass('hidden');
-    }
-
-    if (travelMap && (view === 'map-timeline' || view === 'map' || view === 'both')) {
-        setTimeout(function () { travelMap.invalidateSize(); }, 50);
-    }
-}
-
-function initViewToggle() {
-    var activeView = $('.travel-view-toggle .view-toggle-btn.active').data('view') || 'map-timeline';
-    applyTravelView(activeView);
-
-    $('.travel-view-toggle .view-toggle-btn').on('click', function () {
-        var view = $(this).data('view');
-        $('.travel-view-toggle .view-toggle-btn').removeClass('active').attr('aria-selected', 'false');
-        $(this).addClass('active').attr('aria-selected', 'true');
-        applyTravelView(view);
-    });
-}
-
-// ── Gallery lightbox ─────────────────────────────────────────────────────────────
-
-var lightboxItems = [];
-var lightboxIndex = 0;
-
-function openLightbox(items, startIndex, title) {
-    lightboxItems = items;
-    lightboxIndex = startIndex || 0;
-    $('#travel-lightbox .lightbox-title').text(title || '');
-    renderLightboxItem();
-    $('#travel-lightbox').removeClass('hidden');
-    document.body.style.overflow = 'hidden';
-}
-
-function closeLightbox() {
-    $('#travel-lightbox').addClass('hidden');
-    document.body.style.overflow = '';
-    $('#travel-lightbox video').each(function () { this.pause(); });
-}
-
-function renderLightboxItem() {
-    var item = lightboxItems[lightboxIndex];
-    var mediaEl;
-    if (item.type && item.type.indexOf('video') === 0) {
-        mediaEl = $('<video controls playsinline></video>').attr('src', item.url);
-    } else {
-        mediaEl = $('<img alt="Gallery image">').attr('src', item.url);
-    }
-    $('#travel-lightbox .lightbox-media').empty().append(mediaEl);
-    $('#travel-lightbox .lightbox-counter').text((lightboxIndex + 1) + ' / ' + lightboxItems.length);
-    $('#travel-lightbox .lightbox-prev').toggleClass('hidden', lightboxIndex === 0);
-    $('#travel-lightbox .lightbox-next').toggleClass('hidden', lightboxIndex === lightboxItems.length - 1);
-}
-
-function initLightbox() {
-    var lightbox = document.getElementById('travel-lightbox');
-    if (!lightbox) return;
-
-    var closeBtn = lightbox.querySelector('.lightbox-close');
-    var prevBtn = lightbox.querySelector('.lightbox-prev');
-    var nextBtn = lightbox.querySelector('.lightbox-next');
-
-    if (closeBtn) closeBtn.addEventListener('click', function (e) { e.preventDefault(); e.stopPropagation(); closeLightbox(); });
-    if (prevBtn) prevBtn.addEventListener('click', function (e) { e.preventDefault(); e.stopPropagation(); if (lightboxIndex > 0) { lightboxIndex--; renderLightboxItem(); } });
-    if (nextBtn) nextBtn.addEventListener('click', function (e) { e.preventDefault(); e.stopPropagation(); if (lightboxIndex < lightboxItems.length - 1) { lightboxIndex++; renderLightboxItem(); } });
-
-    lightbox.addEventListener('click', function (e) { if (e.target === lightbox) closeLightbox(); });
-
-    document.addEventListener('keydown', function (e) {
-        if (lightbox.classList.contains('hidden')) return;
-        if (e.key === 'Escape') { e.preventDefault(); closeLightbox(); }
-        else if (e.key === 'ArrowLeft' && lightboxIndex > 0) { e.preventDefault(); lightboxIndex--; renderLightboxItem(); }
-        else if (e.key === 'ArrowRight' && lightboxIndex < lightboxItems.length - 1) { e.preventDefault(); lightboxIndex++; renderLightboxItem(); }
-    });
-}
-
-// ── Travel cards ────────────────────────────────────────────────────────────────────
-
-function loadPublicTravelPosts() {
-    var travelGrid = $('#travel-grid');
-    if (!travelGrid.length) return;
-
-    fetch(API_BASE + '/travel')
-        .then(function (res) {
-            if (!res.ok) throw new Error('Failed to load');
-            return res.json();
-        })
-        .then(function (memories) {
-            if (!memories.length) {
-                $('#travel-empty').removeClass('hidden');
-                $('#travel-map').addClass('hidden');
-                $('.travel-view-toggle').addClass('hidden');
-                return;
-            }
-
-            memories.forEach(function (travel) {
-                travelGrid.append(buildPublicTravelCard(travel, formatVisitDate));
-            });
-
-            var sorted = memories.slice().sort(function (a, b) {
-                var da = a.visit_date ? String(a.visit_date).slice(0, 10) : '';
-                var db = b.visit_date ? String(b.visit_date).slice(0, 10) : '';
-                return db < da ? -1 : db > da ? 1 : 0;
-            });
-            var timelineEl = $('#travel-timeline');
-            sorted.forEach(function (travel) {
-                var allMedia = Array.isArray(travel.media) && travel.media.length ? travel.media : null;
-                var firstMedia = allMedia ? allMedia[0] : null;
-                var mediaUrl = (firstMedia && firstMedia.url) || travel.media_url || travel.mediaUrl;
-                var mediaType = (firstMedia && firstMedia.type) || travel.media_type || travel.mediaType;
-
-                var item = buildTimelineItem({
-                    dateStr: formatVisitDate(travel.visit_date),
-                    title: travel.title,
-                    location: travel.location,
-                    notes: travel.notes,
-                    mediaUrl: mediaUrl,
-                    mediaType: mediaType,
-                    mediaCount: allMedia ? allMedia.length : 0,
-                    linkHref: 'travel-post.html?id=' + encodeURIComponent(travel.id),
-                });
-
-                item.find('.media-thumb-wrap').css('cursor', 'pointer').on('click', function () {
-                    window.location.href = 'travel-post.html?id=' + encodeURIComponent(travel.id);
-                });
-
-                timelineEl.append(item);
-            });
-
-            // All containers must be populated before initViewToggle wires the buttons.
-            initTravelMap(memories);
-            initViewToggle();
-        })
-        .catch(function () {
-            $('#travel-empty').removeClass('hidden');
-            $('#travel-map').addClass('hidden');
-            $('.travel-view-toggle').addClass('hidden');
-        });
-}
-
-// ── GitHub activity widget ─────────────────────────────────────────────────────────
+// ── GitHub activity widget
 
 function loadGithubWidget() {
     var container = $('#github-repos');
@@ -319,7 +98,7 @@ function loadGithubWidget() {
         });
 }
 
-// ── Contact form ────────────────────────────────────────────────────────────────────
+// ── Contact form
 
 function initContactForm() {
     var form = document.getElementById('contact-form');
@@ -331,7 +110,7 @@ function initContactForm() {
         var submitBtn = form.querySelector('button[type="submit"]');
 
         submitBtn.disabled = true;
-        msgEl.textContent = 'Sending\u2026';
+        msgEl.textContent = 'Sending…';
         msgEl.className = 'contact-form-message';
 
         var payload = {
@@ -349,7 +128,7 @@ function initContactForm() {
             .then(function (res) { return res.json().then(function (d) { return { ok: res.ok, data: d }; }); })
             .then(function (result) {
                 if (result.ok) {
-                    msgEl.textContent = 'Message sent \u2014 I\'ll be in touch soon.';
+                    msgEl.textContent = 'Message sent — I\'ll be in touch soon.';
                     msgEl.className = 'contact-form-message success';
                     form.reset();
                 } else {
@@ -365,7 +144,7 @@ function initContactForm() {
     });
 }
 
-// ── Visit counter ────────────────────────────────────────────────────────────────────
+// ── Visit counter
 
 function recordVisit(page) {
     if (isAdminSession()) return;
@@ -385,12 +164,10 @@ function recordVisit(page) {
         .catch(function () {});
 }
 
-// ── Bootstrap ────────────────────────────────────────────────────────────────────────────
+// ── Bootstrap
 
 // Modules are deferred by default — DOM is ready when this executes.
 // jQuery (<script> before this module) and Leaflet (if present) are already loaded.
-if (document.getElementById('travel-lightbox')) initLightbox();
-loadPublicTravelPosts();
 loadGithubWidget();
 initContactForm();
 recordVisit('home');

--- a/resources/java/travel.js
+++ b/resources/java/travel.js
@@ -1,0 +1,228 @@
+import { API_BASE } from './config.js';
+import { escapeHtml } from './utils/html.js';
+import { formatVisitDate } from './utils/date.js';
+import { buildTimelineItem, buildPublicTravelCard } from './utils/dom.js';
+
+// ── Travel map (Leaflet)
+
+var travelMap = null;
+
+function buildPopupHtml(memory) {
+    var mediaUrl = memory.media_url || memory.mediaUrl;
+    var mediaType = memory.media_type || memory.mediaType;
+    var thumb = '';
+    if (mediaUrl && mediaType && mediaType.indexOf('image') === 0) {
+        thumb = '<img class="popup-thumb" src="' + escapeHtml(mediaUrl) + '" alt="">';
+    }
+    return (
+        '<div class="popup-content">' +
+        thumb +
+        '<strong>' + escapeHtml(memory.title) + '</strong>' +
+        (memory.location ? '<div class="popup-location">' + escapeHtml(memory.location) + '</div>' : '') +
+        '</div>'
+    );
+}
+
+function initTravelMap(memories) {
+    if (typeof L === 'undefined') return;
+    var mapEl = document.getElementById('travel-map');
+    if (!mapEl) return;
+
+    var withCoords = memories.filter(function (m) {
+        return m.lat !== null && m.lng !== null && m.lat !== undefined && m.lng !== undefined;
+    });
+
+    if (!withCoords.length) {
+        mapEl.classList.add('hidden');
+        $('.travel-view-toggle').addClass('hidden');
+        return;
+    }
+
+    travelMap = L.map('travel-map', { scrollWheelZoom: false }).setView([20, 0], 2);
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 18,
+        attribution: '\u00a9 <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    }).addTo(travelMap);
+
+    var markers = [];
+    withCoords.forEach(function (m) {
+        var lat = parseFloat(m.lat);
+        var lng = parseFloat(m.lng);
+        if (Number.isNaN(lat) || Number.isNaN(lng)) return;
+        var marker = L.marker([lat, lng]).addTo(travelMap).bindPopup(buildPopupHtml(m));
+        markers.push(marker);
+    });
+
+    if (markers.length === 1) {
+        travelMap.setView(markers[0].getLatLng(), 6);
+    } else if (markers.length > 1) {
+        var group = L.featureGroup(markers);
+        travelMap.fitBounds(group.getBounds().pad(0.2));
+    }
+}
+
+function applyTravelView(view) {
+    var mapEl = $('#travel-map');
+    var grid = $('#travel-grid');
+    var timeline = $('#travel-timeline');
+
+    mapEl.addClass('hidden');
+    grid.addClass('hidden');
+    timeline.addClass('hidden');
+
+    if (view === 'map-timeline') {
+        mapEl.removeClass('hidden');
+        timeline.removeClass('hidden');
+    } else if (view === 'both') {
+        mapEl.removeClass('hidden');
+        grid.removeClass('hidden');
+    } else if (view === 'map') {
+        mapEl.removeClass('hidden');
+    } else if (view === 'cards') {
+        grid.removeClass('hidden');
+    } else if (view === 'timeline') {
+        timeline.removeClass('hidden');
+    }
+
+    if (travelMap && (view === 'map-timeline' || view === 'map' || view === 'both')) {
+        setTimeout(function () { travelMap.invalidateSize(); }, 50);
+    }
+}
+
+function initViewToggle() {
+    var activeView = $('.travel-view-toggle .view-toggle-btn.active').data('view') || 'map-timeline';
+    applyTravelView(activeView);
+
+    $('.travel-view-toggle .view-toggle-btn').on('click', function () {
+        var view = $(this).data('view');
+        $('.travel-view-toggle .view-toggle-btn').removeClass('active').attr('aria-selected', 'false');
+        $(this).addClass('active').attr('aria-selected', 'true');
+        applyTravelView(view);
+    });
+}
+
+// ── Gallery lightbox
+
+var lightboxItems = [];
+var lightboxIndex = 0;
+
+function openLightbox(items, startIndex, title) {
+    lightboxItems = items;
+    lightboxIndex = startIndex || 0;
+    $('#travel-lightbox .lightbox-title').text(title || '');
+    renderLightboxItem();
+    $('#travel-lightbox').removeClass('hidden');
+    document.body.style.overflow = 'hidden';
+}
+
+function closeLightbox() {
+    $('#travel-lightbox').addClass('hidden');
+    document.body.style.overflow = '';
+    $('#travel-lightbox video').each(function () { this.pause(); });
+}
+
+function renderLightboxItem() {
+    var item = lightboxItems[lightboxIndex];
+    var mediaEl;
+    if (item.type && item.type.indexOf('video') === 0) {
+        mediaEl = $('<video controls playsinline></video>').attr('src', item.url);
+    } else {
+        mediaEl = $('<img alt="Gallery image">').attr('src', item.url);
+    }
+    $('#travel-lightbox .lightbox-media').empty().append(mediaEl);
+    $('#travel-lightbox .lightbox-counter').text((lightboxIndex + 1) + ' / ' + lightboxItems.length);
+    $('#travel-lightbox .lightbox-prev').toggleClass('hidden', lightboxIndex === 0);
+    $('#travel-lightbox .lightbox-next').toggleClass('hidden', lightboxIndex === lightboxItems.length - 1);
+}
+
+function initLightbox() {
+    var lightbox = document.getElementById('travel-lightbox');
+    if (!lightbox) return;
+
+    var closeBtn = lightbox.querySelector('.lightbox-close');
+    var prevBtn = lightbox.querySelector('.lightbox-prev');
+    var nextBtn = lightbox.querySelector('.lightbox-next');
+
+    if (closeBtn) closeBtn.addEventListener('click', function (e) { e.preventDefault(); e.stopPropagation(); closeLightbox(); });
+    if (prevBtn) prevBtn.addEventListener('click', function (e) { e.preventDefault(); e.stopPropagation(); if (lightboxIndex > 0) { lightboxIndex--; renderLightboxItem(); } });
+    if (nextBtn) nextBtn.addEventListener('click', function (e) { e.preventDefault(); e.stopPropagation(); if (lightboxIndex < lightboxItems.length - 1) { lightboxIndex++; renderLightboxItem(); } });
+
+    lightbox.addEventListener('click', function (e) { if (e.target === lightbox) closeLightbox(); });
+
+    document.addEventListener('keydown', function (e) {
+        if (lightbox.classList.contains('hidden')) return;
+        if (e.key === 'Escape') { e.preventDefault(); closeLightbox(); }
+        else if (e.key === 'ArrowLeft' && lightboxIndex > 0) { e.preventDefault(); lightboxIndex--; renderLightboxItem(); }
+        else if (e.key === 'ArrowRight' && lightboxIndex < lightboxItems.length - 1) { e.preventDefault(); lightboxIndex++; renderLightboxItem(); }
+    });
+}
+
+// ── Travel cards
+
+function loadPublicTravelPosts() {
+    var travelGrid = $('#travel-grid');
+    if (!travelGrid.length) return;
+
+    fetch(API_BASE + '/travel')
+        .then(function (res) {
+            if (!res.ok) throw new Error('Failed to load');
+            return res.json();
+        })
+        .then(function (memories) {
+            if (!memories.length) {
+                $('#travel-empty').removeClass('hidden');
+                $('#travel-map').addClass('hidden');
+                $('.travel-view-toggle').addClass('hidden');
+                return;
+            }
+
+            memories.forEach(function (travel) {
+                travelGrid.append(buildPublicTravelCard(travel, formatVisitDate));
+            });
+
+            var sorted = memories.slice().sort(function (a, b) {
+                var da = a.visit_date ? String(a.visit_date).slice(0, 10) : '';
+                var db = b.visit_date ? String(b.visit_date).slice(0, 10) : '';
+                return db < da ? -1 : db > da ? 1 : 0;
+            });
+            var timelineEl = $('#travel-timeline');
+            sorted.forEach(function (travel) {
+                var allMedia = Array.isArray(travel.media) && travel.media.length ? travel.media : null;
+                var firstMedia = allMedia ? allMedia[0] : null;
+                var mediaUrl = (firstMedia && firstMedia.url) || travel.media_url || travel.mediaUrl;
+                var mediaType = (firstMedia && firstMedia.type) || travel.media_type || travel.mediaType;
+
+                var item = buildTimelineItem({
+                    dateStr: formatVisitDate(travel.visit_date),
+                    title: travel.title,
+                    location: travel.location,
+                    notes: travel.notes,
+                    mediaUrl: mediaUrl,
+                    mediaType: mediaType,
+                    mediaCount: allMedia ? allMedia.length : 0,
+                    linkHref: 'travel-post.html?id=' + encodeURIComponent(travel.id),
+                });
+
+                item.find('.media-thumb-wrap').css('cursor', 'pointer').on('click', function () {
+                    window.location.href = 'travel-post.html?id=' + encodeURIComponent(travel.id);
+                });
+
+                timelineEl.append(item);
+            });
+
+            // All containers must be populated before initViewToggle wires the buttons.
+            initTravelMap(memories);
+            initViewToggle();
+        })
+        .catch(function () {
+            $('#travel-empty').removeClass('hidden');
+            $('#travel-map').addClass('hidden');
+            $('.travel-view-toggle').addClass('hidden');
+        });
+}
+
+// ── Bootstrap
+fetch(API_BASE + '/stats/visit?page=travel', { method: 'POST' }).catch(function () {});
+loadPublicTravelPosts();
+initLightbox();

--- a/test-results/Regression-20260507-085333.txt
+++ b/test-results/Regression-20260507-085333.txt
@@ -1,0 +1,81 @@
+**********************
+PowerShell transcript start
+Start time: 20260507085333
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\PowerShell\7\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260507T085145\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-31768-919692.json' -FeatureFlags @() 
+Process ID: 10640
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+════════════════════════════════════════════════════════════
+  Regression Test Run — 2026-05-07 08:53:34
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\Regression-20260507-085333.txt
+════════════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+
+  > ak-portfolio-backend@1.0.0 test
+  > vitest run
+
+
+   RUN  v2.1.9 /app
+
+   Ô£ô tests/middleware/errorHandler.test.js (7 tests) 4ms
+   Ô£ô tests/middleware/validate.test.js (25 tests) 12ms
+   Ô£ô tests/routes/contact.test.js (3 tests) 33ms
+   Ô£ô tests/routes/travel.test.js (4 tests) 30ms
+   Ô£ô tests/routes/posts.test.js (5 tests) 35ms
+
+   Test Files  5 passed (5)
+        Tests  44 passed (44)
+     Start at  07:53:34
+     Duration  921ms (transform 562ms, setup 0ms, collect 2.27s, tests 115ms, environment 1ms, prepare 345ms)
+
+  [PASS] Vitest suite
+
+--- No-auth baseline ---
+  [PASS] GET /api/posts returns 200
+  [PASS] POST /api/contact missing name returns 400
+  [PASS] POST /api/contact invalid email returns 400
+  [PASS] GET /api/cv/exists returns 200 with 'exists' field
+  [PASS] POST /api/stats/visit?page=unknown returns 400
+  [PASS] Unknown route returns 404
+
+--- Auth-required baseline ---
+  [PASS] POST /api/posts missing title returns 400
+  [PASS] POST /api/posts invalid date format returns 400
+  [PASS] POST /api/travel missing title returns 400
+  [PASS] GET /api/stats/visits with auth returns 200
+  [PASS] GET /api/stats/visits without auth returns 401
+
+════════════════════════════════════════════════════════════
+  PASSED : 12
+  FAILED : 0
+════════════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\Regression-20260507-085333.txt
+
+**********************
+PowerShell transcript end
+End time: 20260507085336
+**********************

--- a/test-results/Regression-20260507-124825.txt
+++ b/test-results/Regression-20260507-124825.txt
@@ -1,0 +1,81 @@
+**********************
+PowerShell transcript start
+Start time: 20260507124825
+Username: AK-GAMING-PC\keysa
+RunAs User: AK-GAMING-PC\keysa
+Configuration Name: 
+Machine: AK-GAMING-PC (Microsoft Windows NT 10.0.26200.0)
+Host Application: C:\Program Files\PowerShell\7\pwsh.dll -NoProfile -ExecutionPolicy Bypass -Command Import-Module 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules\PowerShellEditorServices\PowerShellEditorServices.psd1'; Start-EditorServices -HostName 'Visual Studio Code Host' -HostProfileId 'Microsoft.VSCode' -HostVersion '2025.4.0' -BundledModulesPath 'c:\Users\keysa\.vscode\extensions\ms-vscode.powershell-2025.4.0\modules' -EnableConsoleRepl -StartupBanner "PowerShell Extension v2025.4.0
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+" -LogLevel 'Warning' -LogPath 'c:\Users\keysa\AppData\Roaming\Code\logs\20260507T085145\window1\exthost\ms-vscode.powershell' -SessionDetailsPath 'c:\Users\keysa\AppData\Roaming\Code\User\globalStorage\ms-vscode.powershell\sessions\PSES-VSCode-31768-919692.json' -FeatureFlags @() 
+Process ID: 10640
+PSVersion: 7.6.1
+PSEdition: Core
+GitCommitId: 7.6.1
+OS: Microsoft Windows 10.0.26200
+Platform: Win32NT
+PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1, 6.0, 7.0
+PSRemotingProtocolVersion: 2.4
+SerializationVersion: 1.1.0.1
+WSManStackVersion: 3.0
+**********************
+  [INFO] No -Token provided — attempting to generate dev JWT from container...
+  [INFO] Dev JWT generated from container JWT_SECRET (1h expiry)
+
+════════════════════════════════════════════════════════════
+  Regression Test Run — 2026-05-07 12:48:25
+  Base URL : http://localhost
+  Token    : auto-generated from container
+  Log file : C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\Regression-20260507-124825.txt
+════════════════════════════════════════════════════════════
+
+--- Vitest unit + integration suite ---
+  Running inside backend container...
+
+  > ak-portfolio-backend@1.0.0 test
+  > vitest run
+
+
+   RUN  v2.1.9 /app
+
+   Ô£ô tests/middleware/errorHandler.test.js (7 tests) 5ms
+   Ô£ô tests/middleware/validate.test.js (25 tests) 11ms
+   Ô£ô tests/routes/travel.test.js (4 tests) 30ms
+   Ô£ô tests/routes/contact.test.js (3 tests) 29ms
+   Ô£ô tests/routes/posts.test.js (5 tests) 34ms
+
+   Test Files  5 passed (5)
+        Tests  44 passed (44)
+     Start at  11:48:25
+     Duration  952ms (transform 562ms, setup 0ms, collect 2.42s, tests 109ms, environment 1ms, prepare 355ms)
+
+  [PASS] Vitest suite
+
+--- No-auth baseline ---
+  [PASS] GET /api/posts returns 200
+  [PASS] POST /api/contact missing name returns 400
+  [PASS] POST /api/contact invalid email returns 400
+  [PASS] GET /api/cv/exists returns 200 with 'exists' field
+  [PASS] POST /api/stats/visit?page=unknown returns 400
+  [PASS] Unknown route returns 404
+
+--- Auth-required baseline ---
+  [PASS] POST /api/posts missing title returns 400
+  [PASS] POST /api/posts invalid date format returns 400
+  [PASS] POST /api/travel missing title returns 400
+  [PASS] GET /api/stats/visits with auth returns 200
+  [PASS] GET /api/stats/visits without auth returns 401
+
+════════════════════════════════════════════════════════════
+  PASSED : 12
+  FAILED : 0
+════════════════════════════════════════════════════════════
+  Full log: C:\Users\keysa\Proton Drive\andy.r.keys\My files\Coding\MyPortfolioSite\scripts\tests\..\..\test-results\Regression-20260507-124825.txt
+
+**********************
+PowerShell transcript end
+End time: 20260507124827
+**********************

--- a/travel.html
+++ b/travel.html
@@ -55,11 +55,11 @@
             <div id="travel-map" class="travel-map" aria-label="Map of travel memories"></div>
 
             <div class="travel-grid" id="travel-grid">
-                <!-- populated from API by script.js -->
+                <!-- populated from API by travel.js -->
             </div>
 
             <div id="travel-timeline" class="timeline">
-                <!-- populated from API by script.js -->
+                <!-- populated from API by travel.js -->
             </div>
 
             <div id="travel-empty" class="travel-empty hidden">
@@ -95,6 +95,6 @@
     <script src="./resources/java/jquery-3.5.1.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-    <script type="module" src="./resources/java/script.js"></script>
+    <script type="module" src="./resources/java/travel.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Closes #133

- Moves travel map, lightbox, card/timeline loading, and view-toggle logic from `script.js` into a new dedicated `resources/java/travel.js` ES module
- `travel.html` now loads `travel.js` instead of `script.js`
- `script.js` is now scoped to the homepage only (GitHub widget, contact form, home visit counter); reduced from ~396 to ~173 lines
- Travel page visit counter now fires correctly on page load (was not firing when travel logic lived in the homepage script)

## Test plan

- [ ] Run `Test-Regression.ps1` — no regressions
- [ ] `travel.html` loads without console errors; travel cards and timeline render
- [ ] Map displays with correct markers; view-toggle buttons switch between views
- [ ] Lightbox opens on card click; close/prev/next/keyboard navigation works
- [ ] Homepage (`index.html`) loads without console errors; GitHub widget, contact form, and visit counter work
- [ ] Travel page visit counter increments in the admin stats panel

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_