### PR TITLE
fix(#134): hash email_tokens.token with bcrypt via pgcrypto

### DIFF
--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS passkeys (
 CREATE TABLE IF NOT EXISTS email_tokens (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  -- token: bcrypt hash stored via crypt(raw_token, gen_salt('bf')); raw token sent in email link only
   token VARCHAR(255) UNIQUE NOT NULL,
   expires_at TIMESTAMPTZ NOT NULL,
   used BOOLEAN DEFAULT FALSE,

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -295,7 +295,7 @@ router.post('/email/send', validate(EmailSendSchema), async (req, res) => {
       const token = uuidv4();
       await pool.query(
         `INSERT INTO email_tokens (user_id, token, expires_at)
-         VALUES ($1, $2, NOW() + INTERVAL '15 minutes')`,
+         VALUES ($1, crypt($2, gen_salt('bf')), NOW() + INTERVAL '15 minutes')`,
         [userResult.rows[0].id, token]
       );
       await sendMagicLink(email.toLowerCase().trim(), token).catch(err => {
@@ -317,16 +317,16 @@ router.get('/email/verify', async (req, res) => {
     if (!token) return res.status(400).json({ error: 'Token required' });
 
     const result = await pool.query(
-      `SELECT et.user_id, et.token, u.email, u.username
+      `SELECT et.id, et.user_id, u.email, u.username
        FROM email_tokens et JOIN users u ON et.user_id = u.id
-       WHERE et.token = $1 AND et.used = FALSE AND et.expires_at > NOW()`,
+       WHERE crypt($1, et.token) = et.token AND et.used = FALSE AND et.expires_at > NOW()`,
       [token]
     );
     if (!result.rows.length) {
       return res.status(400).json({ error: 'Invalid or expired link' });
     }
 
-    await pool.query('UPDATE email_tokens SET used = TRUE WHERE token = $1', [token]);
+    await pool.query('UPDATE email_tokens SET used = TRUE WHERE id = $1', [result.rows[0].id]);
 
     const row = result.rows[0];
     const jwtToken = signJWT({ id: row.user_id, email: row.email, username: row.username });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -83,6 +83,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - `docs/DEPENDENCIES.md` added to AI onboarding prompt in README and When in Doubt list in `docs/AI.md` (#130)
 - `.github/pull_request_template.md` — Smoke Test and Documentation checklist sections added (#130)
 
+### Security
+- Hash `email_tokens.token` with bcrypt via pgcrypto — raw token sent in email only; DB dump cannot be replayed (#134)
+
 ### Fixed
 - Blog post 404 errors — corrected `API_BASE` in `blog-post.js` to always use `/api` (#81)
 - Lightbox close/escape/arrow key handlers rewritten using native `addEventListener` (#82)

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -56,7 +56,7 @@ Short-lived tokens for email magic-link authentication.
 |--------|------|-------|
 | `id` | `UUID PK` | |
 | `user_id` | `UUID FK → users(id)` | `ON DELETE CASCADE` |
-| `token` | `VARCHAR(255) UNIQUE NOT NULL` | Secure random token |
+| `token` | `VARCHAR(255) UNIQUE NOT NULL` | Bcrypt hash of the secure random token (stored via `crypt(raw_token, gen_salt('bf'))`); the raw token is sent in the email link only — see `docs/SECURITY.md` (#134) |
 | `expires_at` | `TIMESTAMPTZ NOT NULL` | Checked on use; expired tokens are rejected |
 | `used` | `BOOLEAN DEFAULT FALSE` | Tokens are single-use |
 | `created_at` | `TIMESTAMPTZ` | |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -35,13 +35,14 @@ Two independent methods are supported. Either can be used to obtain a JWT.
 ### 2. Email Magic Links (fallback)
 
 1. Admin requests a magic link at `/auth/magic-link/request` with their registered email
-2. A secure random token is generated, stored in `email_tokens` with a short expiry, and emailed
-3. Admin clicks the link; `/auth/magic-link/verify` validates the token
+2. A secure random token (UUID) is generated, its bcrypt hash is stored in `email_tokens` via `crypt(token, gen_salt('bf'))`, and the raw token is emailed
+3. Admin clicks the link; `/auth/magic-link/verify` validates the token by re-hashing (`crypt($1, et.token) = et.token`)
 4. Token is marked `used = TRUE` (single-use)
 5. On success, a signed JWT is returned
 
 **Expiry:** Tokens expire based on `expires_at`. Expired tokens are rejected regardless of `used` status.
 **Single-use:** Once a token is used, `used = TRUE` and any subsequent attempt with the same token is rejected.
+**At-rest protection:** Only the bcrypt hash of the token is persisted, so a stolen DB dump cannot be replayed to forge magic-link logins (#134).
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #134

- Magic-link tokens are now stored as bcrypt hashes using `crypt($2, gen_salt('bf'))` rather than plaintext, so a leaked database does not expose valid login tokens
- Verification uses `crypt($1, et.token) = et.token` — the constant-time comparison built into pgcrypto
- `UPDATE` on token consumption uses `id` (primary key) rather than the token value, which is correct after the token column no longer holds plaintext
- `docs/DATABASE.md`, `docs/SECURITY.md`, and `backend/db/schema.sql` updated to document the bcrypt storage

## Test plan

- [ ] Run `Test-Regression.ps1` — no regressions
- [ ] Request a magic link; check `email_tokens` table — `token` column should contain a `$2b$` bcrypt hash, not plaintext
- [ ] Click the link; login should succeed and token marked used
- [ ] Reuse the same link; should be rejected (used = TRUE)
- [ ] Wait for token expiry; should be rejected
- [ ] Confirm `pgcrypto` extension is enabled in the database (`CREATE EXTENSION IF NOT EXISTS pgcrypto` in schema.sql)

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_