### PR TITLE
fix: correct nginx template path in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - "80:80"
     volumes:
       # Local dev template — plain HTTP only, no SSL (prod SSL lives in nginx-portfolio.conf.template)
-      - ./scripts/nginx-local.conf.template:/etc/nginx/templates/default.conf.template
+      - ./scripts/config/nginx-local.conf.template:/etc/nginx/templates/default.conf.template
       - .:/usr/share/nginx/html:ro
       - ./uploads:/usr/share/nginx/html/uploads:ro
     environment:


### PR DESCRIPTION
## Summary

The Nginx template volume mount path in `docker-compose.yml` pointed to a non-existent location, causing Docker to create an empty directory instead of mounting the file. Nginx fell back to its default boilerplate config, which has no `/api/` proxy rules.

Result: all API routes returned 404 from Nginx, breaking the smoke test suite.

## Root cause

- Volume mount: `./scripts/nginx-local.conf.template` (doesn't exist)
- Actual file location: `./scripts/config/nginx-local.conf.template`

Docker created the destination as a directory when the source didn't exist, Nginx skipped template rendering, and the default config was used instead.

## Fix

Changed the volume mount path to the correct location. Nginx will now properly render the template with environment variables and correctly proxy `/api/*` to the backend on port 8080.

## Test plan

- [ ] Rebuild containers: `docker-compose down nginx && docker-compose up -d nginx`
- [ ] Verify Nginx config: `docker exec myportfoliosite-nginx-1 cat /etc/nginx/conf.d/default.conf` should show the custom config with proxy rules, not the boilerplate
- [ ] Rerun regression tests: all 10 failing API tests should now pass

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_