### PR TITLE
feat(#159): dev environment on Ubuntu Server (LAN-only, port 3001)

### DIFF
--- a/.env.dev-server.example
+++ b/.env.dev-server.example
@@ -1,0 +1,35 @@
+# Dev server environment — Ubuntu Server, LAN-only (port 3001)
+# Copy to ~/MyPortfolioSite-dev/.env and fill in all values.
+#
+# IMPORTANT: Use different secrets from production.
+# IMPORTANT: LAN_IP, WEBAUTHN_RP_ID, and WEBAUTHN_ORIGIN must all use the
+#            server's actual LAN IP — passkey registration will fail otherwise.
+
+# Server LAN IP (find with: ip -4 addr show | grep inet)
+LAN_IP=192.168.x.x
+
+# Backend internal port (must not conflict with prod backend on 8080)
+PORT=8081
+
+# Database — separate from prod (portfolio_prod)
+DB_NAME=portfolio_dev
+DB_USER=postgres
+DB_PASSWORD=change-me-strong-dev-password
+
+# Auth — use a different secret from production
+JWT_SECRET=change-me-dev-jwt-secret-min-32-chars
+JWT_EXPIRY=7d
+
+# WebAuthn — must exactly match the URL used to access the dev site
+# RP_ID is just the hostname/IP (no port, no protocol)
+WEBAUTHN_RP_ID=192.168.x.x
+WEBAUTHN_ORIGIN=http://192.168.x.x:3001
+FRONTEND_URL=http://192.168.x.x:3001
+WEBAUTHN_RP_NAME=AK Portfolio (Dev)
+
+# Email (optional — can leave blank to disable contact form)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+ADMIN_EMAIL=

--- a/docker-compose.dev-server.yml
+++ b/docker-compose.dev-server.yml
@@ -1,0 +1,85 @@
+# Dev environment on Ubuntu Server — LAN-only, port 3001, no SSL.
+# Usage: docker compose -f docker-compose.dev-server.yml up -d --build
+#
+# Run from ~/MyPortfolioSite-dev (the dev-branch checkout).
+# See docs/INFRASTRUCTURE.md for full setup instructions.
+#
+# Prerequisites:
+#   - ~/MyPortfolioSite-dev/.env created from .env.dev-server.example
+#   - UFW rule allows LAN access to port 3001:
+#       sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'
+
+services:
+  postgres-dev:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_NAME:-portfolio_dev}
+      POSTGRES_USER: ${DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - postgres_dev_data:/var/lib/postgresql/data
+      - ./backend/db/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend-dev:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: prod
+    restart: unless-stopped
+    environment:
+      PORT: ${PORT:-8081}
+      DB_HOST: postgres-dev
+      DB_PORT: 5432
+      DB_NAME: ${DB_NAME:-portfolio_dev}
+      DB_USER: ${DB_USER:-postgres}
+      DB_PASSWORD: ${DB_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXPIRY: ${JWT_EXPIRY:-7d}
+      WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID}
+      WEBAUTHN_RP_NAME: ${WEBAUTHN_RP_NAME:-AK Portfolio (Dev)}
+      WEBAUTHN_ORIGIN: ${WEBAUTHN_ORIGIN}
+      FRONTEND_URL: ${FRONTEND_URL}
+      SMTP_HOST: ${SMTP_HOST:-smtp.gmail.com}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-}
+      UPLOADS_DIR: /app/uploads
+    volumes:
+      - uploads_dev_data:/app/uploads
+    depends_on:
+      postgres-dev:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:${PORT:-8081}/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  nginx-dev:
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./scripts/config/nginx-dev-server.conf.template:/etc/nginx/templates/default.conf.template
+      - .:/usr/share/nginx/html:ro
+      - uploads_dev_data:/usr/share/nginx/html/uploads:ro
+    environment:
+      DOMAIN: ${LAN_IP:-localhost}
+      REPO_DIR: /usr/share/nginx/html
+      APP_PORT: ${PORT:-8081}
+      BACKEND_HOST: backend-dev
+    depends_on:
+      backend-dev:
+        condition: service_healthy
+
+volumes:
+  postgres_dev_data:
+  uploads_dev_data:

--- a/docs/DEV_SERVER_SETUP.md
+++ b/docs/DEV_SERVER_SETUP.md
@@ -1,10 +1,14 @@
 # Dev Server Setup
 
-Sets up the `dev` branch as a second environment on the Ubuntu Server, accessible LAN-only at `http://<LAN_IP>:3001`. Run these steps once; future updates use `dev-server-deploy.sh`.
+Sets up the `dev` branch as a second environment on the Ubuntu Server, accessible LAN-only at `http://<LAN_IP>:3001`.
+
+The deploy script handles cloning, `.env` creation, building, and health-checking automatically. You only need to do three things manually before the first run.
 
 ---
 
 ## Step 1 — Find your LAN IP
+
+SSH into the server and run:
 
 ```bash
 ip -4 addr show | grep inet | grep -v 127.0.0.1
@@ -14,35 +18,7 @@ Note the address — it will look like `192.168.x.x`. You need it in step 3.
 
 ---
 
-## Step 2 — Create the env file on the server
-
-SSH into the server, then:
-
-```bash
-# The deploy script will clone the repo on first run, but you need
-# the .env in place beforehand. Create it manually:
-mkdir -p ~/MyPortfolioSite-dev
-curl -fsSL https://raw.githubusercontent.com/AndyRKeys/MyPortfolioSite/dev/.env.dev-server.example \
-  -o ~/MyPortfolioSite-dev/.env
-nano ~/MyPortfolioSite-dev/.env
-```
-
-Set these values (generate secrets with `openssl rand -base64 32`):
-
-| Variable | Value |
-|----------|-------|
-| `LAN_IP` | Your LAN IP from step 1 |
-| `DB_PASSWORD` | Strong password — **different from prod** |
-| `JWT_SECRET` | 32+ char random string — **different from prod** |
-| `WEBAUTHN_RP_ID` | Same as `LAN_IP` (no protocol, no port) |
-| `WEBAUTHN_ORIGIN` | `http://<LAN_IP>:3001` |
-| `FRONTEND_URL` | `http://<LAN_IP>:3001` |
-
-Everything else can stay as defaulted.
-
----
-
-## Step 3 — Open port 3001 to LAN only
+## Step 2 — Open port 3001 to LAN only
 
 ```bash
 sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'
@@ -53,7 +29,7 @@ If your home network uses a `10.x.x.x` subnet, adjust the range accordingly.
 
 ---
 
-## Step 4 — Run the deploy
+## Step 3 — Run the deploy script
 
 **From Windows (recommended):**
 
@@ -61,15 +37,37 @@ If your home network uses a `10.x.x.x` subnet, adjust the range accordingly.
 .\scripts\deploy\dev-server-deploy.ps1
 ```
 
-This SSHes into `ak-home-server`, clones the repo on first run, and runs the full deploy script. Uses the same SSH config as `prod-deploy.ps1`.
-
-**From the server directly (or via SSH manually):**
+**From the server directly:**
 
 ```bash
 bash ~/MyPortfolioSite-dev/scripts/deploy/dev-server-deploy.sh
 ```
 
-Expected output on success:
+### What happens on the first run
+
+The script checks for a `.env` file. If one doesn't exist it copies `.env.dev-server.example` into place and stops with instructions:
+
+```
+[WARN]  .env created but not yet configured.
+[WARN]  Edit ~/MyPortfolioSite-dev/.env and set these values:
+[WARN]    LAN_IP           — your server LAN IP (ip -4 addr show)
+[WARN]    DB_PASSWORD      — strong random password
+[WARN]    JWT_SECRET       — random string, min 32 chars (openssl rand -base64 32)
+[WARN]    WEBAUTHN_RP_ID   — same as LAN_IP (bare IP, no protocol/port)
+[WARN]    WEBAUTHN_ORIGIN  — http://<LAN_IP>:3001
+[WARN]    FRONTEND_URL     — http://<LAN_IP>:3001
+```
+
+Edit `~/MyPortfolioSite-dev/.env`, fill in the values above, then re-run the deploy script. Everything else in the file can stay as defaulted.
+
+Generate secrets with:
+```bash
+openssl rand -base64 32
+```
+
+### What happens on the second run (and all future runs)
+
+The script validates `.env`, builds the containers, and polls the health endpoint. On success:
 
 ```
 ╔══════════════════════════════════════════╗
@@ -81,7 +79,7 @@ Expected output on success:
 
 ## Future deploys
 
-Whenever you want to pull the latest `dev` branch to the server:
+Whenever you want to pull the latest `dev` branch to the server, run the same command:
 
 ```powershell
 # From Windows
@@ -119,7 +117,7 @@ docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml restart ba
 
 **Health check fails after deploy**
 
-The deploy script automatically dumps logs on failure. To investigate manually:
+The deploy script automatically dumps container logs on failure. To investigate manually:
 ```bash
 docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml logs --tail=50 backend-dev
 docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml logs --tail=20 postgres-dev
@@ -132,10 +130,10 @@ sudo lsof -i :3001     # confirm nginx-dev is listening
 ```
 
 **WebAuthn / passkey errors on the dev site**
-- Confirm `WEBAUTHN_RP_ID` in `.env` is just the bare IP (no `http://`, no port)
+- Confirm `WEBAUTHN_RP_ID` in `.env` is the bare IP (no `http://`, no port)
 - Confirm `WEBAUTHN_ORIGIN` is exactly `http://<LAN_IP>:3001`
 - Passkeys registered on prod will not work on dev (different origin — expected)
 
 **`.env` validation errors on deploy**
 
-The deploy script checks all required vars on every run and prints exactly which ones are missing or still set to placeholder values. Fix the reported vars in `~/MyPortfolioSite-dev/.env` and re-run.
+The deploy script checks all required vars on every run and tells you exactly which are missing or still set to placeholder values. Fix them in `~/MyPortfolioSite-dev/.env` and re-run.

--- a/docs/DEV_SERVER_SETUP.md
+++ b/docs/DEV_SERVER_SETUP.md
@@ -14,21 +14,17 @@ Note the address — it will look like `192.168.x.x`. You need it in step 3.
 
 ---
 
-## Step 2 — Clone the repo and switch to dev
+## Step 2 — Create the env file on the server
+
+SSH into the server, then:
 
 ```bash
-git clone https://github.com/AndyRKeys/MyPortfolioSite.git ~/MyPortfolioSite-dev
-cd ~/MyPortfolioSite-dev
-git checkout dev
-```
-
----
-
-## Step 3 — Create the env file
-
-```bash
-cp .env.dev-server.example .env
-nano .env
+# The deploy script will clone the repo on first run, but you need
+# the .env in place beforehand. Create it manually:
+mkdir -p ~/MyPortfolioSite-dev
+curl -fsSL https://raw.githubusercontent.com/AndyRKeys/MyPortfolioSite/dev/.env.dev-server.example \
+  -o ~/MyPortfolioSite-dev/.env
+nano ~/MyPortfolioSite-dev/.env
 ```
 
 Set these values (generate secrets with `openssl rand -base64 32`):
@@ -46,7 +42,7 @@ Everything else can stay as defaulted.
 
 ---
 
-## Step 4 — Open port 3001 to LAN only
+## Step 3 — Open port 3001 to LAN only
 
 ```bash
 sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'
@@ -57,7 +53,17 @@ If your home network uses a `10.x.x.x` subnet, adjust the range accordingly.
 
 ---
 
-## Step 5 — Start the dev environment
+## Step 4 — Run the deploy
+
+**From Windows (recommended):**
+
+```powershell
+.\scripts\deploy\dev-server-deploy.ps1
+```
+
+This SSHes into `ak-home-server`, clones the repo on first run, and runs the full deploy script. Uses the same SSH config as `prod-deploy.ps1`.
+
+**From the server directly (or via SSH manually):**
 
 ```bash
 bash ~/MyPortfolioSite-dev/scripts/deploy/dev-server-deploy.sh
@@ -66,8 +72,9 @@ bash ~/MyPortfolioSite-dev/scripts/deploy/dev-server-deploy.sh
 Expected output on success:
 
 ```
-✓ Dev site healthy at http://192.168.x.x:3001
-=== Dev deploy complete ===
+╔══════════════════════════════════════════╗
+║           Dev deploy complete ✓          ║
+╚══════════════════════════════════════════╝
 ```
 
 ---
@@ -76,11 +83,17 @@ Expected output on success:
 
 Whenever you want to pull the latest `dev` branch to the server:
 
+```powershell
+# From Windows
+.\scripts\deploy\dev-server-deploy.ps1
+```
+
 ```bash
+# From the server
 bash ~/MyPortfolioSite-dev/scripts/deploy/dev-server-deploy.sh
 ```
 
-Logs are written to `~/dev-deploy.log`.
+Logs are written to `~/dev-deploy.log` on the server.
 
 ---
 
@@ -105,6 +118,8 @@ docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml restart ba
 ## Troubleshooting
 
 **Health check fails after deploy**
+
+The deploy script automatically dumps logs on failure. To investigate manually:
 ```bash
 docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml logs --tail=50 backend-dev
 docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml logs --tail=20 postgres-dev
@@ -120,3 +135,7 @@ sudo lsof -i :3001     # confirm nginx-dev is listening
 - Confirm `WEBAUTHN_RP_ID` in `.env` is just the bare IP (no `http://`, no port)
 - Confirm `WEBAUTHN_ORIGIN` is exactly `http://<LAN_IP>:3001`
 - Passkeys registered on prod will not work on dev (different origin — expected)
+
+**`.env` validation errors on deploy**
+
+The deploy script checks all required vars on every run and prints exactly which ones are missing or still set to placeholder values. Fix the reported vars in `~/MyPortfolioSite-dev/.env` and re-run.

--- a/docs/DEV_SERVER_SETUP.md
+++ b/docs/DEV_SERVER_SETUP.md
@@ -1,0 +1,122 @@
+# Dev Server Setup
+
+Sets up the `dev` branch as a second environment on the Ubuntu Server, accessible LAN-only at `http://<LAN_IP>:3001`. Run these steps once; future updates use `dev-server-deploy.sh`.
+
+---
+
+## Step 1 — Find your LAN IP
+
+```bash
+ip -4 addr show | grep inet | grep -v 127.0.0.1
+```
+
+Note the address — it will look like `192.168.x.x`. You need it in step 3.
+
+---
+
+## Step 2 — Clone the repo and switch to dev
+
+```bash
+git clone https://github.com/AndyRKeys/MyPortfolioSite.git ~/MyPortfolioSite-dev
+cd ~/MyPortfolioSite-dev
+git checkout dev
+```
+
+---
+
+## Step 3 — Create the env file
+
+```bash
+cp .env.dev-server.example .env
+nano .env
+```
+
+Set these values (generate secrets with `openssl rand -base64 32`):
+
+| Variable | Value |
+|----------|-------|
+| `LAN_IP` | Your LAN IP from step 1 |
+| `DB_PASSWORD` | Strong password — **different from prod** |
+| `JWT_SECRET` | 32+ char random string — **different from prod** |
+| `WEBAUTHN_RP_ID` | Same as `LAN_IP` (no protocol, no port) |
+| `WEBAUTHN_ORIGIN` | `http://<LAN_IP>:3001` |
+| `FRONTEND_URL` | `http://<LAN_IP>:3001` |
+
+Everything else can stay as defaulted.
+
+---
+
+## Step 4 — Open port 3001 to LAN only
+
+```bash
+sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'
+sudo ufw status | grep 3001
+```
+
+If your home network uses a `10.x.x.x` subnet, adjust the range accordingly.
+
+---
+
+## Step 5 — Start the dev environment
+
+```bash
+bash ~/MyPortfolioSite-dev/scripts/deploy/dev-server-deploy.sh
+```
+
+Expected output on success:
+
+```
+✓ Dev site healthy at http://192.168.x.x:3001
+=== Dev deploy complete ===
+```
+
+---
+
+## Future deploys
+
+Whenever you want to pull the latest `dev` branch to the server:
+
+```bash
+bash ~/MyPortfolioSite-dev/scripts/deploy/dev-server-deploy.sh
+```
+
+Logs are written to `~/dev-deploy.log`.
+
+---
+
+## Useful commands
+
+```bash
+# Check container status
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml ps
+
+# View backend logs
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml logs -f backend-dev
+
+# Stop dev environment (frees resources when not needed)
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml down
+
+# Restart backend only
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml restart backend-dev
+```
+
+---
+
+## Troubleshooting
+
+**Health check fails after deploy**
+```bash
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml logs --tail=50 backend-dev
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml logs --tail=20 postgres-dev
+```
+
+**Port 3001 not reachable from other LAN devices**
+```bash
+sudo ufw status        # confirm the allow rule is present
+sudo lsof -i :3001     # confirm nginx-dev is listening
+```
+
+**WebAuthn / passkey errors on the dev site**
+- Confirm `WEBAUTHN_RP_ID` in `.env` is just the bare IP (no `http://`, no port)
+- Confirm `WEBAUTHN_ORIGIN` is exactly `http://<LAN_IP>:3001`
+- Passkeys registered on prod will not work on dev (different origin — expected)

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -389,20 +389,110 @@ sudo journalctl --vacuum=100M   # trim systemd logs
 
 ---
 
+## Dev Environment on Ubuntu Server (LAN-only)
+
+A second environment runs the `dev` branch on the same Ubuntu Server, accessible only on the local network at `http://<LAN_IP>:3001`. This lets you test `dev` changes on real hardware without touching the live site.
+
+### Repository layout
+
+```
+/home/<username>/
+├── MyPortfolioSite/          ← main branch (production)
+└── MyPortfolioSite-dev/      ← dev branch (LAN dev environment)
+    ├── docker-compose.dev-server.yml
+    └── .env                  ← dev env vars (from .env.dev-server.example)
+```
+
+### First-time setup
+
+```bash
+# 1. Clone the repo to a separate directory and switch to dev
+git clone https://github.com/AndyRKeys/MyPortfolioSite.git ~/MyPortfolioSite-dev
+cd ~/MyPortfolioSite-dev
+git checkout dev
+
+# 2. Create the env file and fill in values (especially LAN_IP)
+cp .env.dev-server.example .env
+nano .env
+
+# 3. Open port 3001 to LAN only (adjust subnet to match your home network)
+sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'
+
+# 4. Start dev services
+docker compose -f docker-compose.dev-server.yml up -d --build
+```
+
+### Deploy (update to latest dev branch)
+
+```bash
+bash ~/MyPortfolioSite-dev/scripts/deploy/dev-server-deploy.sh
+```
+
+Logs are written to `~/dev-deploy.log`.
+
+### Service commands
+
+```bash
+# Status
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml ps
+
+# Logs
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml logs -f backend-dev
+
+# Stop dev environment (frees resources when not in use)
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml down
+
+# Restart one service
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml restart backend-dev
+```
+
+### Dev services
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| **nginx-dev** | nginx:alpine | 3001 → host (LAN only) | HTTP reverse proxy + static files |
+| **backend-dev** | myportfoliosite-backend (prod build) | 8081 (internal) | Express API |
+| **postgres-dev** | postgres:16-alpine | internal only | Separate DB (`portfolio_dev`) |
+
+### Key differences from production
+
+| Aspect | Production | Dev Server |
+|--------|-----------|------------|
+| Branch | `main` | `dev` |
+| Compose file | `docker-compose.prod.yml` | `docker-compose.dev-server.yml` |
+| Port | 80 / 443 | 3001 |
+| SSL | Let's Encrypt | None (HTTP only) |
+| Database | `portfolio_prod` | `portfolio_dev` |
+| Backend port | 8080 (internal) | 8081 (internal) |
+| Access | Public internet | LAN only (UFW rule) |
+| WebAuthn origin | `https://<domain>` | `http://<LAN_IP>:3001` |
+
+### Environment variables
+
+See `.env.dev-server.example` for the full reference. Critical values to set:
+- `LAN_IP` — server's LAN IP (find with `ip -4 addr show`)
+- `DB_PASSWORD` — strong random password (different from prod)
+- `JWT_SECRET` — different from prod JWT secret
+- `WEBAUTHN_RP_ID` and `WEBAUTHN_ORIGIN` — must match `http://<LAN_IP>:3001`
+
+---
+
 ## Production vs Dev Environment
 
 With Docker Compose in production, dev and prod are now structurally aligned:
 
-| Aspect | Production (Ubuntu Server) | Development (local Docker) |
-|--------|---|---|
-| **Compose file** | `docker-compose.prod.yml` | `docker-compose.yml` |
-| **Backend image** | Prod build target (no devDeps) | Dev build target (devDeps + hot reload) |
-| **Source code** | In Docker image | Bind-mounted for hot reload |
-| **Database** | Named volume (persists) | Named volume (persists) |
-| **Nginx** | Port 80 + 443 (SSL) | Port 80 only (no SSL) |
-| **SSL** | Let's Encrypt (host certbot, volume-mounted) | None |
-| **Env vars** | `.env` in repo root | `.env` in repo root |
-| **Logs** | `docker compose -f docker-compose.prod.yml logs` | `docker compose logs` |
+| Aspect | Production (Ubuntu Server) | Dev Server (Ubuntu Server LAN) | Local Dev (Windows) |
+|--------|---|---|---|
+| **Compose file** | `docker-compose.prod.yml` | `docker-compose.dev-server.yml` | `docker-compose.yml` |
+| **Branch** | `main` | `dev` | any |
+| **Backend image** | Prod build target (no devDeps) | Prod build target (no devDeps) | Dev build target (devDeps + hot reload) |
+| **Source code** | In Docker image | In Docker image | Bind-mounted for hot reload |
+| **Database** | `portfolio_prod` | `portfolio_dev` | `portfolio_dev` |
+| **Nginx** | Port 80 + 443 (SSL) | Port 3001 (no SSL) | Port 80 (no SSL) |
+| **SSL** | Let's Encrypt | None | None |
+| **Access** | Public internet | LAN only (UFW) | localhost only |
+| **Repo path** | `~/MyPortfolioSite` | `~/MyPortfolioSite-dev` | local clone |
+| **Logs** | `docker compose -f docker-compose.prod.yml logs` | `docker compose -f docker-compose.dev-server.yml logs` | `docker compose logs` |
 
 ---
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -68,7 +68,7 @@ All production services run as Docker containers managed by `docker compose -f d
 ### Docker Volume Names
 
 | Volume | Purpose |
-|--------|----------|
+|--------|---------|
 | `myportfoliosite_postgres_data` | PostgreSQL data directory (persists across deploys) |
 | `myportfoliosite_uploads_data` | User-uploaded files (CVs, images) |
 

--- a/scripts/config/nginx-dev-server.conf.template
+++ b/scripts/config/nginx-dev-server.conf.template
@@ -1,0 +1,45 @@
+# Nginx config for dev environment on Ubuntu Server.
+# HTTP only, port 3001, LAN-accessible only (no SSL).
+# Rendered by envsubst with: DOMAIN, REPO_DIR, APP_PORT, BACKEND_HOST
+
+server {
+    listen 3001;
+    server_name ${DOMAIN} localhost;
+
+    root ${REPO_DIR};
+    index index.html;
+
+    # Allow larger file uploads (matches multer 20 MB limit + headroom)
+    client_max_body_size 25M;
+
+    # ── Security headers
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://unpkg.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self'; frame-ancestors 'none';" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+    location /api/ {
+        proxy_pass http://${BACKEND_HOST}:${APP_PORT}/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /health {
+        proxy_pass http://${BACKEND_HOST}:${APP_PORT}/health;
+        proxy_set_header Host $host;
+    }
+
+    location /uploads/ {
+        alias ${REPO_DIR}/uploads/;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location / {
+        try_files $uri $uri/ $uri.html =404;
+    }
+}

--- a/scripts/config/nginx-dev-server.conf.template
+++ b/scripts/config/nginx-dev-server.conf.template
@@ -13,7 +13,7 @@ server {
     client_max_body_size 25M;
 
     # ── Security headers
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://unpkg.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self'; frame-ancestors 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self'; frame-ancestors 'none';" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/scripts/deploy/dev-server-deploy.ps1
+++ b/scripts/deploy/dev-server-deploy.ps1
@@ -1,0 +1,26 @@
+# Trigger a dev server deploy from Windows via SSH.
+# Connects to the Ubuntu Server and runs scripts/deploy/dev-server-deploy.sh remotely.
+#
+# On first run the bash script will clone the repo automatically.
+# On subsequent runs it pulls the latest dev branch and rebuilds containers.
+#
+# Usage: .\scripts\deploy\dev-server-deploy.ps1 [-Hostname <name>]
+param(
+    [string]$Hostname = 'ak-home-server'
+)
+
+# Bootstrap on first run: if the dev repo doesn't exist yet, clone it first.
+# Subsequent runs just invoke the deploy script directly.
+$remoteCommand = @'
+DEPLOY_SCRIPT=~/MyPortfolioSite-dev/scripts/deploy/dev-server-deploy.sh
+if [ -f "$DEPLOY_SCRIPT" ]; then
+    bash "$DEPLOY_SCRIPT"
+else
+    echo "[INFO] Dev repo not found — cloning for the first time..."
+    git clone https://github.com/AndyRKeys/MyPortfolioSite.git ~/MyPortfolioSite-dev
+    cd ~/MyPortfolioSite-dev && git checkout dev
+    bash scripts/deploy/dev-server-deploy.sh
+fi
+'@
+
+ssh $Hostname $remoteCommand

--- a/scripts/deploy/dev-server-deploy.sh
+++ b/scripts/deploy/dev-server-deploy.sh
@@ -1,59 +1,290 @@
 #!/usr/bin/env bash
-# Deploy the dev branch to the server dev environment (LAN-only, port 3001).
+# dev-server-deploy.sh — Unified dev environment setup and deploy script.
+#
+# Handles both first-time setup and subsequent deploys.
 # Run on the Ubuntu Server as the non-root user.
 #
-# First-time setup:
-#   git clone https://github.com/AndyRKeys/MyPortfolioSite.git ~/MyPortfolioSite-dev
-#   cd ~/MyPortfolioSite-dev && git checkout dev
-#   cp .env.dev-server.example .env   # then edit with real values
-#   sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'
+# Usage:
 #   bash scripts/deploy/dev-server-deploy.sh
+#
+# On first run the script will clone the repo and guide you through .env setup.
+# On subsequent runs it pulls the latest dev branch and rebuilds containers.
+
 set -euo pipefail
 
+# ── Config ──────────────────────────────────────────────────────────────────────────────
+
 DEV_REPO="${HOME}/MyPortfolioSite-dev"
+REPO_URL="https://github.com/AndyRKeys/MyPortfolioSite.git"
 COMPOSE_FILE="${DEV_REPO}/docker-compose.dev-server.yml"
 LOG_FILE="${HOME}/dev-deploy.log"
+HEALTH_TIMEOUT=60   # seconds to wait for the site to become healthy
+HEALTH_INTERVAL=5   # seconds between health check attempts
+
+# Required .env vars — must be present and not a placeholder value
+REQUIRED_VARS=(LAN_IP DB_PASSWORD JWT_SECRET WEBAUTHN_RP_ID WEBAUTHN_ORIGIN FRONTEND_URL)
+
+# Placeholder values that signal the var hasn't been configured
+PLACEHOLDER_PATTERNS=("192.168.x.x" "change-me" "your-" "xxx")
+
+# ── Helpers ───────────────────────────────────────────────────────────────────────────
+
+# Colour support only when attached to a real terminal
+if [ -t 1 ]; then
+    RED='\033[0;31m'; YELLOW='\033[0;33m'; GREEN='\033[0;32m'
+    CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+else
+    RED=''; YELLOW=''; GREEN=''; CYAN=''; BOLD=''; RESET=''
+fi
 
 timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
-log() { echo "[$(timestamp)] $*" | tee -a "$LOG_FILE"; }
+log()     { echo -e "[$(timestamp)] $*" | tee -a "$LOG_FILE"; }
+info()    { log "${CYAN}${BOLD}[INFO]${RESET}  $*"; }
+ok()      { log "${GREEN}${BOLD}[OK]${RESET}    $*"; }
+warn()    { log "${YELLOW}${BOLD}[WARN]${RESET}  $*"; }
+fail()    { log "${RED}${BOLD}[ERROR]${RESET} $*"; }
+section() { log ""; log "${BOLD}── $* ──────────────────────────────────────────────${RESET}"; }
 
-log "=== Dev deploy started ==="
+die() {
+    fail "$*"
+    log "See full log at: $LOG_FILE"
+    exit 1
+}
+
+# ── Entry point ─────────────────────────────────────────────────────────────────────────
+
+log ""
+log "${BOLD}╔══════════════════════════════════════════╗${RESET}"
+log "${BOLD}║     Dev Server Deploy — $(timestamp)   ║${RESET}"
+log "${BOLD}╚══════════════════════════════════════════╝${RESET}"
+log ""
+
+# ── Section 1: Prerequisites ───────────────────────────────────────────────────────────
+
+section "Checking prerequisites"
+
+MISSING_PREREQS=()
+
+if ! command -v docker &>/dev/null; then
+    MISSING_PREREQS+=("docker")
+fi
+
+if ! docker compose version &>/dev/null 2>&1; then
+    MISSING_PREREQS+=("docker-compose-plugin (run: sudo apt install docker-compose-plugin)")
+fi
+
+if ! command -v git &>/dev/null; then
+    MISSING_PREREQS+=("git")
+fi
+
+if ! command -v curl &>/dev/null; then
+    MISSING_PREREQS+=("curl")
+fi
+
+if [ ${#MISSING_PREREQS[@]} -gt 0 ]; then
+    fail "Missing required tools:"
+    for tool in "${MISSING_PREREQS[@]}"; do
+        fail "  • $tool"
+    done
+    die "Install missing tools then re-run this script."
+fi
+
+if ! docker info &>/dev/null 2>&1; then
+    die "Docker daemon is not running. Start it with: sudo systemctl start docker"
+fi
+
+ok "All prerequisites satisfied (docker, git, curl)"
+
+# ── Section 2: First-time setup ─────────────────────────────────────────────────────────
+
+section "Checking repository"
 
 if [ ! -d "$DEV_REPO" ]; then
-    log "ERROR: $DEV_REPO does not exist."
-    log "Run: git clone https://github.com/AndyRKeys/MyPortfolioSite.git $DEV_REPO"
-    log "Then: cd $DEV_REPO && git checkout dev && cp .env.dev-server.example .env"
-    exit 1
+    info "Dev repo not found at $DEV_REPO — cloning..."
+    git clone "$REPO_URL" "$DEV_REPO" || die "git clone failed. Check your internet connection."
+    cd "$DEV_REPO"
+    git checkout dev || die "Could not switch to dev branch."
+    ok "Repo cloned and set to dev branch."
+else
+    ok "Repo found at $DEV_REPO"
 fi
 
 if [ ! -f "${DEV_REPO}/.env" ]; then
-    log "ERROR: ${DEV_REPO}/.env not found."
-    log "Copy .env.dev-server.example to .env and fill in values."
-    exit 1
+    if [ -f "${DEV_REPO}/.env.dev-server.example" ]; then
+        info ".env not found — copying from .env.dev-server.example"
+        cp "${DEV_REPO}/.env.dev-server.example" "${DEV_REPO}/.env"
+        warn ""
+        warn "  .env created but not yet configured."
+        warn "  Edit ${DEV_REPO}/.env and set these values:"
+        warn "    LAN_IP           — your server LAN IP (ip -4 addr show)"
+        warn "    DB_PASSWORD      — strong random password"
+        warn "    JWT_SECRET       — random string, min 32 chars (openssl rand -base64 32)"
+        warn "    WEBAUTHN_RP_ID   — same as LAN_IP (bare IP, no protocol/port)"
+        warn "    WEBAUTHN_ORIGIN  — http://<LAN_IP>:3001"
+        warn "    FRONTEND_URL     — http://<LAN_IP>:3001"
+        warn ""
+        die "Configure .env then re-run this script."
+    else
+        die ".env not found and .env.dev-server.example is missing. Check your checkout."
+    fi
 fi
+
+ok ".env file present"
+
+# ── Section 3: Environment validation ───────────────────────────────────────────────────
+
+section "Validating .env"
+
+# Source .env safely — only export KEY=VALUE lines
+set -a
+# shellcheck disable=SC1090
+source <(grep -E '^[A-Z_]+=.' "${DEV_REPO}/.env" | grep -v '^#') 2>/dev/null || true
+set +a
+
+ENV_ERRORS=()
+
+for var in "${REQUIRED_VARS[@]}"; do
+    value="${!var:-}"
+
+    if [ -z "$value" ]; then
+        ENV_ERRORS+=("$var is not set")
+        continue
+    fi
+
+    for pattern in "${PLACEHOLDER_PATTERNS[@]}"; do
+        if [[ "$value" == *"$pattern"* ]]; then
+            ENV_ERRORS+=("$var still contains placeholder value ('$pattern') — set a real value")
+            break
+        fi
+    done
+done
+
+# JWT_SECRET length check (min 32 chars)
+if [ -n "${JWT_SECRET:-}" ] && [ ${#JWT_SECRET} -lt 32 ]; then
+    ENV_ERRORS+=("JWT_SECRET is too short (${#JWT_SECRET} chars — minimum 32). Generate with: openssl rand -base64 32")
+fi
+
+# WebAuthn consistency — RP_ID must be just the IP, ORIGIN must include port
+if [ -n "${WEBAUTHN_RP_ID:-}" ] && [ -n "${LAN_IP:-}" ]; then
+    if [ "$WEBAUTHN_RP_ID" != "$LAN_IP" ]; then
+        ENV_ERRORS+=("WEBAUTHN_RP_ID ('$WEBAUTHN_RP_ID') must match LAN_IP ('$LAN_IP') exactly")
+    fi
+fi
+
+if [ -n "${WEBAUTHN_ORIGIN:-}" ] && [[ "$WEBAUTHN_ORIGIN" != *":3001"* ]]; then
+    ENV_ERRORS+=("WEBAUTHN_ORIGIN ('$WEBAUTHN_ORIGIN') should end with :3001 — passkey registration will fail otherwise")
+fi
+
+if [ ${#ENV_ERRORS[@]} -gt 0 ]; then
+    fail ".env validation failed:"
+    for err in "${ENV_ERRORS[@]}"; do
+        fail "  • $err"
+    done
+    die "Fix the above .env issues then re-run."
+fi
+
+ok "All required env vars set and valid (LAN_IP=${LAN_IP})"
+
+# ── Section 4: UFW check ───────────────────────────────────────────────────────────────────
+
+section "Checking firewall (UFW)"
+
+if command -v ufw &>/dev/null && sudo ufw status 2>/dev/null | grep -q "3001"; then
+    ok "UFW rule for port 3001 is present"
+else
+    warn "No UFW rule found for port 3001."
+    warn "The dev site may not be reachable from other LAN devices."
+    warn "To open port 3001 to your LAN:"
+    warn "  sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'"
+    warn "Continuing anyway — this is a warning, not an error."
+fi
+
+# ── Section 5: Git update ───────────────────────────────────────────────────────────────────
+
+section "Updating to latest dev branch"
 
 cd "$DEV_REPO"
 
-log "Fetching latest dev branch..."
-git fetch origin dev
-git reset --hard origin/dev
+PREV_SHA=$(git rev-parse HEAD 2>/dev/null || echo "none")
+info "Current commit: $PREV_SHA"
 
-log "Building and restarting dev services..."
-docker compose -f "$COMPOSE_FILE" up -d --build
+git fetch origin dev 2>&1 | tee -a "$LOG_FILE" || die "git fetch failed. Check your internet connection."
+git reset --hard origin/dev 2>&1 | tee -a "$LOG_FILE"
 
-log "Waiting for dev site to become healthy..."
-LAN_IP=$(grep '^LAN_IP=' "${DEV_REPO}/.env" | cut -d= -f2 | tr -d '[:space:]')
-DEV_URL="http://${LAN_IP:-localhost}:3001"
+NEW_SHA=$(git rev-parse HEAD)
+if [ "$NEW_SHA" = "$PREV_SHA" ]; then
+    info "Already at latest commit — no code changes."
+else
+    ok "Updated: ${PREV_SHA:0:7} → ${NEW_SHA:0:7}"
+fi
 
-for i in $(seq 1 12); do
-    if curl -sf "${DEV_URL}/api/health" > /dev/null 2>&1; then
-        log "✓ Dev site healthy at ${DEV_URL}"
-        log "=== Dev deploy complete ==="
-        exit 0
+# ── Section 6: Docker build & up ───────────────────────────────────────────────────────────
+
+section "Building and starting dev services"
+
+info "Running: docker compose up -d --build"
+if ! docker compose -f "$COMPOSE_FILE" up -d --build 2>&1 | tee -a "$LOG_FILE"; then
+    fail "docker compose up failed. Container logs:"
+    docker compose -f "$COMPOSE_FILE" logs --tail=40 2>&1 | tee -a "$LOG_FILE"
+    # Roll back to previous commit if there was one
+    if [ "$PREV_SHA" != "none" ] && [ "$PREV_SHA" != "$NEW_SHA" ]; then
+        warn "Rolling back to previous commit ($PREV_SHA)..."
+        git reset --hard "$PREV_SHA"
+        docker compose -f "$COMPOSE_FILE" up -d --build 2>&1 | tee -a "$LOG_FILE" || true
     fi
-    sleep 5
+    die "Deploy failed — see above for details."
+fi
+
+# ── Section 7: Health check ───────────────────────────────────────────────────────────────────
+
+section "Waiting for site to become healthy"
+
+DEV_URL="http://${LAN_IP}:3001"
+ATTEMPTS=$(( HEALTH_TIMEOUT / HEALTH_INTERVAL ))
+
+info "Polling ${DEV_URL}/api/health (${HEALTH_TIMEOUT}s timeout)..."
+
+for i in $(seq 1 "$ATTEMPTS"); do
+    if curl -sf --max-time 4 "${DEV_URL}/api/health" > /dev/null 2>&1; then
+        ok "✓ Dev site healthy at ${DEV_URL}"
+        break
+    fi
+    if [ "$i" -eq "$ATTEMPTS" ]; then
+        fail "✗ Health check failed after ${HEALTH_TIMEOUT}s"
+        fail ""
+        fail "Backend logs (last 50 lines):"
+        docker compose -f "$COMPOSE_FILE" logs --tail=50 backend-dev 2>&1 | tee -a "$LOG_FILE"
+        fail ""
+        fail "Postgres logs (last 20 lines):"
+        docker compose -f "$COMPOSE_FILE" logs --tail=20 postgres-dev 2>&1 | tee -a "$LOG_FILE"
+        # Roll back if the code changed
+        if [ "$PREV_SHA" != "none" ] && [ "$PREV_SHA" != "$NEW_SHA" ]; then
+            warn "Rolling back to previous commit (${PREV_SHA:0:7})..."
+            git reset --hard "$PREV_SHA" 2>&1 | tee -a "$LOG_FILE"
+            docker compose -f "$COMPOSE_FILE" up -d --build 2>&1 | tee -a "$LOG_FILE" || true
+            warn "Rolled back — verify the site is healthy before investigating the failed update."
+        fi
+        die "Deploy failed — see log at $LOG_FILE"
+    fi
+    info "  attempt $i/$ATTEMPTS — not ready yet, retrying in ${HEALTH_INTERVAL}s..."
+    sleep "$HEALTH_INTERVAL"
 done
 
-log "✗ Health check failed after 60s — check logs:"
-log "  docker compose -f $COMPOSE_FILE logs --tail=50 backend-dev"
-exit 1
+# ── Section 8: Summary ───────────────────────────────────────────────────────────────────────────
+
+section "Deploy complete"
+
+ok ""
+ok "  Site:    ${DEV_URL}"
+ok "  Commit:  $(git rev-parse --short HEAD)"
+ok "  Log:     $LOG_FILE"
+ok ""
+
+info "Container status:"
+docker compose -f "$COMPOSE_FILE" ps 2>&1 | tee -a "$LOG_FILE"
+
+log ""
+log "${BOLD}╔══════════════════════════════════════════╗${RESET}"
+log "${BOLD}║           Dev deploy complete ✓          ║${RESET}"
+log "${BOLD}╚══════════════════════════════════════════╝${RESET}"
+log ""

--- a/scripts/deploy/dev-server-deploy.sh
+++ b/scripts/deploy/dev-server-deploy.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Deploy the dev branch to the server dev environment (LAN-only, port 3001).
+# Run on the Ubuntu Server as the non-root user.
+#
+# First-time setup:
+#   git clone https://github.com/AndyRKeys/MyPortfolioSite.git ~/MyPortfolioSite-dev
+#   cd ~/MyPortfolioSite-dev && git checkout dev
+#   cp .env.dev-server.example .env   # then edit with real values
+#   sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'
+#   bash scripts/deploy/dev-server-deploy.sh
+set -euo pipefail
+
+DEV_REPO="${HOME}/MyPortfolioSite-dev"
+COMPOSE_FILE="${DEV_REPO}/docker-compose.dev-server.yml"
+LOG_FILE="${HOME}/dev-deploy.log"
+
+timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(timestamp)] $*" | tee -a "$LOG_FILE"; }
+
+log "=== Dev deploy started ==="
+
+if [ ! -d "$DEV_REPO" ]; then
+    log "ERROR: $DEV_REPO does not exist."
+    log "Run: git clone https://github.com/AndyRKeys/MyPortfolioSite.git $DEV_REPO"
+    log "Then: cd $DEV_REPO && git checkout dev && cp .env.dev-server.example .env"
+    exit 1
+fi
+
+if [ ! -f "${DEV_REPO}/.env" ]; then
+    log "ERROR: ${DEV_REPO}/.env not found."
+    log "Copy .env.dev-server.example to .env and fill in values."
+    exit 1
+fi
+
+cd "$DEV_REPO"
+
+log "Fetching latest dev branch..."
+git fetch origin dev
+git reset --hard origin/dev
+
+log "Building and restarting dev services..."
+docker compose -f "$COMPOSE_FILE" up -d --build
+
+log "Waiting for dev site to become healthy..."
+LAN_IP=$(grep '^LAN_IP=' "${DEV_REPO}/.env" | cut -d= -f2 | tr -d '[:space:]')
+DEV_URL="http://${LAN_IP:-localhost}:3001"
+
+for i in $(seq 1 12); do
+    if curl -sf "${DEV_URL}/api/health" > /dev/null 2>&1; then
+        log "✓ Dev site healthy at ${DEV_URL}"
+        log "=== Dev deploy complete ==="
+        exit 0
+    fi
+    sleep 5
+done
+
+log "✗ Health check failed after 60s — check logs:"
+log "  docker compose -f $COMPOSE_FILE logs --tail=50 backend-dev"
+exit 1


### PR DESCRIPTION
## Summary

Adds everything needed to run the `dev` branch as a second environment on the Ubuntu Server, accessible LAN-only at `http://<LAN_IP>:3001`. Production is unchanged.

- **`docker-compose.dev-server.yml`** — separate stack: `postgres-dev` (`portfolio_dev` DB), `backend-dev` (prod build, port 8081 internal), `nginx-dev` (port 3001 exposed to host)
- **`scripts/config/nginx-dev-server.conf.template`** — HTTP-only nginx on port 3001 with identical security headers to the local dev config
- **`.env.dev-server.example`** — env template documenting `LAN_IP`, separate DB/JWT secrets, and WebAuthn origin pointing at `http://<LAN_IP>:3001`
- **`scripts/deploy/dev-server-deploy.sh`** — pulls latest `dev` branch into `~/MyPortfolioSite-dev`, rebuilds containers, polls `/api/health`, logs to `~/dev-deploy.log`
- **`docs/DEV_SERVER_SETUP.md`** — step-by-step first-time setup guide (5 steps: find LAN IP → clone → create .env → UFW rule → start)
- **`docs/INFRASTRUCTURE.md`** — new dev server section + updated 3-way comparison table (prod / dev-server / local)

## Test plan

- [ ] SSH into Ubuntu Server and follow `docs/DEV_SERVER_SETUP.md` steps 1–5
- [ ] Confirm `http://<LAN_IP>:3001` loads the site from a second device on the LAN
- [ ] Confirm `http://<LAN_IP>:3001` is not reachable from mobile data (external)
- [ ] Confirm live site (`https://andykeys.me`) continues to work normally
- [ ] Confirm prod and dev databases are separate (`portfolio_prod` vs `portfolio_dev`)
- [ ] Run `dev-server-deploy.sh` a second time — confirm it pulls latest and restarts cleanly

Closes #159

https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1

---
_Generated by [Claude Code](https://claude.ai/code/session_012Jn75K3CQRuk7GNPYS5mv1)_