### PR TITLE
fix: prompt user to set up missing maintenance items after deploy

### DIFF
--- a/scripts/deploy/dev-server-deploy.sh
+++ b/scripts/deploy/dev-server-deploy.sh
@@ -203,33 +203,29 @@ fi
 
 section "Checking Docker maintenance setup"
 
-MAINTENANCE_OK=true
+NEED_CRON=false
+NEED_AUTOSTART=false
 
 # Check for Docker system prune cron job
 if sudo crontab -l 2>/dev/null | grep -q "docker system prune"; then
     ok "Docker cleanup cron job is scheduled"
 else
-    warn "Docker cleanup cron job not found"
-    warn "Schedule weekly cleanup to prevent disk issues:"
-    warn "  sudo crontab -e"
-    warn "  # Add: 0 2 * * 0 /usr/bin/docker system prune -f --volumes >> /var/log/docker-prune.log 2>&1"
-    MAINTENANCE_OK=false
+    warn "Docker cleanup cron job not found — will offer setup after deploy"
+    NEED_CRON=true
 fi
 
 # Check for autostart service
 if systemctl is-enabled myportfolio-dev.service &>/dev/null 2>&1; then
     ok "Dev autostart service is enabled"
 else
-    warn "Dev autostart service not enabled"
-    warn "Enable autostart on reboot:"
-    warn "  sudo bash $DEV_REPO/scripts/setup/install-dev-autostart.sh"
-    MAINTENANCE_OK=false
+    warn "Dev autostart service not enabled — will offer setup after deploy"
+    NEED_AUTOSTART=true
 fi
 
-if [ "$MAINTENANCE_OK" = false ]; then
+if [ "$NEED_CRON" = true ] || [ "$NEED_AUTOSTART" = true ]; then
     warn ""
-    warn "Some maintenance items are missing, but continuing deploy anyway."
-    warn "Configure them at your convenience to improve stability."
+    warn "Some maintenance items are missing. Deploy will continue and you"
+    warn "will be prompted to set them up once the site is healthy."
     warn ""
 fi
 
@@ -333,3 +329,47 @@ log "${BOLD}╔═════════════════════�
 log "${BOLD}║           Dev deploy complete ✓          ║${RESET}"
 log "${BOLD}╚══════════════════════════════════════════╝${RESET}"
 log ""
+
+# ── Section 10: Post-deploy maintenance setup ─────────────────────────────────────────────────
+
+if [ "$NEED_CRON" = true ] || [ "$NEED_AUTOSTART" = true ]; then
+    section "Optional maintenance setup"
+
+    if [ "$NEED_CRON" = true ] && [ -t 0 ]; then
+        echo ""
+        echo -e "${YELLOW}${BOLD}[SETUP]${RESET} Docker cleanup cron job is not scheduled."
+        echo "        Running 'docker system prune' weekly prevents disk issues over time."
+        read -r -p "        Set up weekly Docker cleanup cron now? [y/N] " _cron_resp
+        if [[ "$_cron_resp" =~ ^[Yy]$ ]]; then
+            (sudo crontab -l 2>/dev/null; echo "0 2 * * 0 /usr/bin/docker system prune -f --volumes >> /var/log/docker-prune.log 2>&1") | sudo crontab -
+            ok "Weekly Docker cleanup cron scheduled (Sundays at 2 AM)"
+            log "[$(timestamp)] Cron job added by deploy script" | tee -a "$LOG_FILE"
+        else
+            warn "Skipped — run 'sudo crontab -e' to add it manually when ready."
+        fi
+    fi
+
+    if [ "$NEED_AUTOSTART" = true ] && [ -t 0 ]; then
+        echo ""
+        echo -e "${YELLOW}${BOLD}[SETUP]${RESET} Dev autostart service is not installed."
+        echo "        Without it, the dev stack won't come back up automatically after a reboot."
+        read -r -p "        Install autostart service now? [y/N] " _autostart_resp
+        if [[ "$_autostart_resp" =~ ^[Yy]$ ]]; then
+            if sudo bash "$DEV_REPO/scripts/setup/install-dev-autostart.sh"; then
+                ok "Dev autostart service installed and enabled"
+                log "[$(timestamp)] Autostart service installed by deploy script" | tee -a "$LOG_FILE"
+            else
+                warn "Autostart install failed — run manually: sudo bash $DEV_REPO/scripts/setup/install-dev-autostart.sh"
+            fi
+        else
+            warn "Skipped — run 'sudo bash $DEV_REPO/scripts/setup/install-dev-autostart.sh' when ready."
+        fi
+    fi
+
+    if [ ! -t 0 ]; then
+        warn "Running non-interactively — skipping maintenance prompts."
+        warn "Set up missing items manually:"
+        [ "$NEED_CRON" = true ]      && warn "  Cron:      sudo crontab -e  (add: 0 2 * * 0 /usr/bin/docker system prune -f --volumes >> /var/log/docker-prune.log 2>&1)"
+        [ "$NEED_AUTOSTART" = true ] && warn "  Autostart: sudo bash $DEV_REPO/scripts/setup/install-dev-autostart.sh"
+    fi
+fi

--- a/scripts/deploy/dev-server-deploy.sh
+++ b/scripts/deploy/dev-server-deploy.sh
@@ -189,14 +189,13 @@ ok "All required env vars set and valid (LAN_IP=${LAN_IP})"
 
 section "Checking firewall (UFW)"
 
+NEED_UFW=false
+
 if command -v ufw &>/dev/null && sudo ufw status 2>/dev/null | grep -q "3001"; then
     ok "UFW rule for port 3001 is present"
 else
-    warn "No UFW rule found for port 3001."
-    warn "The dev site may not be reachable from other LAN devices."
-    warn "To open port 3001 to your LAN:"
-    warn "  sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'"
-    warn "Continuing anyway — this is a warning, not an error."
+    warn "No UFW rule found for port 3001 — will offer setup after deploy"
+    NEED_UFW=true
 fi
 
 # ── Section 5: Maintenance checks ───────────────────────────────────────────────────────────
@@ -222,9 +221,9 @@ else
     NEED_AUTOSTART=true
 fi
 
-if [ "$NEED_CRON" = true ] || [ "$NEED_AUTOSTART" = true ]; then
+if [ "$NEED_CRON" = true ] || [ "$NEED_AUTOSTART" = true ] || [ "$NEED_UFW" = true ]; then
     warn ""
-    warn "Some maintenance items are missing. Deploy will continue and you"
+    warn "Some configuration items are missing. Deploy will continue and you"
     warn "will be prompted to set them up once the site is healthy."
     warn ""
 fi
@@ -332,8 +331,27 @@ log ""
 
 # ── Section 10: Post-deploy maintenance setup ─────────────────────────────────────────────────
 
-if [ "$NEED_CRON" = true ] || [ "$NEED_AUTOSTART" = true ]; then
-    section "Optional maintenance setup"
+if [ "$NEED_CRON" = true ] || [ "$NEED_AUTOSTART" = true ] || [ "$NEED_UFW" = true ]; then
+    section "Optional configuration setup"
+
+    if [ "$NEED_UFW" = true ] && [ -t 0 ]; then
+        echo ""
+        echo -e "${YELLOW}${BOLD}[SETUP]${RESET} UFW firewall rule for port 3001 is not configured."
+        echo "        The dev site won't be reachable from other LAN devices without this rule."
+        read -r -p "        Set up UFW rule now? [y/N] " _ufw_resp
+        if [[ "$_ufw_resp" =~ ^[Yy]$ ]]; then
+            if sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only' 2>&1 | tee -a "$LOG_FILE"; then
+                ok "UFW rule added for 192.168.0.0/16 on port 3001"
+                log "[$(timestamp)] UFW rule added by deploy script" | tee -a "$LOG_FILE"
+                warn "Note: If your LAN uses a different subnet (e.g. 10.x.x.x), run:"
+                warn "  sudo ufw allow from YOUR_SUBNET to any port 3001 comment 'Dev site LAN-only'"
+            else
+                warn "UFW rule setup failed — run manually: sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'"
+            fi
+        else
+            warn "Skipped — run manually when ready: sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'"
+        fi
+    fi
 
     if [ "$NEED_CRON" = true ] && [ -t 0 ]; then
         echo ""
@@ -367,8 +385,9 @@ if [ "$NEED_CRON" = true ] || [ "$NEED_AUTOSTART" = true ]; then
     fi
 
     if [ ! -t 0 ]; then
-        warn "Running non-interactively — skipping maintenance prompts."
+        warn "Running non-interactively — skipping setup prompts."
         warn "Set up missing items manually:"
+        [ "$NEED_UFW" = true ]       && warn "  UFW:       sudo ufw allow from 192.168.0.0/16 to any port 3001 comment 'Dev site LAN-only'"
         [ "$NEED_CRON" = true ]      && warn "  Cron:      sudo crontab -e  (add: 0 2 * * 0 /usr/bin/docker system prune -f --volumes >> /var/log/docker-prune.log 2>&1)"
         [ "$NEED_AUTOSTART" = true ] && warn "  Autostart: sudo bash $DEV_REPO/scripts/setup/install-dev-autostart.sh"
     fi


### PR DESCRIPTION
## Summary

Small follow-up to #214. Instead of just warning about missing cron/autostart/UFW at the start of the deploy, the script now prompts the user interactively **after** the site is confirmed healthy.

- Sections 4-5 record what's missing (`NEED_UFW`, `NEED_CRON`, `NEED_AUTOSTART`) but no longer tell the user to go fix it manually mid-deploy
- New Section 10 runs after the success banner — if any items are missing and there's an interactive terminal (`-t 0`), the user is prompted with a clear explanation and a `[y/N]` choice for each
- Saying yes installs the item immediately (adds UFW rule, adds cron entry, or runs `install-dev-autostart.sh`)
- Non-interactive runs (SSH pipe, CI) fall back to printed instructions

## Test Plan

- [ ] Run deploy script when UFW is missing — confirm prompt appears after success banner
- [ ] Answer `y` for UFW — confirm `sudo ufw status | grep 3001` shows the 192.168.0.0/16 rule
- [ ] Answer `n` for UFW — confirm skip message is shown, nothing installed
- [ ] Run deploy script when cron is missing — confirm prompt appears
- [ ] Answer `y` for cron — confirm `sudo crontab -l` shows the weekly prune entry
- [ ] Run deploy script when autostart is not installed — confirm prompt appears
- [ ] Answer `y` for autostart — confirm `systemctl list-unit-files | grep myportfolio-dev` shows enabled
- [ ] Run non-interactively (`bash deploy.sh < /dev/null`) — confirm fallback instructions printed, no hang