### PR TITLE
Dev server: no-SSL variant with improved deploy script and HTTP health

### DIFF
--- a/scripts/config/nginx-dev-server.conf.template
+++ b/scripts/config/nginx-dev-server.conf.template
@@ -2,26 +2,27 @@
 # HTTPS on port 3001 with self-signed certificate for WebAuthn support.
 # Rendered by envsubst with: DOMAIN, REPO_DIR, APP_PORT, BACKEND_HOST
 
-# HTTP → HTTPS redirect
+# HTTP → HTTPS redirect (disabled in no-SSL dev branch)
+# server {
+#     listen 3001;
+#     server_name ${DOMAIN} localhost;
+#     return 301 https://$host$request_uri;
+# }
+
+# HTTP server (no SSL) for dev
 server {
+    # listen 3001 ssl;
     listen 3001;
     server_name ${DOMAIN} localhost;
-    return 301 https://$host$request_uri;
-}
 
-# HTTPS server
-server {
-    listen 3001 ssl;
-    server_name ${DOMAIN} localhost;
+    # SSL certificate paths (disabled in no-SSL dev branch)
+    # ssl_certificate     /etc/nginx/certs/dev-server.crt;
+    # ssl_certificate_key /etc/nginx/certs/dev-server.key;
 
-    # SSL certificate paths (mounted from host in docker-compose)
-    ssl_certificate     /etc/nginx/certs/dev-server.crt;
-    ssl_certificate_key /etc/nginx/certs/dev-server.key;
-
-    # Modern SSL configuration
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers HIGH:!aNULL:!MD5;
-    ssl_prefer_server_ciphers on;
+    # Modern SSL configuration (not used without SSL)
+    # ssl_protocols TLSv1.2 TLSv1.3;
+    # ssl_ciphers HIGH:!aNULL:!MD5;
+    # ssl_prefer_server_ciphers on;
 
     root ${REPO_DIR};
     index index.html;


### PR DESCRIPTION
Dev-only branch to stabilise the dev server without HTTPS while keeping the new deploy script and health check behaviour.

Changes in this branch:

- Created from `feature/219-dev-server-https-plan`.
- Updated `scripts/config/nginx-dev-server.conf.template` to:
  - Comment out the HTTP→HTTPS redirect server block.
  - Comment out `listen 3001 ssl` and replace with plain `listen 3001`.
  - Comment out `ssl_certificate`, `ssl_certificate_key`, and SSL protocol/cipher lines.
  - Preserve all existing security headers, `/api` proxy, `/health` proxy`, uploads, and static file handling.

Result:

- Dev Nginx now serves HTTP on port 3001 without requiring certs.
- Backend still exposes `/health` and `/api/health`, and the deploy script continues to use backend HTTP health, decoupled from TLS.
- This branch is intended as a safe baseline while Docker/Snap permissions and the future TLS reimplementation are sorted out.

Next steps (later PRs):

- Migrate Docker off Snap and ensure container ownership/permissions are consistent.
- Reintroduce HTTPS for dev (WebAuthn) with a stable Docker setup and updated cert wiring.
