### PR TITLE
docs: ops-first roadmap reprioritisation + workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,7 @@ const result = await pool.query(`SELECT * FROM posts WHERE id = ${postId}`);
 - **No structured logging:** `console.log` used throughout; no severity levels or request context. (#152)
 - **Admin.html monolithic:** 18KB single file; refactoring needed. (No issue yet; low priority)
 - **No schema migration tool:** schema.sql is idempotent but has no version tracking. (#169)
-- **PM2 in prod, Docker in dev:** Structural difference; moving prod to Docker is next big task. (#165)
+- **Manual, script-driven deploys:** prod and dev both run Docker Compose (PM2 retired, #165/#179), but deploys are still script-driven and have caused orphan-container/stale-code incidents. (#253; ROADMAP §3.5)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ Files moved to scripts/config/ in #130 but compose file wasn't updated.
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 
 # Push and create PR
+# PR creation is the DEFAULT: once the branch is pushed and the work is
+# complete, open the PR to dev automatically — do not ask first. You still
+# never merge it (owner reviews + merges). Skip only if explicitly told to,
+# or the work is incomplete/experimental (and say so).
 git push -u origin fix/issue-N-short-description
 gh pr create --base dev --title "Title" --body "Description. Closes #N"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,16 @@ const result = await pool.query(`SELECT * FROM posts WHERE id = ${postId}`);
   - Same deploy step → move to deploy-lib.sh function
   - Same HTML structure → extract to a shared template or builder function
 
+### Debugging & Logging
+
+**Build observability into every change — it is part of the implementation, not a follow-up.** Deployment bugs and blind debugging have been the biggest recent time sink (ops-first priority — `ROADMAP.md` §3.5).
+
+- Add structured log lines at meaningful decision points (entry, external-call outcomes, branch taken, failure reasons) — not just the happy path. Use a unique, greppable `[area] message — context` prefix.
+- Log the *why* of a failure (error + relevant inputs + expectation), never secrets (`.env`, tokens, JWTs, hashes).
+- A change isn't done until you can answer: "if this breaks in prod, how would we diagnose it from logs alone?" If you can't, add the logging before the PR.
+- Deploy/infra changes: fail loud, not silent — surface orphan/port/env warnings as hard failures.
+- Full rule: see **[docs/AI.md](docs/AI.md) → Debugging & Logging**.
+
 ### Testing
 
 **Vitest suite:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,11 @@ Files moved to scripts/config/ in #130 but compose file wasn't updated.
 
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 
+# One branch at a time for OPS and SECURITY work — do not run multiple
+# ops/infra or security (auth/tokens/secrets/rate-limit) branches in
+# parallel; finish + PR + merge one before starting the next. Unrelated
+# low-risk work may still parallelise.
+
 # Push and create PR
 # PR creation is the DEFAULT: once the branch is pushed and the work is
 # complete, open the PR to dev automatically — do not ask first. You still

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A full-stack personal portfolio site built with plain HTML/CSS/JS on the fronten
 | Auth | WebAuthn/FIDO2 passkeys + email magic links, JWT |
 | Database | PostgreSQL |
 | Web server | Nginx (static files + reverse proxy) |
-| Process manager | PM2 |
+| Runtime | Docker Compose (backend + Postgres + Nginx containerised) |
 | SSL | Let's Encrypt (certbot, auto-renewing) |
 | DNS | Namecheap + dynamic DNS (ddclient) |
 | Hosting | Self-hosted, Raspberry Pi |
@@ -27,7 +27,7 @@ A full-stack personal portfolio site built with plain HTML/CSS/JS on the fronten
 ```
 Browser → andykeys.me
        → Nginx :80/:443
-           ├── /auth/*  → proxy → Node.js backend (PM2)
+           ├── /auth/*  → proxy → Node.js backend (Docker)
            │                        └── PostgreSQL
            └── /*       → static files
 ```
@@ -189,37 +189,40 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 This SSHs into the Pi and runs `scripts/deploy/prod-deploy.sh`, which:
 1. Fetches and lists what changed
 2. Pulls the latest code
-3. Runs `npm install` only if `backend/package.json` changed
-4. Re-runs `backend/db/schema.sql` only if it changed or DB is empty (idempotent)
-5. Re-renders and reloads Nginx only if `scripts/deploy/nginx-portfolio.conf.template` changed
-6. Restarts PM2 only if backend files changed
-7. Reports PM2 status
+3. Pulls the target branch and rebuilds images
+4. Re-runs `backend/db/schema.sql` (idempotent — `IF NOT EXISTS`)
+5. Brings the stack up with `docker compose -f docker-compose.prod.yml up -d --build`
+6. Reports container status via `docker compose -f docker-compose.prod.yml ps`
 
 ### What needs a restart?
+
+The whole stack is containerised, so a deploy rebuilds and recreates the affected containers. There is no separate process manager to restart.
 
 | Change type | Action needed |
 |-------------|--------------|
 | HTML / CSS / JS (frontend) | None — Nginx serves files directly |
-| Backend `.js` files | Auto: `pm2 restart portfolio-backend` |
-| `package.json` / new deps | Auto: `npm install --omit=dev` + `pm2 restart` |
-| `backend/db/schema.sql` | Auto: re-runs schema (uses `IF NOT EXISTS`) + `pm2 restart` |
-| `scripts/deploy/nginx-portfolio.conf.template` | Auto: renders via `envsubst`, validates with `nginx -t`, reloads Nginx |
-| `.env` | Edit on server manually + `pm2 restart` |
+| Backend `.js` files | Auto: image rebuild + `docker compose up -d --build` recreates the backend container |
+| `package.json` / new deps | Auto: image rebuild reinstalls deps, container recreated |
+| `backend/db/schema.sql` | Auto: re-runs schema (uses `IF NOT EXISTS`) on boot |
+| `scripts/config/nginx-*.conf.template` | Auto: rendered + validated with `nginx -t` before the Nginx container reloads |
+| `.env` | Edit on server manually, then re-run the deploy (Compose reloads env on recreate) |
 
 ### Useful server commands
 
+> Prod uses `docker-compose.prod.yml`. SSH into the server first, then run from the repo directory.
+
 ```bash
 # Check backend logs
-ssh <pi-hostname> "pm2 logs portfolio-backend --lines 50"
+docker compose -f docker-compose.prod.yml logs --tail=50 backend
 
-# Check backend status
-ssh <pi-hostname> "pm2 status"
+# Check container status
+docker compose -f docker-compose.prod.yml ps
 
-# Restart backend manually
-ssh <pi-hostname> "pm2 restart portfolio-backend"
+# Restart the backend container
+docker compose -f docker-compose.prod.yml restart backend
 
-# Check Nginx status
-ssh <pi-hostname> "sudo systemctl status nginx"
+# Check Nginx (containerised — via Compose, not systemd)
+docker compose -f docker-compose.prod.yml logs --tail=50 nginx
 
 # Renew SSL cert (also auto-renews via systemd timer)
 ssh <pi-hostname> "sudo certbot renew"

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ docker compose -f docker-compose.prod.yml restart backend
 docker compose -f docker-compose.prod.yml logs --tail=50 nginx
 
 # Renew SSL cert (also auto-renews via systemd timer)
-ssh <pi-hostname> "sudo certbot renew"
+ssh <hostname> "sudo certbot renew"
 ```
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,6 +72,16 @@ The goals for the project are:
 
 **Outcome:** Less friction around making and deploying changes, more confidence when experimenting.
 
+### 3.4 Automated test gate (CI-only — precursor to §4.4)
+
+Promoted ahead of the full CI/CD pipeline (§4.4): the test-gate half needs no self-hosted runner, GHCR, or beefier host, so it can land now and start catching regressions immediately. Today the Vitest suite and `Test-Regression.ps1` only run when invoked manually on the dev server; nothing blocks a red change from reaching `dev`. Security-sensitive PRs (e.g. the `email_tokens` bcrypt work, #134) are exactly where an automated gate pays off.
+
+- GitHub Actions workflow on every PR to `dev`: run the existing Vitest suite in the backend container (Postgres as a service container), plus lint/format checks.
+- Block merge on red CI; surface results on the PR.
+- No deployment, registry, or runner work in scope here — this is purely the merge-time safety net. The build/publish/deploy automation stays in §4.4 and still sequences after dual-environment hosting (3.1).
+
+**Outcome:** Regressions caught at PR time instead of by hand, with zero new infrastructure — a cheap, reversible first step that de-risks everything in §4.4.
+
 ## 4. Medium-term directions
 
 ### 4.1 AI Lab v2
@@ -97,6 +107,8 @@ The goals for the project are:
 ### 4.4 Professionalised CI/CD pipeline (GitHub + open-source tooling)
 
 Deployments are still script-driven and manual, which has caused real incidents (e.g. orphan containers serving stale code after a compose service rename — see issue #253). The goal is a reproducible, observable pipeline using only GitHub-native and open-source tools — no paid SaaS, consistent with the self-hosted ethos.
+
+> **Note:** The Continuous Integration test gate below has been promoted to a near-term priority as **§3.4** — it needs no extra infrastructure and lands first. §4.4 now focuses on the Continuous Delivery half (versioned image build/publish, self-hosted runner, gated prod deploy), which still sequences after dual-environment hosting (3.1) and likely alongside the mini PC migration (5.1). The CI section is retained here for completeness of the end-state picture.
 
 **Continuous Integration (on every PR to `dev`):**
 
@@ -230,3 +242,4 @@ Speculative, not committed — captured so good ideas are not lost. To be promot
 - **2026-05-07** – Initial roadmap drafting, based on issues #15, #151, #159 and current architecture.
 - **2026-05-15** – Added §4.4 Professionalised CI/CD pipeline (GitHub Actions + GHCR + self-hosted runner), prompted by the orphan-container deploy incident (#253).
 - **2026-05-15** – Added §4.5 Open-source tooling adoption (Dependabot/Renovate, gitleaks, ESLint/Prettier, Uptime Kuma, Grafana/Loki, migration tooling) and §5.5 Future development suggestions, cross-referencing existing open issues.
+- **2026-05-15** – Promoted the CI test gate out of §4.4 into near-term priority §3.4 (Automated test gate); it needs no new infrastructure and lands before the full CD pipeline. §4.4 re-scoped to the Continuous Delivery half.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-_Last updated: 2026-05-15_
+_Last updated: 2026-05-16_
 
 ## 1. Vision and goals
 
@@ -37,6 +37,8 @@ The goals for the project are:
 - Limited observability (minimal metrics/logs surfaced in UI).
 
 ## 3. Near-term priorities
+
+> **Sequencing principle (ops first):** Deployment reliability, logging, and the automated test gate take precedence over new feature work (including AI Lab v1, §3.2). Recent sessions have lost significant time to deployment bugs (orphan containers, stale code, env-var gaps) and to debugging blind without structured logs. Until deploys are boringly reliable and observable, ops/deploy/logging items are pulled ahead of feature delivery. Concretely the near-term order is: **3.5 (deploy reliability & logging) → 3.4 (test gate) → 3.1 (dual-env) → 3.3 (QoL) → 3.2 (AI Lab v1)**.
 
 ### 3.1 Dual-environment hosting (LAN dev + public prod)
 
@@ -81,6 +83,24 @@ Promoted ahead of the full CI/CD pipeline (§4.4): the test-gate half needs no s
 - No deployment, registry, or runner work in scope here — this is purely the merge-time safety net. The build/publish/deploy automation stays in §4.4 and still sequences after dual-environment hosting (3.1).
 
 **Outcome:** Regressions caught at PR time instead of by hand, with zero new infrastructure — a cheap, reversible first step that de-risks everything in §4.4.
+
+### 3.5 Deployment reliability & structured logging
+
+The highest-priority near-term item (see the sequencing principle above). Deployment bugs and blind debugging have been the single biggest drain on recent work — orphan containers serving stale code (#253), env-var gaps that only surfaced at runtime, and `console.log`-only output that made diagnosis slow. This pulls the deploy-hardening and structured-logging work forward from §4.2/§4.5.
+
+**Deployment reliability:**
+
+- Bake orphan-container prevention into the deploy scripts: `docker compose up` always runs with `--remove-orphans`, and the deploy fails loudly on orphan/port-conflict warnings (#253).
+- Add a post-deploy verification step to `deploy-lib.sh`: hit `/api/health`, confirm the running image/commit matches the intended ref, and surface a clear pass/fail in the deploy output (catches the stale-code class of bug).
+- Document the single canonical deploy path and reduce script branching so there are fewer ways to get it subtly wrong.
+
+**Structured logging:**
+
+- Replace ad-hoc `console.log` with structured logging (Pino) carrying severity levels and request context (#152).
+- Ensure deploy scripts and the admin deploy console surface the relevant log lines on failure, so a bad deploy is diagnosable without SSH archaeology.
+- Never log secrets (`.env`, tokens, refresh tokens) — structured logging makes redaction a deliberate, reviewable choice.
+
+**Outcome:** Deploys become boringly reliable and self-verifying; failures are diagnosable from logs in minutes instead of hours. This unblocks everything else by stopping deployment bugs from eating feature/testing time.
 
 ## 4. Medium-term directions
 
@@ -243,3 +263,4 @@ Speculative, not committed — captured so good ideas are not lost. To be promot
 - **2026-05-15** – Added §4.4 Professionalised CI/CD pipeline (GitHub Actions + GHCR + self-hosted runner), prompted by the orphan-container deploy incident (#253).
 - **2026-05-15** – Added §4.5 Open-source tooling adoption (Dependabot/Renovate, gitleaks, ESLint/Prettier, Uptime Kuma, Grafana/Loki, migration tooling) and §5.5 Future development suggestions, cross-referencing existing open issues.
 - **2026-05-15** – Promoted the CI test gate out of §4.4 into near-term priority §3.4 (Automated test gate); it needs no new infrastructure and lands before the full CD pipeline. §4.4 re-scoped to the Continuous Delivery half.
+- **2026-05-16** – Added an ops-first sequencing principle to §3 and new near-term priority §3.5 (Deployment reliability & structured logging), pulling deploy-hardening (#253) and Pino structured logging (#152) ahead of feature work after repeated deployment-bug time sinks.

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -311,6 +311,28 @@ var name = user.name; // Get the user's name
 - **No Quick Fixes:** If tempted to duplicate code, create a utility instead
 - **Testability:** Write utilities to be testable independently of DOM
 
+## Debugging & Logging (build it in, don't bolt it on)
+
+Recent work has lost significant time to deployment bugs and blind debugging. Observability is **part of the change, not a follow-up**. This is a roadmap priority (`ROADMAP.md` §3.5) — treat it as a working rule, not an aspiration.
+
+**Logging is part of the implementation:**
+
+- When adding or modifying a backend route, deploy step, or any non-trivial flow, add **structured log lines at the meaningful decision points** (entry with relevant identifiers, external-call outcomes, the branch taken, failure reasons) — not just on the happy path.
+- Use the project's structured logger where it exists; until Pino lands (#152), use `console.log`/`console.error` with a consistent `[area] message — context` prefix (e.g. `[auth/email/send] token inserted — user=...`). A new log prefix should be unique enough to grep for and to distinguish new code from old.
+- Log the **why** of a failure, not just that it failed: include the error, the inputs that mattered (never secrets), and what was expected.
+- **Never log secrets** — `.env` values, JWTs, tokens, refresh tokens, password hashes. Redaction is a deliberate, reviewable choice.
+
+**Debuggability is a deliverable:**
+
+- A change is not done until you can answer "if this breaks in prod, how would we know, and how would we diagnose it from logs alone?" If the answer is "we couldn't", add the logging before opening the PR.
+- For deploy/infra changes, prefer fail-loud over fail-silent: surface warnings (orphan containers, port conflicts, env-var gaps) as hard failures, not buried output.
+- When you fix a bug, leave behind the log line that would have made it obvious — that's how the next instance gets caught in minutes, not hours.
+
+**PR expectations:**
+
+- The PR description should note what logging/observability was added and how a failure would surface.
+- Diagnostic scripts or temporary verbose logging used while debugging should either be cleaned up or, if generally useful, kept deliberately and mentioned in the PR — not left as accidental noise.
+
 ## Architecture Notes
 
 - **Frontend:** ES modules for JavaScript, shared utilities in `resources/java/utils/*`; HTML/CSS, jQuery for legacy compat; no build step

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -107,6 +107,9 @@ Before writing code:
 4. Push commits as you go (don't wait until done)
 
 ### 4. PR to Dev
+
+**PR creation is the default.** Once the work is committed and the branch is pushed, open the PR to `dev` automatically — do not ask "shall I open a PR?" first. The standing authorisation is: branch + push + complete work ⇒ open the PR. (You still do **not** merge it — review and merge remain the owner's.) Only skip or defer the PR if the owner explicitly says so for that piece of work, or the work is genuinely incomplete/experimental (say so explicitly).
+
 Once implementation is complete:
 1. Raise a PR from the branch → `dev`
 2. Link the issue number (`Closes #N`)

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -75,6 +75,7 @@ feature/* or fix/* (per GitHub issue)
 - One branch per GitHub issue only
 
 **Critical guardrails:**
+- **One branch at a time for ops and security work.** Do not open or develop multiple branches simultaneously when the work touches deployment/infrastructure or security (auth, tokens, secrets, rate limiting). These changes are interdependent and easy to get subtly wrong in parallel — finish, PR, and get one merged before starting the next. Independent low-risk work (e.g. a docs tweak, an unrelated UI fix) may still proceed in parallel; this restriction is specific to ops/security.
 - **Always develop on a feature or fix branch** (`feature/issue-N-*` or `fix/issue-N-*`). Never commit directly to `dev` or `main`.
 - **Pull requests** go `feature|fix/* → dev` for integration testing and review.
 - **Release branches** go `release/YYYY-MM-DD → main` when you instruct the AI to prepare a release.

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -414,8 +414,8 @@ When working with this project:
 - **Architecture:** Nginx reverse proxy (`/api/*` → Node backend), static frontend served by Nginx
 - **Database:** PostgreSQL with UUID primary keys, idempotent schema migrations
 - **Frontend:** No build step — vanilla JS/HTML/CSS with jQuery for compatibility
-- **Stack:** Node.js/Express backend, WebAuthn/JWT auth, PM2 process manager
-- **Deployment:** Smart deploy script detects changes and restarts only what's needed
+- **Stack:** Node.js/Express backend, WebAuthn/JWT auth, fully containerised (Docker Compose — PM2 retired, #165/#179)
+- **Deployment:** Script-driven Docker Compose deploy (`prod-deploy.sh` → `docker compose -f docker-compose.prod.yml up -d --build`); rebuilds and recreates affected containers
 - **Terminal:** Developer uses PowerShell on Windows. Provide PowerShell-compatible commands for local machine operations. Bash is correct for Pi/server/container operations.
 - **Testing:** All tests run inside the Docker backend container via `docker compose exec`. Never instruct the developer to run `npm test` directly on their local machine.
 


### PR DESCRIPTION
## Summary

Docs-only reprioritisation toward ops/deployment/logging, plus two standing workflow rules. No code changes.

## Changes

**`ROADMAP.md`:**
- Promoted the CI test gate out of §4.4 into near-term priority **§3.4** (no infrastructure needed; §4.4 re-scoped to the CD half).
- Added an **ops-first sequencing principle** to §3: deploy/logging/test-gate take precedence over feature work (incl. AI Lab v1). Order: 3.5 → 3.4 → 3.1 → 3.3 → 3.2.
- New **§3.5 Deployment reliability & structured logging** — pulls deploy hardening (#253) and Pino structured logging (#152) forward.
- Changelog + "Last updated" bumped to 2026-05-16.

**`docs/AI.md` + `CLAUDE.md`:**
- New **Debugging & Logging** working rule — observability is built into every change, not bolted on (log decision points, log the *why*, never log secrets, fail-loud on deploy/infra).
- **PR creation is now the default** on branch push (owner still reviews + merges).

## Test plan

- [ ] N/A — documentation only; no backend code touched
- [ ] Confirm `ROADMAP.md` §3 ordering and §3.5 read as intended
- [ ] Confirm the AI.md / CLAUDE.md workflow rules match expected behaviour

Closes nothing — process/roadmap change.

https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM)_