### PR TITLE
docs: require explicit step-by-step commands in PR test plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,15 @@ const result = await pool.query(`SELECT * FROM posts WHERE id = ${postId}`);
 - `scripts/tests/Test-PRNNN.ps1` — specific PR tests (created as needed)
 - Run on your machine to verify no regressions before merging
 
+**PR test plan rules (every PR that touches backend code):**
+- Every step must include the **exact copy-paste command** — no assumed knowledge, no "run the usual command"
+- Add a `# comment` above every command explaining what it verifies and why it matters for this PR
+- State the **expected output** after each command so the tester knows pass vs fail at a glance
+- Use correct compose file + service for the target env: dev server → `docker-compose.dev-server.yml`, services `backend-dev` / `postgres-dev`, DB `portfolio_dev`; local Docker → `docker-compose.yml`, services `backend` / `postgres`
+- Where a step requires waiting (e.g. token expiry), provide a DB command to simulate it instead
+- HTTP requests from Windows: use `curl.exe` PowerShell syntax; from inside a container or the server: plain `curl`
+- Full rule: see **[docs/AI.md](docs/AI.md) → PR test plans must include**
+
 ### Documentation
 
 **When to write docs:**

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -128,6 +128,14 @@ The AI does not merge PRs — you will review, test locally, and merge when read
 - The smoke test checkbox: a reference to `scripts/tests/Test-PRN.ps1` if backend code was touched, or an explicit N/A if not
 - The documentation checklist: confirm `docs/CHANGELOG.md` updated and any relevant doc updated, or N/A
 
+**Test plan commands — mandatory rules:**
+- Every step that requires a terminal command must include the **exact, copy-paste command** — no placeholders left unexplained, no "run the usual command".
+- Use the correct compose file and service name for the environment being tested (e.g. `docker-compose.dev-server.yml` with service `backend-dev` and `postgres-dev` for the dev server; `docker-compose.yml` with `backend`/`postgres` for local Docker).
+- Add a **comment line above every command** (using `#`) that explains what the command does and why it matters for this specific PR — not just what the tool is, but what you are verifying.
+- Include the **expected output or outcome** after each command so the tester knows immediately whether it passed or failed.
+- Where a step would normally require waiting (e.g. token expiry), provide a DB command to simulate it rather than leaving the tester to wait.
+- Use PowerShell `curl.exe` syntax for HTTP requests run from Windows; use plain `curl` for commands run inside the server or a container.
+
 ### 5. Release to Production
 
 When you are ready to release to production, instruct the AI with:


### PR DESCRIPTION
## Summary

Docs-only. Tightens the PR test plan rules so every step is copy-paste ready — no assumed knowledge, no vague steps like "confirm pgcrypto is loaded".

## Changes

**`docs/AI.md` — expanded "PR test plans must include" with mandatory command rules:**
- Exact copy-paste commands for every terminal step
- `# comment` above every command explaining what it verifies and why it matters for the PR
- Expected output stated after each command (pass/fail is unambiguous)
- Correct compose file + service name for the target environment
- DB command to simulate waits (e.g. token expiry) rather than leaving the tester waiting
- `curl.exe` PowerShell syntax for Windows; plain `curl` inside a container

**`CLAUDE.md` — same rules mirrored in the Testing section for in-session pickup**

## Motivation

PR #251 (bcrypt) had a vague test step: "Confirm pgcrypto extension is loaded (already in schema.sql)". That gives no command and no expected output — a tester has to already know how to query `pg_extension`. These rules close that gap going forward.

## Test plan

- [ ] N/A — documentation only; no backend code touched

https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM)_