### PR TITLE
docs: standardise host terminology + add docs/TERMINOLOGY.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,11 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 git push -u origin fix/issue-N-short-description
 gh pr create --base dev --title "Title" --body "Description. Closes #N"
 
+# After opening the PR, also recommend a ready-to-copy squash commit
+# message (fenced code block: imperative ≤50-char summary, blank line,
+# short why/what body, Co-Authored-By footer). Repo squash-merges, so
+# this becomes the permanent history entry — owner pastes it on merge.
+
 # After review, merge to dev (user does this, not you)
 # User will then create a release PR: dev → main for deploy
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Quick Orientation (2 minutes)
 
-**What is this?** A personal portfolio site at andykeys.me — blog, travel posts, admin console for managing content, and AI lab experiments. Hosted on a Raspberry Pi (moving to Ubuntu Server gaming PC).
+**What is this?** A personal portfolio site at andykeys.me — blog, travel posts, admin console for managing content, and AI lab experiments. Self-hosted on an Ubuntu Server (`ak-home-server`, a repurposed gaming PC); the original Raspberry Pi has been retired. See `docs/TERMINOLOGY.md` for canonical names.
 
 **Tech stack:**
 - Frontend: vanilla JS/HTML/CSS (no build step), jQuery for legacy compatibility
@@ -36,6 +36,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
    - docs/DATABASE.md — schema reference
    - docs/SECURITY.md — auth model, JWT, threat model
    - docs/DEPENDENCIES.md — dependency rules
+   - docs/TERMINOLOGY.md — canonical names (host, environments, services, branches)
 
 2. **Project orientation:**
    - Branching: `main` (prod) ← `dev` (integration) ← `feature/issue-N-*` (your work)
@@ -322,6 +323,7 @@ const result = await pool.query(`SELECT * FROM posts WHERE id = ${postId}`);
 - **Database schema** → `docs/DATABASE.md`
 - **Auth deep-dive** → `docs/SECURITY.md`
 - **Naming & code patterns** → `docs/STYLE_GUIDE.md`
+- **Canonical names (host, environments, services)** → `docs/TERMINOLOGY.md`
 - **Branching rules** → README.md
 - **Dependency rules** → `docs/DEPENDENCIES.md`
 - **AI working instructions** → `docs/AI.md` (scope discipline, commit hygiene, workflow)

--- a/PROJECT_ASSESSMENT.md
+++ b/PROJECT_ASSESSMENT.md
@@ -1,6 +1,6 @@
 # Project Assessment
 
-_Last updated: 2026-05-07_
+_Last updated: 2026-05-16_
 
 This document is a frank self-assessment of the current state of MyPortfolioSite — what is working well, what is fragile, where technical debt lives, and what would benefit most from attention. It is written to be honest rather than flattering.
 
@@ -81,8 +81,8 @@ This document is a frank self-assessment of the current state of MyPortfolioSite
 
 ### Reliability
 
-- **PM2 provides basic process supervision.** If the Node process crashes, PM2 restarts it. This is the minimum viable reliability for a personal site.
-- **Nginx handles static files independently.** Even if the Node backend crashes, static pages would theoretically still be served by Nginx. In practice, most pages rely on API calls, so this is limited comfort.
+- **Docker Compose provides process supervision.** Since the migration off PM2 (#165/#171/#179), the backend runs under Docker with a restart policy — if the container exits, Docker restarts it. This is the minimum viable reliability for a personal site and is now consistent between dev and prod.
+- **Nginx handles static files independently.** The Nginx container serves static pages even if the backend container is down. In practice, most pages rely on API calls, so this is limited comfort.
 - **No automated SSL renewal monitoring.** Let's Encrypt auto-renews via a systemd timer, but there is no alert if renewal silently fails. The first sign of a problem would be a browser HTTPS warning — not ideal.
 - **No automated host health monitoring.** There is no alerting on CPU, memory, disk space, or process health. If the server disk fills up, nothing will warn you before the site goes down.
 
@@ -94,8 +94,8 @@ This document is a frank self-assessment of the current state of MyPortfolioSite
 
 ### Performance
 
-- **Performance is not currently a concern.** Traffic is low, the stack is efficient (Nginx serves static files directly, Node only handles API calls), and PostgreSQL is not under load. The server is adequate for current usage.
-- **No image optimisation.** Uploaded images are stored and served at their original size. For a travel site with multiple photos per post, this will become noticeable as content grows.
+- **Performance is not a concern, and the previous resource ceiling is gone.** The migration from the Raspberry Pi to the Ubuntu Server (`ak-home-server`) removed the constrained-hardware worry that dominated earlier assessments. Traffic is low, the stack is efficient (Nginx serves static files directly, Node only handles API calls), PostgreSQL is not under load, and the server now has substantial CPU/RAM headroom relative to the workload. Resource exhaustion is no longer a realistic risk for current or foreseeable usage.
+- **No image optimisation.** Uploaded images are stored and served at their original size. With ample server headroom this is no longer a performance risk, but it still wastes bandwidth and slows page loads for visitors as content grows — a UX concern rather than a capacity one.
 - **No caching headers on static assets.** Nginx likely serves static files without long-lived cache headers, meaning repeat visitors re-download assets on every visit.
 
 **Overall reliability/observability rating: Red-Amber.** The site works but is flying blind in production. No backups, no health checks, no alerting, no log strategy. For a personal site this is acceptable risk; for anything more important it would not be.
@@ -179,5 +179,6 @@ It should **not** be updated for every PR or minor fix. It is a baseline snapsho
 
 ## 9. Change log
 
+- **2026-05-16** — Post-migration reassessment. Corrected statements that the earlier terminology pass left factually stale: §4 now describes Docker Compose (not PM2) as the process supervisor, consistent with the completed migration; the performance subsection now reflects that the Raspberry Pi resource ceiling is gone and the Ubuntu Server has substantial headroom, downgrading image-optimisation from a capacity risk to a UX/bandwidth concern.
 - **2026-05-07 (updated)** — Refined AI-readiness rating from Green-Amber to Amber based on real-world friction observed in agent sessions. Elevated priority of infrastructure docs and clarified frontend testing constraints. Updated improvement opportunities ordering to reflect agent friction alongside operational risk.
 - **2026-05-07** — Initial assessment written based on `dev` branch state, covering architecture, codebase health, DX, reliability, security, and AI readiness.

--- a/PROJECT_ASSESSMENT.md
+++ b/PROJECT_ASSESSMENT.md
@@ -22,14 +22,14 @@ This document is a frank self-assessment of the current state of MyPortfolioSite
 
 ### Weaknesses and risks
 
-- **Single-node, single-point-of-failure production.** Everything runs on one Raspberry Pi. There is no redundancy, no failover, and no easy rollback if a deploy breaks the server. A bad deploy to `main` means the site is down until manually fixed over SSH.
-- **Production is not containerised.** Local dev uses Docker Compose cleanly, but production runs PM2 directly on the Pi. This means the dev and prod environments are structurally different, which is a source of "works locally, breaks in prod" risk. Moving prod to Docker is the right next step.
-- **No database backups.** There is no automated backup of the PostgreSQL data on the Pi. If the SD card dies or the Pi is lost, all blog posts, travel entries, and user data are gone permanently.
-- **Uploads are stored on the Pi filesystem.** User-uploaded images (`/uploads`) live directly on the Pi with no backup, no CDN, and no size/type validation beyond what multer provides. This is fine for now but will become a problem as content grows.
+- **Single-node, single-point-of-failure production.** Everything runs on one Ubuntu Server (`ak-home-server`). There is no redundancy, no failover, and no easy rollback if a deploy breaks the server. A bad deploy to `main` means the site is down until manually fixed over SSH.
+- **Production is containerised (migration complete).** Both dev and prod now run on Docker Compose, closing the structural dev/prod gap that previously caused "works locally, breaks in prod" risk. The original Raspberry Pi + PM2 setup has been retired (#165/#171/#179); residual risk is now operational (script-driven deploys — see ROADMAP §3.5) rather than architectural.
+- **No database backups.** There is no automated backup of the PostgreSQL data on the server. If the disk dies or the server is lost, all blog posts, travel entries, and user data are gone permanently.
+- **Uploads are stored on the server filesystem.** User-uploaded images (`/uploads`) live directly on the server with no backup, no CDN, and no size/type validation beyond what multer provides. This is fine for now but will become a problem as content grows.
 - **No staging environment.** `dev` branch is tested locally in Docker but there is no equivalent of the prod environment to test against before merging to `main`. The dual-environment work in the roadmap (Issues #151/#159) directly addresses this.
 - **The schema has no migration versioning.** Re-running `schema.sql` is safe but there is no record of what version the live database is at. As the schema grows, this becomes harder to manage without a tool like `node-postgres-migrate` or Flyway.
 
-**Overall architecture rating: Amber.** Solid for a personal project at this stage; the Pi + no-backup + no-staging combination is the biggest real risk.
+**Overall architecture rating: Amber.** Solid for a personal project at this stage; the single-server + no-backup + no-staging combination is the biggest real risk.
 
 ---
 
@@ -67,8 +67,8 @@ This document is a frank self-assessment of the current state of MyPortfolioSite
 
 ### Pain points
 
-- **SSH from Windows to Pi is not frictionless.** Key authentication sometimes fails, requiring password fallback. This breaks the automation story — `prod-deploy.ps1` should be a one-command operation, and any time it requires manual intervention it erodes confidence in the workflow.
-- **Production deploy has no visible outcome.** After running `prod-deploy.ps1`, you have to separately SSH to the Pi to check PM2 status and Nginx logs to confirm the deploy worked. There is no success/failure signal back to the developer's terminal in a clear, structured way.
+- **SSH from Windows to the server is not frictionless.** Key authentication sometimes fails, requiring password fallback. This breaks the automation story — `prod-deploy.ps1` should be a one-command operation, and any time it requires manual intervention it erodes confidence in the workflow.
+- **Production deploy has no visible outcome.** After running `prod-deploy.ps1`, you have to separately SSH to the server to check container and Nginx logs to confirm the deploy worked. There is no success/failure signal back to the developer's terminal in a clear, structured way. (Tracked in ROADMAP §3.5.)
 - **There is no health check URL.** There is no `/api/health` endpoint that returns a structured response (app status, DB connectivity, version). This means the only way to confirm a deploy succeeded is to manually test the site. A health check would take 10 minutes to add and dramatically improve deploy confidence.
 - **The admin panel has grown without a clear UX model.** It handles blog posts, travel posts, CV upload, deploy triggers, and stats in one page. Functionally fine for one user; but navigating it is increasingly "just knowing where things are" rather than following an obvious structure.
 - **Agent context resets every session.** Each new Claude session must re-read all the docs from scratch. The onboarding prompt handles this well, but long sessions where the context fills up risk agents losing track of earlier decisions. Devlogs (Issues linked in earlier sessions) help mitigate this but require discipline to maintain.
@@ -84,17 +84,17 @@ This document is a frank self-assessment of the current state of MyPortfolioSite
 - **PM2 provides basic process supervision.** If the Node process crashes, PM2 restarts it. This is the minimum viable reliability for a personal site.
 - **Nginx handles static files independently.** Even if the Node backend crashes, static pages would theoretically still be served by Nginx. In practice, most pages rely on API calls, so this is limited comfort.
 - **No automated SSL renewal monitoring.** Let's Encrypt auto-renews via a systemd timer, but there is no alert if renewal silently fails. The first sign of a problem would be a browser HTTPS warning — not ideal.
-- **No automated Pi health monitoring.** There is no alerting on CPU, memory, disk space, or process health. If the Pi SD card fills up (a known Raspberry Pi failure mode), nothing will warn you before the site goes down.
+- **No automated host health monitoring.** There is no alerting on CPU, memory, disk space, or process health. If the server disk fills up, nothing will warn you before the site goes down.
 
 ### Observability
 
-- **Logging is minimal.** PM2 captures stdout/stderr, but there is no structured logging, no log rotation policy, and no centralised view. Debugging a production issue requires SSHing to the Pi and tailing logs manually.
+- **Logging is minimal.** Docker captures stdout/stderr, but there is no structured logging, no log rotation policy, and no centralised view. Debugging a production issue requires SSHing to the server and tailing container logs manually. (Tracked in ROADMAP §3.5.)
 - **No metrics.** There is no tracking of request counts, error rates, response times, or API usage. The `stats.js` route exists but its scope is limited.
 - **The admin deploy console is the nearest thing to an ops dashboard.** This is a good foundation but it currently only shows deploy output, not runtime health.
 
 ### Performance
 
-- **Performance is not currently a concern.** Traffic is low, the stack is efficient (Nginx serves static files directly, Node only handles API calls), and PostgreSQL is not under load. The Pi is adequate for current usage.
+- **Performance is not currently a concern.** Traffic is low, the stack is efficient (Nginx serves static files directly, Node only handles API calls), and PostgreSQL is not under load. The server is adequate for current usage.
 - **No image optimisation.** Uploaded images are stored and served at their original size. For a travel site with multiple photos per post, this will become noticeable as content grows.
 - **No caching headers on static assets.** Nginx likely serves static files without long-lived cache headers, meaning repeat visitors re-download assets on every visit.
 
@@ -119,7 +119,7 @@ This document is a frank self-assessment of the current state of MyPortfolioSite
 - **The deploy endpoint (`/api/deploy`) is high-value and must remain tightly protected.** A compromise of the JWT that gates this route would give an attacker the ability to trigger deploys. This endpoint should be audited specifically as part of any security review.
 - **No Content Security Policy (CSP) headers.** Nginx does not appear to set CSP headers. This is a meaningful XSS mitigation that is missing.
 - **Uploaded files are served from the same origin.** If a malicious file were uploaded (e.g., an SVG with embedded script), it could be served directly. Input validation on uploads should be reviewed.
-- **The Pi itself is the weakest link.** The Pi is a home-hosted server with a dynamic IP. Physical access, SD card health, and home network security are all outside the application's control but affect the overall security posture.
+- **The server itself is the weakest link.** It is a home-hosted machine (`ak-home-server`) with a dynamic IP. Physical access, disk health, and home network security are all outside the application's control but affect the overall security posture.
 - **AI Lab will add new attack surface.** Once implemented, the AI Lab introduces API keys for Perplexity and Anthropic, prompt injection risk, and potential for resource abuse. The auth-token gating planned in Issue #15 is necessary but not sufficient — the Lab endpoints will need their own threat model.
 
 **Overall security rating: Amber.** Auth is solid; infrastructure and headers need attention; AI Lab will require a dedicated security review before launch.
@@ -141,7 +141,7 @@ This is an unusual section for a project assessment, but it is directly relevant
 
 - **No architecture diagram.** There is no visual representation of how the pieces fit together. Agents (and new humans) must construct a mental model from reading code. A simple `docs/ARCHITECTURE.md` with an ASCII or Mermaid diagram of Nginx → Node → PostgreSQL and the file structure would reduce onboarding time.
 - **`admin.html` is hard for agents to modify safely.** Its size and mixed concerns mean agents often request clarification or make overly conservative changes. Splitting it into logical sections or extracting JS modules would help. This is a concrete friction point that affects every session where admin changes are needed.
-- **Implicit Pi-specific knowledge.** Several operational facts are not written down: the exact PM2 service name, where Nginx config files live on the Pi, how `ddclient` is configured, where the Let's Encrypt certs are. An agent asked to diagnose a production issue would be guessing at these. A short `docs/INFRASTRUCTURE.md` would close this gap. This is more impactful than the current assessment suggests — agents need this to be operationally independent without asking the owner for facts.
+- **Implicit server-specific knowledge.** Several operational facts (Compose service names, where Nginx config files live on the server, how `ddclient` is configured, where the Let's Encrypt certs are) were previously undocumented. This is now captured in `docs/INFRASTRUCTURE.md` and `docs/TERMINOLOGY.md`; keep them current so agents can diagnose production issues without asking the owner for facts.
 - **Context window pressure in long sessions.** The doc suite is thorough but also long. In extended sessions, earlier context (especially specific file contents read at the start) can be lost. This is a fundamental LLM constraint, not a fixable problem, but it means breaking work into smaller issues (which the project already does well) is especially important here.
 - **No structured way for agents to flag "I am not sure about this."** When an agent is uncertain, it either proceeds (risky) or asks (slows things down). A convention like "if in doubt, raise a GitHub issue with the `needs-decision` label and stop" would help, but this is aspirational rather than current practice.
 
@@ -154,14 +154,14 @@ This is an unusual section for a project assessment, but it is directly relevant
 These are ordered by impact-to-effort ratio, considering both operational risk and agent friction.
 
 **High priority (operational + agent enablement):**
-1. **Write `docs/INFRASTRUCTURE.md`** — a short document covering PM2 service name, Nginx config paths, cert locations, ddclient config, and any other Pi-specific facts that currently live only in someone's head. Directly improves agent effectiveness in production debugging scenarios and is a prerequisite for safe agent-driven troubleshooting.
-2. **Containerise production (move prod to Docker Compose on Pi)** — aligns dev and prod environments, makes deploys predictable, reduces friction from environment gaps, and is a prerequisite for the dual-environment setup in the roadmap.
+1. ✅ **Done — `docs/INFRASTRUCTURE.md` written** (Compose service names, Nginx config paths, cert locations, ddclient config and other server-specific facts). Now complemented by `docs/TERMINOLOGY.md`. Keep both current.
+2. ✅ **Done — production containerised** (migrated off the Raspberry Pi to Ubuntu Server, Docker Compose; #165/#171/#179). Dev and prod environments are now aligned. Residual risk is operational (script-driven deploys — ROADMAP §3.5).
 3. **Add a `/api/health` endpoint** — 30 minutes of work, dramatically improves deploy confidence and sets the foundation for future monitoring. Should return `{ status: "ok", db: "ok", version: "..." }`.
 
 **High priority (security + agent friction):**
 4. **Add CSP and security headers to Nginx config** — one Nginx config block; meaningfully improves XSS and clickjacking protection with minimal risk.
 
-**Note on backups:** Database backups are critically important, but will be implemented holistically during the Ubuntu Server migration (#171) with a proper backup + offsite strategy.
+**Note on backups:** Database backups are critically important. The Ubuntu Server migration (#171) is complete, but a hardened backup + offsite strategy is still outstanding — tracked in ROADMAP §4.5 (pgBackRest / `pg_dump` + restic/rclone).
 
 ---
 
@@ -169,7 +169,7 @@ These are ordered by impact-to-effort ratio, considering both operational risk a
 
 This document should be updated when:
 
-- The architecture changes meaningfully (e.g. moving from Pi to mini PC, adding Docker to prod, introducing a new major component).
+- The architecture changes meaningfully (e.g. a major hosting change, introducing a new major component).
 - A significant area of technical debt is resolved (mark it as addressed, update the rating).
 - A new risk is identified that is not captured here.
 

--- a/PROJECT_ASSESSMENT.md
+++ b/PROJECT_ASSESSMENT.md
@@ -67,7 +67,6 @@ This document is a frank self-assessment of the current state of MyPortfolioSite
 
 ### Pain points
 
-- **SSH from Windows to the server is not frictionless.** Key authentication sometimes fails, requiring password fallback. This breaks the automation story — `prod-deploy.ps1` should be a one-command operation, and any time it requires manual intervention it erodes confidence in the workflow.
 - **Production deploy has no visible outcome.** After running `prod-deploy.ps1`, you have to separately SSH to the server to check container and Nginx logs to confirm the deploy worked. There is no success/failure signal back to the developer's terminal in a clear, structured way. (Tracked in ROADMAP §3.5.)
 - **There is no health check URL.** There is no `/api/health` endpoint that returns a structured response (app status, DB connectivity, version). This means the only way to confirm a deploy succeeded is to manually test the site. A health check would take 10 minutes to add and dramatically improve deploy confidence.
 - **The admin panel has grown without a clear UX model.** It handles blog posts, travel posts, CV upload, deploy triggers, and stats in one page. Functionally fine for one user; but navigating it is increasingly "just knowing where things are" rather than following an obvious structure.
@@ -179,6 +178,6 @@ It should **not** be updated for every PR or minor fix. It is a baseline snapsho
 
 ## 9. Change log
 
-- **2026-05-16** — Post-migration reassessment. Corrected statements that the earlier terminology pass left factually stale: §4 now describes Docker Compose (not PM2) as the process supervisor, consistent with the completed migration; the performance subsection now reflects that the Raspberry Pi resource ceiling is gone and the Ubuntu Server has substantial headroom, downgrading image-optimisation from a capacity risk to a UX/bandwidth concern.
+- **2026-05-16** — Post-migration reassessment. Corrected statements that the earlier terminology pass left factually stale: §4 now describes Docker Compose (not PM2) as the process supervisor, consistent with the completed migration; the performance subsection now reflects that the Raspberry Pi resource ceiling is gone and the Ubuntu Server has substantial headroom, downgrading image-optimisation from a capacity risk to a UX/bandwidth concern. Removed the "SSH from Windows is not frictionless" DX pain point — key auth has stabilised and is now reliable.
 - **2026-05-07 (updated)** — Refined AI-readiness rating from Green-Amber to Amber based on real-world friction observed in agent sessions. Elevated priority of infrastructure docs and clarified frontend testing constraints. Updated improvement opportunities ordering to reflect agent friction alongside operational risk.
 - **2026-05-07** — Initial assessment written based on `dev` branch state, covering architecture, codebase health, DX, reliability, security, and AI readiness.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # andykeys.me — Personal Portfolio Site
 
-A full-stack personal portfolio site built with plain HTML/CSS/JS on the frontend and a Node.js/Express backend, self-hosted on a Raspberry Pi at [andykeys.me](https://andykeys.me).
+A full-stack personal portfolio site built with plain HTML/CSS/JS on the frontend and a Node.js/Express backend, self-hosted on an Ubuntu Server (`ak-home-server`) at [andykeys.me](https://andykeys.me).
 
 ---
 
@@ -17,7 +17,7 @@ A full-stack personal portfolio site built with plain HTML/CSS/JS on the fronten
 | Runtime | Docker Compose (backend + Postgres + Nginx containerised) |
 | SSL | Let's Encrypt (certbot, auto-renewing) |
 | DNS | Namecheap + dynamic DNS (ddclient) |
-| Hosting | Self-hosted, Raspberry Pi |
+| Hosting | Self-hosted, Ubuntu Server (`ak-home-server`) |
 | AI pair programmer | Claude (Anthropic) |
 
 ---
@@ -186,7 +186,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 .\scripts\deploy\prod-deploy.ps1
 ```
 
-This SSHs into the Pi and runs `scripts/deploy/prod-deploy.sh`, which:
+This SSHs into the server (`ak-home-server`) and runs `scripts/deploy/prod-deploy.sh`, which:
 1. Fetches and lists what changed
 2. Pulls the latest code
 3. Pulls the target branch and rebuilds images
@@ -240,7 +240,7 @@ scripts/
 │   ├── debug-network.sh    Network diagnostics helper
 │   └── watch-logs.sh       Tail multiple log streams
 ├── deploy/
-│   ├── prod-deploy.sh      Smart deploy — runs on Pi, detects what changed
+│   ├── prod-deploy.sh      Smart deploy — runs on the server, detects what changed
 │   ├── prod-deploy.ps1     Trigger deploy from Windows via SSH
 │   ├── pi-setup.sh         Full server setup from scratch
 │   ├── install-monitor.sh  Install monitoring tooling

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ The goals for the project are:
 
 - Turn the site into a reliable home for my content (blog, travel, devlogs) with low-friction publishing.
 - Evolve the AI Lab into a genuinely useful personal tool for research, coding, and project planning.
-- Mature the infrastructure from “Pi experiment” to a stable, observable service, eventually on a mini PC.
+- Mature the infrastructure into a stable, observable service (migration off the original Raspberry Pi to Ubuntu Server is complete; see §5.1).
 - Reduce operational friction (deployments, SSH, certs) so changes are safe and quick to ship.
 
 ## 2. Current state snapshot
@@ -19,7 +19,7 @@ The goals for the project are:
 
 - Node/Express backend serving static HTML/CSS/JS pages.
 - PostgreSQL database backing blog/travel content and admin features.
-- Hosted on a Raspberry Pi (Docker + Nginx reverse proxy + Let’s Encrypt TLS).
+- Hosted on an Ubuntu Server (`ak-home-server`) — Docker Compose + Nginx reverse proxy + Let’s Encrypt TLS. (Migrated off the original Raspberry Pi; see §5.1.)
 - Single production environment; dev work is mostly local.
 
 **Features**
@@ -31,9 +31,9 @@ The goals for the project are:
 
 **Pain points**
 
-- Deployments are still somewhat manual and Pi-centric.
+- Deployments are still somewhat manual and script-centric.
 - SSH key authentication from Windows is not yet frictionless.
-- Pi resource ceiling limits what can run concurrently (especially with future AI experiments).
+- Single-server resource ceiling limits what can run concurrently (especially with future AI experiments).
 - Limited observability (minimal metrics/logs surfaced in UI).
 
 ## 3. Near-term priorities
@@ -44,7 +44,7 @@ The goals for the project are:
 
 - Implement the dual-environment setup described in Issue #151 / #159:
   - Production on `main` via Nginx → Docker service bound to loopback.
-  - Dev/staging on `dev` via LAN-only port on the Pi.
+  - Dev/staging on `dev` via LAN-only port on the server (`ak-home-server`).
 - Extend the admin console to:
   - Show status for both environments.
   - Trigger “Pull & Restart” for prod and dev separately.
@@ -68,7 +68,7 @@ The goals for the project are:
 
 ### 3.3 Quality-of-life fixes
 
-- Fix SSH key auth from Windows to Pi so passwordless login works reliably.
+- Fix SSH key auth from Windows to the server (`ak-home-server`) so passwordless login works reliably.
 - Simplify deployment scripts and document the standard path (admin console as the primary interface).
 - Tidy up small UI/UX issues in admin and public pages as they surface.
 
@@ -114,7 +114,7 @@ The highest-priority near-term item (see the sequencing principle above). Deploy
 ### 4.2 Observability and reliability
 
 - Surface basic metrics in the admin console:
-  - Request counts, error counts, uptime, Pi CPU/RAM usage.
+  - Request counts, error counts, uptime, server CPU/RAM usage.
 - Add simple health checks and status indicators:
   - App, DB, disk space, SSL status.
 
@@ -190,12 +190,19 @@ Beyond the CI/CD pipeline (§4.4), several existing pain points and open issues 
 
 ## 5. Longer-term ideas
 
-### 5.1 Move from Pi to mini PC
+### 5.1 Move off the Raspberry Pi — ✅ Completed (2026-05)
 
-- Migrate hosting from Raspberry Pi to a more capable mini PC:
-  - Reuse Docker + Nginx + Postgres pattern.
-  - Keep deployment and admin model consistent.
-- Take the opportunity to tighten backup/restore and monitoring.
+Hosting was migrated from the original Raspberry Pi to an Ubuntu Server
+(`ak-home-server`, a repurposed gaming PC) and fully containerised with
+Docker Compose. The Docker + Nginx + Postgres pattern and the
+deployment/admin model were kept consistent. See `docs/INFRASTRUCTURE.md`
+for the current host layout and `docs/RELEASE_NOTES.md` for the migration
+record (#171).
+
+Remaining follow-ups from this milestone are tracked elsewhere:
+
+- Backup/restore hardening — see §4.5 (pgBackRest / `pg_dump` + restic/rclone).
+- Monitoring/observability — see §3.5 and §4.2.
 
 ### 5.2 Local AI capabilities
 
@@ -253,7 +260,7 @@ Speculative, not committed — captured so good ideas are not lost. To be promot
 
 ## 6. Risks and assumptions
 
-- **Pi resource limits:** Running multiple containers and AI features on the Pi will be tight; the mini PC migration is assumed.
+- **Host resource limits:** Running multiple containers and AI features concurrently on the single Ubuntu Server (`ak-home-server`) may be tight; heavier workloads could need dedicated resources. (The original Raspberry Pi has already been retired — see §5.1.)
 - **Time vs scope:** The roadmap assumes part-time work; priorities may be adjusted as reality dictates.
 - **External dependencies:** Perplexity and Anthropic APIs are central to AI Lab plans; changes in their pricing or features could affect direction.
 

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -120,6 +120,8 @@ Once implementation is complete:
 
 The AI does not merge PRs — you will review, test locally, and merge when ready.
 
+**Recommend a squash commit message with every PR.** After opening the PR, post (in the PR description or as a chat reply) a ready-to-copy squash commit message for the owner to paste when squash-merging on test completion. The repo merges via squash, so the PR's individual commits are discarded — this message becomes the permanent history entry. Format it the same as a normal commit: imperative summary ≤50 chars, blank line, a short body covering what changed and why, and the `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` footer. Present it in a fenced code block so it can be copied verbatim.
+
 **PR test plans must include:**
 - Specific steps to verify the happy path (e.g. exact URL, action, expected result)
 - Edge cases to check (e.g. empty state, error handling, mobile view)

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -257,7 +257,7 @@ curl.exe -s -X POST http://localhost/api/contact `
   -d '{\"name\":\"Test\",\"email\":\"test@example.com\",\"message\":\"Hello\"}'
 ```
 
-- Bash scripts (`*.sh`) are still used for Pi/server-side operations and Docker. When providing commands intended to run on the Pi or inside a container, Bash syntax is correct. When providing commands to run on your local Windows machine, use PowerShell.
+- Bash scripts (`*.sh`) are still used for server-side operations and Docker. When providing commands intended to run on the server (`ak-home-server`) or inside a container, Bash syntax is correct. When providing commands to run on your local Windows machine, use PowerShell.
 
 ## Code Style
 
@@ -416,7 +416,7 @@ When working with this project:
 - **Frontend:** No build step — vanilla JS/HTML/CSS with jQuery for compatibility
 - **Stack:** Node.js/Express backend, WebAuthn/JWT auth, fully containerised (Docker Compose — PM2 retired, #165/#179)
 - **Deployment:** Script-driven Docker Compose deploy (`prod-deploy.sh` → `docker compose -f docker-compose.prod.yml up -d --build`); rebuilds and recreates affected containers
-- **Terminal:** Developer uses PowerShell on Windows. Provide PowerShell-compatible commands for local machine operations. Bash is correct for Pi/server/container operations.
+- **Terminal:** Developer uses PowerShell on Windows. Provide PowerShell-compatible commands for local machine operations. Bash is correct for server (`ak-home-server`) / container operations.
 - **Testing:** All tests run inside the Docker backend container via `docker compose exec`. Never instruct the developer to run `npm test` directly on their local machine.
 
 See README.md for full details, scripts, and local dev setup.
@@ -429,9 +429,10 @@ See README.md for full details, scripts, and local dev setup.
 4. Check [docs/DATABASE.md](docs/DATABASE.md) before adding or changing any routes, migrations, or queries
 5. Check [docs/SECURITY.md](docs/SECURITY.md) before touching auth, sessions, or input handling
 6. Check [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md) before adding, updating, or removing a dependency
-7. Check `.github/pull_request_template.md` when raising a PR — every section must be filled in
-8. Check `.github/ISSUE_TEMPLATE/` when creating an issue — use `bug_report.md` or `feature_request.md` as appropriate
-9. Review recent commits to match code style
-10. Ask: "Is this change isolated, testable, and reversible?"
-11. If a task is too large, break it into smaller PRs
-12. Test inside the Docker container before proposing changes — use `. scripts\dev\dev-local.ps1 test`
+7. Check [docs/TERMINOLOGY.md](docs/TERMINOLOGY.md) for the canonical name of the host, environments, services, or branches — never invent or reuse old names (e.g. "the Pi", `portfolio-server`)
+8. Check `.github/pull_request_template.md` when raising a PR — every section must be filled in
+9. Check `.github/ISSUE_TEMPLATE/` when creating an issue — use `bug_report.md` or `feature_request.md` as appropriate
+10. Review recent commits to match code style
+11. Ask: "Is this change isolated, testable, and reversible?"
+12. If a task is too large, break it into smaller PRs
+13. Test inside the Docker container before proposing changes — use `. scripts\dev\dev-local.ps1 test`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,7 +237,7 @@ As an example of how the system works end-to-end:
 |-----------|------|--------|-----------|
 | `admin.html` | Large, monolithic, high-risk to modify | Changes risk breaking multiple features | Refactoring planned (#175) |
 | `auth.js` | Complex WebAuthn + JWT state machine | Auth bugs have security implications | High test coverage, careful code review |
-| PostgreSQL (single instance) | No replication, no backup | Data loss if SD card fails | Backups planned for Ubuntu migration (#164) |
+| PostgreSQL (single instance) | No replication, no backup | Data loss if the server disk fails | Backup hardening outstanding — see ROADMAP §4.5 (#164) |
 | Nginx reverse proxy | Single point of failure | If Nginx breaks, entire site is down | Keep Nginx config simple and tested |
 | PM2 (process manager) | Limited visibility into errors | Crashes not always obvious | Health endpoint planned (#163) |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,9 +13,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Rate limiting on auth endpoints: `/auth/email/send` (5/hr/IP), passkey register/login (10/hr/IP) (#237)
 - Magic-link recipient gate: tokens only sent to `ADMIN_EMAIL`; other addresses get the same success response with no email (anti-enumeration) (#241)
 - `OUTLOOK_*` env vars wired through all three compose files and documented in every `.env*.example`
+- `docs/TERMINOLOGY.md` — canonical names for host, hostnames, environments, services, and branches; wired into the onboarding doc lists
 
 ### Changed
 - Email transport: SMTP basic auth → Outlook OAuth2 (Graph API). Microsoft disabled SMTP basic auth; `nodemailer` SMTP retained only as a fallback for non-Outlook providers
+- Documentation: replaced stale "Raspberry Pi" / `portfolio-server` host references with the canonical "Ubuntu Server (`ak-home-server`)" across README, CLAUDE.md, ROADMAP, PROJECT_ASSESSMENT, AI.md, and deploy/monitor script comments (migration off the Pi is complete; #171). Historical records (CHANGELOG, RELEASE_NOTES, lessons-learned) left intact. `scripts/infra/pi-setup.sh` marked deprecated in favour of `scripts/deploy/server-setup.sh`
 - `.env*.example`: OAuth2 promoted to the primary email method, SMTP demoted to documented fallback
 
 ### Removed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Email transport: SMTP basic auth → Outlook OAuth2 (Graph API). Microsoft disabled SMTP basic auth; `nodemailer` SMTP retained only as a fallback for non-Outlook providers
 - Documentation: replaced stale "Raspberry Pi" / `portfolio-server` host references with the canonical "Ubuntu Server (`ak-home-server`)" across README, CLAUDE.md, ROADMAP, PROJECT_ASSESSMENT, AI.md, and deploy/monitor script comments (migration off the Pi is complete; #171). Historical records (CHANGELOG, RELEASE_NOTES, lessons-learned) left intact. Pi-era infra scripts marked deprecated in favour of `scripts/deploy/server-setup.sh` + the containerised Nginx setup: `scripts/infra/pi-setup.sh`, `setup-nginx-ssl.ps1`, `setup-ssl.ps1`, `fix-apache.ps1`
 - `.env*.example`: OAuth2 promoted to the primary email method, SMTP demoted to documented fallback
+- `PROJECT_ASSESSMENT.md`: post-migration reassessment — corrected stale PM2/performance statements and removed the resolved SSH-from-Windows pain point
+- Working instructions (`docs/AI.md`, `CLAUDE.md`): after opening a PR, recommend a ready-to-copy squash commit message for the owner to apply on merge
 
 ### Removed
 - `docker/.env.example` — duplicate of root `.env.example`; README updated to reference the canonical file

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 
 ### Changed
 - Email transport: SMTP basic auth → Outlook OAuth2 (Graph API). Microsoft disabled SMTP basic auth; `nodemailer` SMTP retained only as a fallback for non-Outlook providers
-- Documentation: replaced stale "Raspberry Pi" / `portfolio-server` host references with the canonical "Ubuntu Server (`ak-home-server`)" across README, CLAUDE.md, ROADMAP, PROJECT_ASSESSMENT, AI.md, and deploy/monitor script comments (migration off the Pi is complete; #171). Historical records (CHANGELOG, RELEASE_NOTES, lessons-learned) left intact. `scripts/infra/pi-setup.sh` marked deprecated in favour of `scripts/deploy/server-setup.sh`
+- Documentation: replaced stale "Raspberry Pi" / `portfolio-server` host references with the canonical "Ubuntu Server (`ak-home-server`)" across README, CLAUDE.md, ROADMAP, PROJECT_ASSESSMENT, AI.md, and deploy/monitor script comments (migration off the Pi is complete; #171). Historical records (CHANGELOG, RELEASE_NOTES, lessons-learned) left intact. Pi-era infra scripts marked deprecated in favour of `scripts/deploy/server-setup.sh` + the containerised Nginx setup: `scripts/infra/pi-setup.sh`, `setup-nginx-ssl.ps1`, `setup-ssl.ps1`, `fix-apache.ps1`
 - `.env*.example`: OAuth2 promoted to the primary email method, SMTP demoted to documented fallback
 
 ### Removed

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -51,7 +51,10 @@ Production DB name: `portfolio`. Dev DB name: `portfolio_dev`.
 | Use this | Notes |
 |----------|-------|
 | **`scripts/deploy/server-setup.sh`** | Current one-shot Ubuntu Server provisioning (Docker). |
-| ~~`scripts/infra/pi-setup.sh`~~ | **Deprecated.** Original Raspberry Pi provisioning (PM2). Kept for historical reference only — do not use or cite as current. |
+| ~~`scripts/infra/pi-setup.sh`~~ | **Deprecated.** Original Raspberry Pi provisioning (PM2). Historical reference only. |
+| ~~`scripts/infra/setup-nginx-ssl.ps1`~~ | **Deprecated.** Pi-era host Nginx/SSL vhost (`raspberrypi3`, PM2). Nginx is containerised now. |
+| ~~`scripts/infra/setup-ssl.ps1`~~ | **Deprecated.** Pi-era host certbot bootstrap. Use `scripts/backup/certbot-renew.sh`. |
+| ~~`scripts/infra/fix-apache.ps1`~~ | **Deprecated.** Pi-era host Apache→Nginx swap. No host web server now. |
 
 ## Access
 

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -1,0 +1,71 @@
+# Terminology
+
+Canonical names for this project. **Use these exact terms in all docs, comments, commit messages, and instructions.** If you find an old or inconsistent name, fix it (except in historical records — see the bottom of this file).
+
+This file is the single source of truth for naming. `docs/INFRASTRUCTURE.md` describes the host layout in detail; this file just fixes the vocabulary.
+
+---
+
+## Host / hardware
+
+| Use this | Not this | Notes |
+|----------|----------|-------|
+| **Ubuntu Server (`ak-home-server`)** on first mention; **"the server"** thereafter | "the Pi", "Raspberry Pi", "the gaming PC", "mini PC", "portfolio-server", "home server" | Production host: a repurposed gaming PC running headless Ubuntu Server LTS. The original Raspberry Pi has been **retired** (migration completed 2026-05; #171). |
+| **`ak-home-server`** | `portfolio-server` | The SSH hostname. `portfolio-server` was the old name, removed in #179. Always `ak-home-server` in commands, scripts, and variables. |
+
+The Raspberry Pi is only mentioned to say it is no longer used, or in historical records.
+
+## Environments
+
+| Use this | Meaning |
+|----------|---------|
+| **production** (or **prod**) | `main` branch, public, HTTPS on 80/443. Compose file `docker-compose.prod.yml`. Repo dir `~/MyPortfolioSite/`. |
+| **dev environment** (or **LAN dev**) | `dev` branch, LAN-only, HTTP on port **3001**. Compose file `docker-compose.dev-server.yml`. Repo dir `~/MyPortfolioSite-dev/`. |
+| **local dev** | A developer's own machine via Docker Compose (`docker-compose.yml`). Distinct from the LAN "dev environment" above. |
+
+Do not call the LAN dev environment "staging" — there is no separate staging tier.
+
+## Docker Compose services
+
+| Environment | Compose file | Service names |
+|-------------|--------------|---------------|
+| production | `docker-compose.prod.yml` | `backend`, `postgres`, `nginx` |
+| dev environment | `docker-compose.dev-server.yml` | `backend-dev`, `postgres-dev`, `nginx-dev` |
+| local dev | `docker-compose.yml` | `backend`, `postgres`, `nginx` |
+
+Production DB name: `portfolio`. Dev DB name: `portfolio_dev`.
+
+## Branches
+
+| Use this | Meaning |
+|----------|---------|
+| **`main`** | Production. Owner merges only. |
+| **`dev`** | Integration branch. Features/fixes PR here first. |
+| **`feature/issue-N-*`** | New feature, one per issue. |
+| **`fix/issue-N-*`** | Bug fix, one per issue. |
+| **`release/YYYY-MM-DD`** | Release staging, PR'd `dev` → `main`. |
+| **`hotfix/issue-N-*`** | Emergency fix, branched from `main`. |
+
+## Scripts
+
+| Use this | Notes |
+|----------|-------|
+| **`scripts/deploy/server-setup.sh`** | Current one-shot Ubuntu Server provisioning (Docker). |
+| ~~`scripts/infra/pi-setup.sh`~~ | **Deprecated.** Original Raspberry Pi provisioning (PM2). Kept for historical reference only — do not use or cite as current. |
+
+## Access
+
+- Normal SSH: `ssh ak-home-server`
+- Disk-decryption after reboot (Dropbear): `ssh -p 2222 root@ak-home-server` then `cryptroot-unlock`
+
+---
+
+## Historical records — do not rewrite
+
+These files intentionally preserve old terms (Pi, `portfolio-server`, PM2) because they describe past events. **Do not "correct" terminology in them:**
+
+- `docs/CHANGELOG.md`
+- `docs/RELEASE_NOTES.md`
+- `docs/DEPLOYMENT_LESSONS_LEARNED.md`
+- Anything under `docs/archive/`
+- Seed-data devlog content (`scripts/dev/seed-dev-data.sh`) that narrates the migration as a story

--- a/scripts/deploy/prod-deploy.ps1
+++ b/scripts/deploy/prod-deploy.ps1
@@ -3,7 +3,7 @@
 # Defaults to main branch — override with -Branch only when intentional.
 #
 # IMPORTANT: If the server has rebooted, decrypt it first via Dropbear:
-#   ssh -p 2222 root@portfolio-server
+#   ssh -p 2222 root@ak-home-server
 #   cryptroot-unlock
 #   (enter disk encryption passphrase, wait for system to boot)
 #

--- a/scripts/infra/debug-network.sh
+++ b/scripts/infra/debug-network.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Network and deployment debug script for andykeys.me
-# Run on the Pi: bash ~/MyPortfolioSite/scripts/debug-network.sh
+# Run on the server (ak-home-server): bash ~/MyPortfolioSite/scripts/debug-network.sh
 # Paste the full output when reporting issues.
 
 BAR="======================================="

--- a/scripts/infra/fix-apache.ps1
+++ b/scripts/infra/fix-apache.ps1
@@ -1,1 +1,10 @@
+# ============================================================
+# DEPRECATED — DO NOT USE
+# ============================================================
+# Pi-era one-off: targets the old `raspberrypi3` SSH alias and
+# swaps host Apache→Nginx. Production now runs on Ubuntu Server
+# (ak-home-server) with containerised Nginx — there is no host
+# Apache/Nginx to fix. Kept for historical reference only.
+# See docs/TERMINOLOGY.md and docs/INFRASTRUCTURE.md.
+# ============================================================
 ssh raspberrypi3 "sudo systemctl stop apache2 && sudo systemctl disable apache2 && sudo systemctl enable nginx && sudo systemctl start nginx && sudo nginx -t && sudo systemctl reload nginx && sudo ss -tlnp | grep :80"

--- a/scripts/infra/pi-setup.sh
+++ b/scripts/infra/pi-setup.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# ============================================================
+# DEPRECATED — DO NOT USE FOR NEW SETUPS
+# ============================================================
+# This script provisioned the ORIGINAL Raspberry Pi 3 host
+# (Raspberry Pi OS / Debian, PM2-based). That host has been
+# retired. Production now runs on Ubuntu Server (ak-home-server)
+# via Docker Compose.
+#
+# For current server provisioning use:
+#   scripts/deploy/server-setup.sh   (Ubuntu Server, Docker)
+#
+# Kept only for historical reference. See docs/TERMINOLOGY.md
+# and docs/INFRASTRUCTURE.md for the current host layout.
+# ============================================================
 # Portfolio site setup script for Raspberry Pi 3 (Raspberry Pi OS / Debian)
 # Run as the 'pi' user: bash pi-setup.sh
 set -e

--- a/scripts/infra/setup-nginx-ssl.ps1
+++ b/scripts/infra/setup-nginx-ssl.ps1
@@ -1,3 +1,19 @@
+# ============================================================
+# DEPRECATED — DO NOT USE
+# ============================================================
+# Pi-era one-shot SSL/Nginx setup: it targets the old `raspberrypi3`
+# SSH alias, writes a HOST Nginx vhost, hardcodes /home/pi/, and
+# restarts PM2 (`pm2 restart portfolio-backend`). None of that
+# reflects the current setup: production runs on Ubuntu Server
+# (ak-home-server) with Nginx + backend in Docker Compose
+# (docker-compose.prod.yml), and the repo lives at ~/MyPortfolioSite
+# (prod) / ~/MyPortfolioSite-dev (dev).
+#
+# Use scripts/deploy/server-setup.sh for provisioning and the
+# containerised Nginx config under scripts/config/ instead.
+# Kept for historical reference only. See docs/TERMINOLOGY.md
+# and docs/INFRASTRUCTURE.md.
+# ============================================================
 ssh raspberrypi3 @'
 set -e
 

--- a/scripts/infra/setup-ssl.ps1
+++ b/scripts/infra/setup-ssl.ps1
@@ -1,3 +1,13 @@
+# ============================================================
+# DEPRECATED — DO NOT USE
+# ============================================================
+# Pi-era SSL bootstrap: targets the old `raspberrypi3` SSH alias
+# and runs host-level certbot/Nginx. Production now runs on Ubuntu
+# Server (ak-home-server) with containerised Nginx; certs are
+# managed via scripts/backup/certbot-renew.sh and the Docker setup.
+# Use scripts/deploy/server-setup.sh for provisioning.
+# Kept for historical reference only. See docs/TERMINOLOGY.md.
+# ============================================================
 ssh raspberrypi3 @'
 set -e
 

--- a/scripts/monitoring/monitor.sh
+++ b/scripts/monitoring/monitor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ============================================================
-# monitor.sh — Resource monitor & self-healing for Pi
+# monitor.sh — Resource monitor & self-healing for the server (ak-home-server)
 # Run via cron every 5 minutes:
 #   */5 * * * * /bin/bash ~/MyPortfolioSite/scripts/monitor.sh 2>&1
 # Also safe to run manually — always writes to ~/logs/monitor.log


### PR DESCRIPTION
## Summary

Docs/comments only. Resolves the contradiction where some docs described the Raspberry Pi as the current host while `INFRASTRUCTURE.md`/`RELEASE_NOTES.md` showed the migration to Ubuntu Server was already complete. Establishes one canonical vocabulary and removes stale references.

Confirmed with owner: **migration off the Pi is complete**; canonical term is **"Ubuntu Server (`ak-home-server`)"**; repo paths are **`~/MyPortfolioSite`** (prod) / **`~/MyPortfolioSite-dev`** (dev).

## Changes

**New:** `docs/TERMINOLOGY.md` — single source of truth for host, hostnames, environments, services, branches, scripts, and repo paths. Wired into the onboarding lists in `CLAUDE.md` and the "When in Doubt" list in `docs/AI.md`.

**Stale → canonical** across `README.md`, `CLAUDE.md`, `ROADMAP.md` (§5.1 reframed as ✅ completed; §2/§6 corrected), `PROJECT_ASSESSMENT.md` (incl. two now-done recommendations marked done), `docs/AI.md`, `docs/ARCHITECTURE.md`:
- "Raspberry Pi" / "the Pi" / "SD card" / "PM2 on Pi" as *current* → "Ubuntu Server (`ak-home-server`)" / "the server" / Docker
- `prod-deploy.ps1` comment: `root@portfolio-server` → `root@ak-home-server`
- `monitor.sh` / `debug-network.sh` comment headers updated

**Deprecated Pi-era infra scripts** (targeted the old `raspberrypi3` host with PM2 + host Nginx — superseded by containerised Ubuntu Server setup; marked, not deleted):
- `scripts/infra/pi-setup.sh`
- `scripts/infra/setup-nginx-ssl.ps1` (also resolved the flagged `/home/pi/` path — whole script is dead, not just that line)
- `scripts/infra/setup-ssl.ps1`
- `scripts/infra/fix-apache.ps1`

**Left intact (historical records):** `CHANGELOG.md`, `RELEASE_NOTES.md`, `DEPLOYMENT_LESSONS_LEARNED.md`, seed-data devlog content — `TERMINOLOGY.md` documents this carve-out.

## Test plan

- [ ] N/A — documentation and comments only; no code paths changed
- [ ] Skim `docs/TERMINOLOGY.md` and confirm canonical names match reality (service names, DB names, ports, repo paths)
- [ ] Confirm the four deprecated scripts are genuinely unused (nothing references them in active flows)

https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM