### PR TITLE
fix: mock pool.js directly in route tests to fix CI

### DIFF
--- a/backend/tests/routes/contact.test.js
+++ b/backend/tests/routes/contact.test.js
@@ -6,12 +6,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import { createApp } from '../../app.js';
 
-// Mock pg pool — contact route uses it for rate-limit checks
-vi.mock('pg', () => {
-  const query = vi.fn();
-  const Pool  = vi.fn(() => ({ query }));
-  return { default: { Pool }, Pool };
-});
+// Mock pool directly — contact route uses it for rate-limit checks
+vi.mock('../../db/pool.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
 
 // Mock nodemailer so no real SMTP is needed
 vi.mock('nodemailer', () => ({
@@ -24,18 +22,12 @@ vi.mock('nodemailer', () => ({
 
 const app = createApp();
 
-const VALID_CONTACT = {
-  name:    'Alice',
-  email:   'alice@example.com',
-  message: 'Hello there',
-};
-
 describe('POST /contact', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     // Default: no existing rate-limit record
-    const { Pool } = vi.mocked(await import('pg'));
-    Pool.mock.results[0]?.value.query.mockResolvedValue({ rows: [] });
+    const { pool } = vi.mocked(await import('../../db/pool.js'));
+    pool.query.mockResolvedValue({ rows: [] });
   });
 
   it('returns 400 with error message when name is missing', async () => {

--- a/backend/tests/routes/posts.test.js
+++ b/backend/tests/routes/posts.test.js
@@ -8,11 +8,9 @@ import request   from 'supertest';
 import jwt        from 'jsonwebtoken';
 import { createApp } from '../../app.js';
 
-vi.mock('pg', () => {
-  const query = vi.fn().mockResolvedValue({ rows: [] });
-  const Pool  = vi.fn(() => ({ query }));
-  return { default: { Pool }, Pool };
-});
+vi.mock('../../db/pool.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
 
 const app = createApp();
 
@@ -35,9 +33,8 @@ describe('POST /posts', () => {
   });
 
   it('returns 400 when title is missing (DB not touched)', async () => {
-    const { Pool } = vi.mocked(await import('pg'));
-    const querySpy = Pool.mock.results[0].value.query;
-    querySpy.mockClear();
+    const { pool } = vi.mocked(await import('../../db/pool.js'));
+    pool.query.mockClear();
 
     const res = await request(app)
       .post('/posts')
@@ -47,7 +44,7 @@ describe('POST /posts', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/title/i);
     // Validation fires before DB — no query should have run
-    expect(querySpy).not.toHaveBeenCalled();
+    expect(pool.query).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/tests/routes/travel.test.js
+++ b/backend/tests/routes/travel.test.js
@@ -6,11 +6,9 @@ import request from 'supertest';
 import jwt      from 'jsonwebtoken';
 import { createApp } from '../../app.js';
 
-vi.mock('pg', () => {
-  const query = vi.fn().mockResolvedValue({ rows: [] });
-  const Pool  = vi.fn(() => ({ query }));
-  return { default: { Pool }, Pool };
-});
+vi.mock('../../db/pool.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
 
 const app = createApp();
 


### PR DESCRIPTION
## Summary

- Replaces `vi.mock('pg', ...)` with `vi.mock('../../db/pool.js', ...)` in all three route test files
- Root cause: `pool.js` calls `new Pool()` at import time; an arrow-function `vi.fn()` can't be used as a constructor, so the mock silently failed and the real `pg` module was used instead
- All 44 tests now pass with no real DB or network required

## Files changed

- `backend/tests/routes/contact.test.js`
- `backend/tests/routes/posts.test.js`
- `backend/tests/routes/travel.test.js`

## Test plan

```bash
# Run inside the backend container (local dev):
docker compose exec backend npm test

# Or directly if deps are installed:
cd backend && JWT_SECRET=test-secret NODE_ENV=test npx vitest run
# Expected: 5 test files, 44 tests — all passed
```

## Squash commit message

```
fix: mock pool.js directly in route tests to fix CI

Arrow-function vi.fn() can't be used as a constructor when pool.js
calls new Pool() at import time. Switching to vi.mock('../../db/pool.js')
sidesteps the constructor entirely — all 44 tests now pass.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM)_