### PR TITLE
feat: automated .env sync and redacted snapshot in deploy pipeline

### DIFF
--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -262,6 +262,119 @@ load_env() {
   set +a
 }
 
+# Print the current .env with secret values masked.
+# Keys matching *SECRET*|*TOKEN*|*PASS*|*KEY*|*REFRESH*|*CREDENTIAL* have their
+# value replaced with [redacted]. Safe to include in deploy logs.
+redact_env() {
+  local file="${1:-$ENV_FILE}"
+  local sensitive_pattern='SECRET|TOKEN|PASS|KEY|REFRESH|CREDENTIAL'
+
+  while IFS= read -r line; do
+    # Pass through blank lines and comments unchanged
+    if [[ "$line" =~ ^[[:space:]]*$ ]] || [[ "$line" =~ ^[[:space:]]*# ]]; then
+      echo "$line"
+      continue
+    fi
+    # For KEY=VALUE lines, redact the value if the key is sensitive
+    if [[ "$line" =~ ^([A-Z_][A-Z0-9_]*)=(.*)$ ]]; then
+      local key="${BASH_REMATCH[1]}"
+      local val="${BASH_REMATCH[2]}"
+      if echo "$key" | grep -qE "$sensitive_pattern"; then
+        # Show that a value exists but not what it is
+        if [ -n "$val" ]; then
+          echo "${key}=[redacted]"
+        else
+          echo "${key}=(empty)"
+        fi
+      else
+        echo "$line"
+      fi
+    else
+      echo "$line"
+    fi
+  done < "$file"
+}
+
+# Compare .env against the template and append any keys that are present in the
+# template but missing from the live .env. The appended block carries its
+# original template comments so the operator knows what each var does.
+# Returns 0 if .env was already complete, 1 if keys were added (operator must
+# fill in values before the next deploy succeeds).
+sync_env_from_template() {
+  dsection "Phase 3b: syncing .env against template"
+
+  if [ -z "${ENV_TEMPLATE:-}" ] || [ ! -f "$ENV_TEMPLATE" ]; then
+    dinfo "No ENV_TEMPLATE set — skipping template sync"
+    return 0
+  fi
+
+  # Keys already present in .env (only KEY lines, not comments)
+  local existing_keys
+  existing_keys=$(grep -E '^[A-Z_][A-Z0-9_]*=' "$ENV_FILE" | cut -d= -f1 | sort)
+
+  # Keys defined in the template
+  local template_keys
+  template_keys=$(grep -E '^[A-Z_][A-Z0-9_]*=' "$ENV_TEMPLATE" | cut -d= -f1 | sort)
+
+  # Keys in template but not in .env
+  local missing_keys
+  missing_keys=$(comm -23 <(echo "$template_keys") <(echo "$existing_keys"))
+
+  if [ -z "$missing_keys" ]; then
+    dok ".env is up to date with template — no missing keys"
+    return 0
+  fi
+
+  dwarn "New keys in template not yet in .env — appending with placeholder values:"
+  local appended_any=0
+
+  # Append a section header
+  printf '\n# ── Added by deploy sync %s ────────────────────────────────────────────────────\n' \
+    "$(date '+%Y-%m-%d')" >> "$ENV_FILE"
+
+  # Walk the template line-by-line, output comment+key blocks for missing keys only
+  local pending_comments=""
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*$ ]]; then
+      pending_comments=""
+      continue
+    fi
+    if [[ "$line" =~ ^[[:space:]]*# ]]; then
+      pending_comments+="${line}"$'\n'
+      continue
+    fi
+    if [[ "$line" =~ ^([A-Z_][A-Z0-9_]*)= ]]; then
+      local key="${BASH_REMATCH[1]}"
+      if echo "$missing_keys" | grep -qx "$key"; then
+        # Write buffered comments then the key line from the template
+        [ -n "$pending_comments" ] && printf '%s' "$pending_comments" >> "$ENV_FILE"
+        echo "$line" >> "$ENV_FILE"
+        dwarn "  + $key (added from template — fill in a real value)"
+        appended_any=1
+      fi
+      pending_comments=""
+    fi
+  done < "$ENV_TEMPLATE"
+
+  if [ "$appended_any" -eq 1 ]; then
+    dwarn ""
+    dwarn "  Action required: edit $ENV_FILE and set the new vars above before re-running."
+    # Treat missing-but-appended keys as a deploy blocker only if they are in REQUIRED_VARS.
+    # validate_env will catch them; we warn here so the operator sees the specific list first.
+    return 1
+  fi
+
+  return 0
+}
+
+# Log a redacted snapshot of the current .env to the deploy log.
+log_env_snapshot() {
+  dsection "Active .env (secrets redacted)"
+  redact_env "$ENV_FILE" | while IFS= read -r line; do
+    dlog "  $line"
+  done
+}
+
 validate_env() {
   dsection "Phase 4: validating .env"
 

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -263,11 +263,11 @@ load_env() {
 }
 
 # Print the current .env with secret values masked.
-# Keys matching *SECRET*|*TOKEN*|*PASS*|*KEY*|*REFRESH*|*CREDENTIAL* have their
+# Keys matching *SECRET*|*TOKEN*|*PASS*|*KEY*|*REFRESH*|*CREDENTIAL*|*EMAIL* have their
 # value replaced with [redacted]. Safe to include in deploy logs.
 redact_env() {
   local file="${1:-$ENV_FILE}"
-  local sensitive_pattern='SECRET|TOKEN|PASS|KEY|REFRESH|CREDENTIAL'
+  local sensitive_pattern='SECRET|TOKEN|PASS|KEY|REFRESH|CREDENTIAL|EMAIL'
 
   while IFS= read -r line; do
     # Pass through blank lines and comments unchanged

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -303,8 +303,12 @@ redact_env() {
 sync_env_from_template() {
   dsection "Phase 3b: syncing .env against template"
 
-  if [ -z "${ENV_TEMPLATE:-}" ] || [ ! -f "$ENV_TEMPLATE" ]; then
-    dinfo "No ENV_TEMPLATE set — skipping template sync"
+  if [ -z "${ENV_TEMPLATE:-}" ]; then
+    dwarn "ENV_TEMPLATE not set — .env drift detection disabled (set ENV_TEMPLATE to enable)"
+    return 0
+  fi
+  if [ ! -f "$ENV_TEMPLATE" ]; then
+    dwarn "ENV_TEMPLATE '$ENV_TEMPLATE' not found — .env drift detection skipped"
     return 0
   fi
 

--- a/scripts/deploy/dev-deploy.sh
+++ b/scripts/deploy/dev-deploy.sh
@@ -81,23 +81,13 @@ ensure_repo_cloned
 
 ensure_env_file
 
+sync_env_from_template
+
 load_env
 
+log_env_snapshot
+
 validate_env
-
-# ── Template validation ────────────────────────────────────────────────────────────
-
-dsection "Validating .env against template"
-
-if command -v node >/dev/null 2>&1; then
-  if node "$REPO_DIR/scripts/validate-env.js" "$ENV_FILE" "$ENV_TEMPLATE" 2>&1 | tee -a "$LOG_FILE"; then
-    dok ".env template validation passed"
-  else
-    dwarn ".env is missing variables from template — review and update if needed"
-  fi
-else
-  dwarn "Node.js not found — skipping template validation"
-fi
 
 # ── UFW check (dev-specific) ───────────────────────────────────────────────────────────
 

--- a/scripts/deploy/prod-deploy.sh
+++ b/scripts/deploy/prod-deploy.sh
@@ -77,7 +77,11 @@ ensure_repo_cloned
 
 ensure_env_file
 
+sync_env_from_template
+
 load_env
+
+log_env_snapshot
 
 validate_env
 


### PR DESCRIPTION
## Summary

Part of deployment hardening (#263). Adds automatic `.env` drift detection and safe logging to every deploy — no manual step required.

### What runs on every deploy (between `ensure_env_file` and `validate_env`)

**`sync_env_from_template`** — diffs the live `.env` against `ENV_TEMPLATE` and appends any keys that exist in the template but are missing from `.env`. Each appended key carries its original template comment block so the operator knows what the var is for. If new keys were appended, the deploy logs a warning listing them and `validate_env` will block the deploy if any of those new keys are in `REQUIRED_VARS` — forcing the operator to fill them in before proceeding.

**`log_env_snapshot`** — writes a full copy of the active `.env` to the deploy log with all sensitive values redacted. Keys matching `SECRET|TOKEN|PASS|KEY|REFRESH|CREDENTIAL|EMAIL` are replaced with `[redacted]`. Covers `JWT_SECRET`, `DB_PASSWORD`, `OUTLOOK_CLIENT_SECRET`, `OUTLOOK_REFRESH_TOKEN`, `OUTLOOK_EMAIL`, `ADMIN_EMAIL`, `SMTP_PASS`, etc. Safe to share in support sessions or review without leaking secrets.

**`redact_env`** — the underlying redaction helper, also callable standalone (e.g. from a support session: `redact_env /path/to/.env`).

### Deploy flow change

```
ensure_env_file         # .env exists or is copied from template
sync_env_from_template  # NEW: append missing keys from template
load_env                # source vars into environment
log_env_snapshot        # NEW: log redacted .env to deploy log
validate_env            # block if required vars are empty/placeholders
```

### Also

- Removes the old `node scripts/validate-env.js` call from `dev-deploy.sh` (replaced by the pure-bash `sync_env_from_template` — no Node dependency)
- `prod-deploy.sh` previously had no template sync at all; now gets the same coverage

## Test plan

```bash
# On dev server — SSH in, then:

# 1. Add a new var to the template that's absent from the live .env
#    Expected: deploy log shows "[WARN] New keys in template not yet in .env"
#    and lists the added key; var is appended to .env with placeholder value

# 2. Run deploy normally (no missing keys)
#    Expected: "Phase 3b" shows ".env is up to date with template"
#    and "Active .env (secrets redacted)" section shows all vars with
#    SECRET/TOKEN/PASS/KEY/EMAIL values replaced by [redacted]
bash ~/MyPortfolioSite-dev/scripts/deploy/dev-deploy.sh

# 3. Check the deploy log for the redacted snapshot
grep -A 50 'Active .env' ~/dev-deploy.log | head -60
#    Expected: all vars present, sensitive values show [redacted]
#    Specifically verify: ADMIN_EMAIL=[redacted], OUTLOOK_EMAIL=[redacted]

# 4. Confirm no raw secrets or emails appear anywhere in the log
grep -iE 'password|secret|token|refresh|@' ~/dev-deploy.log | grep -v redacted
#    Expected: no output
```

## Squash commit message

```
feat: automated .env sync and redacted snapshot in deploy pipeline

sync_env_from_template diffs .env against ENV_TEMPLATE on every deploy
and appends missing keys with template comments so operators know what
to fill in. log_env_snapshot writes a secrets-redacted copy to the
deploy log — keys matching SECRET|TOKEN|PASS|KEY|REFRESH|CREDENTIAL|EMAIL
are masked, covering ADMIN_EMAIL and OUTLOOK_EMAIL as well as secrets.
Replaces the node-based validate-env.js call in dev-deploy.sh; adds
equivalent coverage to prod-deploy.sh.

Part of #263

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

---
_Generated by [Claude Code](https://claude.ai/code)_