### PR TITLE
refactor: use switch-branch.sh consistently across all deploy ps1 scripts

### DIFF
--- a/scripts/deploy/dev-deploy-wrapper.sh
+++ b/scripts/deploy/dev-deploy-wrapper.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 # dev-server-deploy-wrapper.sh — Bootstrap wrapper for dev deploys.
 #
+# DEPRECATED — superseded by switch-branch.sh + dev-deploy.sh called directly
+# from dev-deploy.ps1. Retained for reference only; schedule for removal once
+# no callers remain.
+#
+# Replacement pattern (used by dev-deploy.ps1 and Seed-DevData.ps1):
+#   bash scripts/deploy/switch-branch.sh <branch> <repo-path>
+#   bash scripts/deploy/dev-deploy.sh <branch>
+#
 # Solves the self-updating script problem: updates the working tree to the
 # requested branch BEFORE invoking dev-deploy.sh, so the deploy always runs
 # the latest version of the script, not the version that was loaded before the pull.
-#
-# This is the correct entrypoint for dev deploys. Call this, not dev-deploy.sh directly.
 #
 # Usage:
 #   bash scripts/deploy/dev-server-deploy-wrapper.sh [branch]

--- a/scripts/deploy/dev-deploy.ps1
+++ b/scripts/deploy/dev-deploy.ps1
@@ -17,7 +17,7 @@ if ([string]::IsNullOrEmpty($Branch)) {
 Write-Host "Deploying branch '$Branch' to dev server..." -ForegroundColor Green
 
 $remoteCommand = @"
-DEV_REPO=`$HOME/MyPortfolioSite-dev
+DEV_REPO=`$~/MyPortfolioSite-dev
 REPO_URL=https://github.com/AndyRKeys/MyPortfolioSite.git
 BRANCH="$Branch"
 

--- a/scripts/deploy/dev-deploy.ps1
+++ b/scripts/deploy/dev-deploy.ps1
@@ -17,7 +17,7 @@ if ([string]::IsNullOrEmpty($Branch)) {
 Write-Host "Deploying branch '$Branch' to dev server..." -ForegroundColor Green
 
 $remoteCommand = @"
-DEV_REPO=`$~/MyPortfolioSite-dev
+DEV_REPO=`$HOME/MyPortfolioSite-dev
 REPO_URL=https://github.com/AndyRKeys/MyPortfolioSite.git
 BRANCH="$Branch"
 

--- a/scripts/deploy/dev-deploy.ps1
+++ b/scripts/deploy/dev-deploy.ps1
@@ -1,34 +1,37 @@
 # Trigger a dev server deploy from Windows via SSH.
-# Connects to the Ubuntu Server and runs scripts/deploy/dev-server-deploy-wrapper.sh remotely.
-# The wrapper updates the branch first, then execs dev-deploy.sh with the latest code.
+# Uses switch-branch.sh to update the repo to the target branch first,
+# then runs dev-deploy.sh — so the deploy always executes the current
+# version of the scripts, not whatever was checked out before the pull.
 #
-# IMPORTANT: Use this script, not dev-deploy.ps1, to ensure the wrapper runs and
-# the deploy always executes the current version of the deploy scripts.
-#
-# Usage: .\scripts\deploy\dev-server-deploy.ps1 [-Hostname <name>] [-Branch <branch>]
+# Usage: .\scripts\deploy\dev-deploy.ps1 [-Hostname <name>] [-Branch <branch>]
 param(
     [string]$Hostname = 'ak-home-server',
     [string]$Branch = ''
 )
 
-# Detect current branch if not specified
 if ([string]::IsNullOrEmpty($Branch)) {
     $Branch = git rev-parse --abbrev-ref HEAD
     Write-Host "Detected branch: $Branch" -ForegroundColor Cyan
 }
 
-Write-Host "Deploying branch '$Branch' to dev server via wrapper..." -ForegroundColor Green
+Write-Host "Deploying branch '$Branch' to dev server..." -ForegroundColor Green
 
 $remoteCommand = @"
-WRAPPER=~/MyPortfolioSite-dev/scripts/deploy/dev-server-deploy-wrapper.sh
-DEPLOY_BRANCH="$Branch"
-if [ -f "`$WRAPPER" ]; then
-    bash "`$WRAPPER" "`$DEPLOY_BRANCH"
-else
-    echo "[INFO] Dev repo not found — cloning for the first time..."
-    git clone https://github.com/AndyRKeys/MyPortfolioSite.git ~/MyPortfolioSite-dev
-    bash ~/MyPortfolioSite-dev/scripts/deploy/dev-deploy-wrapper.sh "`$DEPLOY_BRANCH"
+DEV_REPO=`$HOME/MyPortfolioSite-dev
+REPO_URL=https://github.com/AndyRKeys/MyPortfolioSite.git
+BRANCH="$Branch"
+
+# Clone on first run
+if [ ! -d "`$DEV_REPO/.git" ]; then
+    echo "[INFO] Dev repo not found — cloning..."
+    git clone "`$REPO_URL" "`$DEV_REPO"
 fi
+
+# Switch to the requested branch (fetch + hard reset to origin)
+bash "`$DEV_REPO/scripts/deploy/switch-branch.sh" "`$BRANCH" "`$DEV_REPO"
+
+# Run the deploy with the now-current scripts
+bash "`$DEV_REPO/scripts/deploy/dev-deploy.sh" "`$BRANCH"
 "@
 
 # Strip CRLF — bash on the server rejects Windows line endings

--- a/scripts/deploy/prod-deploy.ps1
+++ b/scripts/deploy/prod-deploy.ps1
@@ -22,7 +22,7 @@ if ($Rollback) { $remoteArgs += "--rollback $Rollback" }
 Write-Host "Deploying branch '$Branch' to prod server..." -ForegroundColor Green
 
 $remoteCommand = @"
-PROD_REPO=`$HOME/MyPortfolioSite
+PROD_REPO=`$~/MyPortfolioSite
 BRANCH="$Branch"
 
 # Switch to the requested branch (fetch + hard reset to origin)

--- a/scripts/deploy/prod-deploy.ps1
+++ b/scripts/deploy/prod-deploy.ps1
@@ -1,6 +1,7 @@
 # Trigger a production deploy from Windows via SSH.
-# Connects to the server and runs scripts/deploy/prod-deploy.sh remotely.
-# Defaults to main branch — override with -Branch only when intentional.
+# Uses switch-branch.sh to update the repo to the target branch first,
+# then runs prod-deploy.sh — so the deploy always executes the current
+# version of the scripts, not whatever was checked out before the pull.
 #
 # IMPORTANT: If the server has rebooted, decrypt it first via Dropbear:
 #   ssh -p 2222 root@ak-home-server
@@ -18,11 +19,20 @@ $remoteArgs = @()
 if ($Branch)   { $remoteArgs += "--branch $Branch" }
 if ($Rollback) { $remoteArgs += "--rollback $Rollback" }
 
+Write-Host "Deploying branch '$Branch' to prod server..." -ForegroundColor Green
+
 $remoteCommand = @"
-cd ~/MyPortfolioSite
-bash scripts/deploy/prod-deploy.sh $($remoteArgs -join ' ')
+PROD_REPO=`$HOME/MyPortfolioSite
+BRANCH="$Branch"
+
+# Switch to the requested branch (fetch + hard reset to origin)
+bash "`$PROD_REPO/scripts/deploy/switch-branch.sh" "`$BRANCH" "`$PROD_REPO"
+
+# Run the deploy with the now-current scripts
+bash "`$PROD_REPO/scripts/deploy/prod-deploy.sh" $($remoteArgs -join ' ')
 "@
 
-Write-Host "Deploying branch '$Branch' to prod server..." -ForegroundColor Green
+# Strip CRLF — bash on the server rejects Windows line endings
+$remoteCommand = $remoteCommand -replace "`r`n", "`n"
 
 ssh $Hostname $remoteCommand


### PR DESCRIPTION
## Summary

`Seed-DevData.ps1` already used `switch-branch.sh` correctly. This brings `dev-deploy.ps1` and `prod-deploy.ps1` in line with the same pattern and marks the now-redundant bash wrapper as deprecated.

### Changes

**`dev-deploy.ps1`** — replaces the `dev-server-deploy-wrapper.sh` call with `switch-branch.sh` + `dev-deploy.sh` directly. Clone-on-first-run logic retained inline for bootstrapping. Cleaner and consistent with `Seed-DevData.ps1`.

**`prod-deploy.ps1`** — adds the `switch-branch.sh` step that was previously missing entirely. Without it, `prod-deploy.sh` was always running against whatever branch the repo happened to be on rather than the requested one — the self-updating script problem existed silently for prod.

**`dev-deploy-wrapper.sh`** — marked `DEPRECATED` in the file header with the replacement pattern documented. Retained for reference; scheduled for removal once no callers remain.

### Pattern now consistent across all three callers

```bash
# Switch first (fetch + hard reset to origin/<branch>)
bash scripts/deploy/switch-branch.sh "$BRANCH" "$REPO"

# Then deploy with the now-current scripts
bash scripts/deploy/dev-deploy.sh "$BRANCH"   # or prod-deploy.sh
```

## Test plan

```powershell
# Dev deploy — verify branch switch appears in SSH output before deploy phases
.\scripts\deploy\dev-deploy.ps1 -Branch dev
# Expected: "[OK][switch-branch] Repo is now on 'dev' at <sha>" then deploy phases

# Prod deploy — same check
.\scripts\deploy\prod-deploy.ps1
# Expected: "[OK][switch-branch] Repo is now on 'main' at <sha>" then deploy phases

# Feature branch deploy — confirm branch switch works for non-default branches
.\scripts\deploy\dev-deploy.ps1 -Branch fix/253-orphan-containers
# Expected: switch-branch confirms correct branch, deploy runs from that branch
```

## Squash commit message

```
refactor: use switch-branch.sh consistently in all deploy ps1 scripts

dev-deploy.ps1 replaces dev-server-deploy-wrapper.sh with the generic
switch-branch.sh + dev-deploy.sh pattern already used by Seed-DevData.ps1.
prod-deploy.ps1 gains the same switch-branch step it was previously missing.
dev-deploy-wrapper.sh marked deprecated for future removal.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM)_