### PR TITLE
disable GitHub Actions CI — tests run in deployment pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
-name: CI
+# CI tests are now run inside the deployed container as part of the deploy scripts.
+# Test failures trigger automatic rollback via deploy-lib.sh run_deploy_tests().
+# See scripts/deploy/deploy-lib.sh and issue #270.
+#
+# This workflow is disabled (workflow_dispatch only) — kept for reference.
+name: CI (disabled — tests run in deployment)
 
 on:
-  push:
-    branches:
-      - dev
-  pull_request:
-    branches:
-      - dev
-      - main
+  workflow_dispatch:
 
 jobs:
   tests:


### PR DESCRIPTION
Single file change — sets `ci.yml` to `workflow_dispatch` only so it no longer triggers on push or PR.

Tests now run inside the deployed container via `run_deploy_tests()` in `deploy-lib.sh` (see PR #269). No more fresh `npm install` on every push.

The workflow file is retained (not deleted) for reference and manual runs if ever needed.

Closes #270 (partial — full wiring is in #269)

## Test plan

After merge, push a commit to `dev` and confirm no CI run appears in the GitHub Actions tab.

https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM)_