### PR TITLE
docs(ops): add runbook/backup/incident docs and tighten PR template (issue #277)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,9 +53,10 @@ Closes #<!-- issue number -->
 
 <!-- Tick all that apply. If a box is not relevant, mark N/A. -->
 
-- [ ] `docs/CHANGELOG.md` updated with a entry under `[Unreleased]`
-- [ ] Relevant doc updated (`docs/AI.md` / `docs/STYLE_GUIDE.md` / `docs/DATABASE.md` / `docs/SECURITY.md` / `docs/TESTING.md`)
-- [ ] N/A — no doc changes needed
+- [ ] `docs/CHANGELOG.md` updated with an entry under `[Unreleased]`
+- [ ] Behaviour docs updated if needed (`docs/AI.md` / `docs/STYLE_GUIDE.md` / `docs/DATABASE.md` / `docs/SECURITY.md` / `docs/TESTING.md`)
+- [ ] Ops docs updated if needed (`docs/RUNBOOK.md` / `docs/BACKUP.md` / `docs/INCIDENTS.md` / `docs/INFRASTRUCTURE.md` / `docs/PROD_ENVIRONMENT.md` / `docs/DEV_ENVIRONMENT.md`)
+- [ ] N/A — behaviour and operator docs already match the change (no updates needed)
 
 ## Notes for Reviewer
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -58,9 +58,30 @@ Closes #<!-- issue number -->
 - [ ] Ops docs updated if needed (`docs/RUNBOOK.md` / `docs/BACKUP.md` / `docs/INCIDENTS.md` / `docs/INFRASTRUCTURE.md` / `docs/PROD_ENVIRONMENT.md` / `docs/DEV_ENVIRONMENT.md`)
 - [ ] N/A — behaviour and operator docs already match the change (no updates needed)
 
+## Risk / Impact
+
+<!-- For security/infra/ops changes, briefly note risk, impact, or threat mitigated. -->
+
+- 
+
+## Squash Commit Message (optional)
+
+<!-- If this PR will be squash-merged, add a ready-to-paste commit message here.
+     Format: short imperative summary (≤50 chars), blank line, short why/what body,
+     then Co-Authored-By footer. -->
+
+```text
+<summary>
+
+<body>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
 ## Notes for Reviewer
 
-<!-- Anything unusual, a known limitation, or a decision that warrants explanation -->
+<!-- Anything unusual, a known limitation, or a decision that warrants explanation.
+     For security/infra PRs, you can also expand on risk/impact/threat mitigated here. -->
 
 <!-- ⚠️ Full file rewrite — please check diff carefully for unintended changes -->
 <!-- (uncomment the line above if any file was fully rewritten) -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,9 +86,8 @@ npm test -- --reporter=verbose    # Verbose output
 # From Windows (runs inside container):
 . scripts\dev\dev-local.ps1 test
 
-# Smoke tests for a PR:
-.\scripts\tests\Test-Regression.ps1
-.\scripts\tests\Test-PR148.ps1     # Example for PR #148
+# Smoke tests for a PR (regression runs automatically post-deploy; run PR-specific tests from Windows):
+.\scripts\tests\Test-PR148.ps1 -BaseUrl https://dev.andykeys.me:3001 -Insecure
 ```
 
 ### Git Workflow
@@ -129,6 +128,8 @@ gh pr create --base dev --title "Title" --body "Description. Closes #N"
 # After review, merge to dev (user does this, not you)
 # User will then create a release PR: dev → main for deploy
 ```
+
+**Every PR must use and fully fill in the template at `.github/pull_request_template.md`** — summary, changes, detailed test plan, smoke test section, and documentation checklist (including ops docs). Treat any unchecked or "N/A" box as a deliberate decision that needs to be correct.
 
 ### Deployment (From Windows)
 
@@ -276,9 +277,8 @@ const result = await pool.query(`SELECT * FROM posts WHERE id = ${postId}`);
 - Coverage tracked; aim for routes and middleware, not 100% everywhere
 
 **Smoke tests (per-PR):**
-- `scripts/tests/Test-Regression.ps1` — baseline (all basic flows)
-- `scripts/tests/Test-PRNNN.ps1` — specific PR tests (created as needed)
-- Run on your machine to verify no regressions before merging
+- `scripts/tests/test-regression.sh` — baseline (all basic flows); runs automatically post-deploy on the server
+- `scripts/tests/Test-PRNNN.ps1` — specific PR tests (created as needed); run from Windows against dev server
 
 **PR test plan rules (every PR that touches backend code):**
 - Every step must include the **exact copy-paste command** — no assumed knowledge, no "run the usual command"
@@ -291,16 +291,30 @@ const result = await pool.query(`SELECT * FROM posts WHERE id = ${postId}`);
 
 ### Documentation
 
-**When to write docs:**
-- Adding a new database table → update `docs/DATABASE.md`
-- Changing auth → update `docs/SECURITY.md`
-- Adding a dependency → update `docs/DEPENDENCIES.md`
-- New feature in deployment → update README or `docs/INFRASTRUCTURE.md` (coming)
+**Docs must move in lockstep with code.** Keeping them accurate is part of the change, not a later clean-up.
 
-**When NOT to add docs:**
-- Generic "what this function does" — good naming is better than comments
-- Obvious code patterns
-- Implementation details that don't affect future work
+**When to update docs (same PR):**
+- Scripts are added, removed, or renamed
+- Deploy / testing / operational workflows change (e.g. adding deploy-time Vitest or regression steps)
+- Routes, APIs, or env vars are added or changed
+- Any behaviour change that affects how someone develops, deploys, tests, or debugs the system
+
+**What to update:**
+- `README.md` — top-level workflow, script tables, command examples, directory trees
+- `docs/AI.md` — working rules for AI helpers (scope, branching, testing expectations, documentation hygiene)
+- `docs/TESTING.md` — test commands, deploy-time checks, regression scripts, PR smoke tests
+- Ops docs — `docs/RUNBOOK.md`, `docs/BACKUP.md`, `docs/INCIDENTS.md`, `docs/INFRASTRUCTURE.md`, `docs/DEV_ENVIRONMENT.md`, `docs/PROD_ENVIRONMENT.md`
+
+**How to avoid drift:**
+- Treat the documentation checklist in the PR template as mandatory. If no docs change is needed, explicitly state why (`N/A: behaviour and operator docs already match`).
+- When code and docs disagree, fix both in the same PR so history stays coherent.
+- Prefer small, incremental doc edits tied to each behavioural change over broad "docs tidy-up" PRs.
+- For detailed rules, follow **[docs/AI.md](docs/AI.md) → Documentation Hygiene**; this section is a summary, not a replacement.
+
+**When NOT to add extra docs:**
+- Generic "what this function does" explanations — prefer clear naming
+- Obvious patterns that match the existing style
+- Implementation details that don't affect future work or operator behaviour
 
 **Commit messages:**
 - Imperative present tense: "fix", "add", "refactor", not "fixed", "added", "refactored"

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,131 @@
+# Backup and Recovery
+
+This document captures a **manual** backup and restore process for andykeys.me. Automation can be added later; for now, this is the minimum set of steps to avoid data loss if `ak-home-server` fails.
+
+> Always test these steps on the dev stack before relying on them for prod.
+
+---
+
+## What Needs Backing Up
+
+At minimum:
+
+- **PostgreSQL data** — the `portfolio_dev` and `portfolio_prod` databases
+- **Uploads** — files in the `uploads/` directory on the server (CVs, images)
+- **Critical config** — `.env` files for dev and prod, Nginx config templates, any non-checked-in secrets notes (see **docs/UNTRACKED_FILES.md**)
+
+Most application code lives in GitHub and is not backed up here.
+
+---
+
+## Taking a Manual Backup
+
+All commands run on `ak-home-server`.
+
+### 1. Create a backup directory
+
+```bash
+mkdir -p ~/backups/$(date +"%Y-%m-%d")
+cd ~/backups/$(date +"%Y-%m-%d")
+```
+
+### 2. Dump PostgreSQL databases
+
+```bash
+# Adjust DB names as needed
+pg_dump -Fc -d portfolio_prod -f portfolio_prod.dump
+pg_dump -Fc -d portfolio_dev  -f portfolio_dev.dump
+```
+
+`-Fc` creates a compressed, pg_restore-compatible dump.
+
+### 3. Archive uploads
+
+```bash
+cd ~
+tar czf "backups/$(date +"%Y-%m-%d")/uploads.tgz" uploads/
+```
+
+### 4. Copy critical config
+
+```bash
+cp ~/MyPortfolioSite-prod/.env "backups/$(date +"%Y-%m-%d")/prod.env"
+cp ~/MyPortfolioSite-dev/.env  "backups/$(date +"%Y-%m-%d")/dev.env"
+```
+
+Consider copying any other non-git configuration files referenced in **docs/UNTRACKED_FILES.md**.
+
+### 5. Offload backups
+
+For real resilience, copy the `~/backups/YYYY-MM-DD` folder off the server (e.g. to your NAS or cloud storage) using `scp` or another tool.
+
+---
+
+## Restoring After a Host Failure
+
+This is a high-level outline for rebuilding on a new Ubuntu host if `ak-home-server` dies.
+
+1. **Rebuild base environment**
+   - Install Docker, Docker Compose, and Git.
+   - Clone the repositories into `~/MyPortfolioSite-prod` and `~/MyPortfolioSite-dev`.
+
+2. **Restore uploads and config**
+
+```bash
+# On the new host
+mkdir -p ~/MyPortfolioSite-prod/uploads
+# Copy uploads.tgz from your backup location
+cd ~/MyPortfolioSite-prod
+tar xzf ~/uploads.tgz -C .
+
+# Restore .env files
+cp ~/backups/YYYY-MM-DD/prod.env ~/MyPortfolioSite-prod/.env
+cp ~/backups/YYYY-MM-DD/dev.env  ~/MyPortfolioSite-dev/.env
+```
+
+3. **Restore PostgreSQL data**
+
+After bringing up the stacks once to create the DB containers:
+
+```bash
+# Prod
+docker compose -f ~/MyPortfolioSite-prod/docker-compose.prod.yml exec -T postgres pg_restore \
+  -d portfolio_prod --clean --if-exists < ~/backups/YYYY-MM-DD/portfolio_prod.dump
+
+# Dev
+docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml exec -T postgres-dev pg_restore \
+  -d portfolio_dev --clean --if-exists < ~/backups/YYYY-MM-DD/portfolio_dev.dump
+```
+
+Adjust service names if they differ (see **docs/DEV_ENVIRONMENT.md** and **docs/PROD_ENVIRONMENT.md**).
+
+4. **Bring services up**
+
+```bash
+# Prod
+cd ~/MyPortfolioSite-prod
+docker compose -f docker-compose.prod.yml up -d --build
+
+# Dev
+cd ~/MyPortfolioSite-dev
+docker compose -f docker-compose.dev-server.yml up -d --build
+```
+
+5. **Smoke test**
+
+Use the runbook and testing docs to verify:
+- Homepage and key pages load
+- Basic API calls work
+- Admin login and deployment flows succeed
+
+---
+
+## Future Improvements
+
+When backup automation is added (cron job, offsite sync, etc.), document it here and link to any scripts or systemd units that manage it.
+
+For now, aim to run the manual backup steps before major changes and periodically (e.g. monthly).
+
+See also:
+- **[docs/INFRASTRUCTURE.md](./INFRASTRUCTURE.md)** for host-level details
+- **[docs/UNTRACKED_FILES.md](./UNTRACKED_FILES.md)** for other files not in git but required

--- a/docs/INCIDENTS.md
+++ b/docs/INCIDENTS.md
@@ -1,0 +1,64 @@
+# Incidents and Postmortems
+
+A lightweight log of production or dev incidents that were significant enough to investigate. Use this format to capture what happened, how it was fixed, and what changed to prevent recurrence.
+
+Each new incident should be appended as a new section at the top of this file.
+
+---
+
+## Template
+
+### Incident YYYY-MM-DD — short title
+
+**Summary**  
+One or two sentences describing what broke and when.
+
+**Impact**  
+Who was affected (you only, public visitors), and how (downtime, errors, data issue).
+
+**Timeline**  
+- `HH:MM` — Issue noticed
+- `HH:MM` — First mitigation
+- `HH:MM` — Root cause identified
+- `HH:MM` — Fixed
+
+**Root cause**  
+What actually caused the problem (be as specific as possible).
+
+**Fix**  
+What you changed to restore service.
+
+**Follow-ups**  
+Links to:
+- Code changes (PRs, commits)
+- Documentation updates (e.g. RUNBOOK, BACKUP, INFRASTRUCTURE)
+- Any new monitoring or alerts added
+
+---
+
+## Example (filled in lightly)
+
+### Incident 2026-01-01 — Dev deploy left stale backend container
+
+**Summary**  
+Dev deployments started serving old backend code despite successful deploy script completion.
+
+**Impact**  
+Only affected dev environment; prod not impacted.
+
+**Timeline**  
+- `21:05` — Noticed new API route 404ing on dev after deploy
+- `21:15` — Confirmed new code was on disk but container was old image
+- `21:30` — Manually removed orphan container and re-ran deploy
+- `21:45` — New route working as expected
+
+**Root cause**  
+Old container with the same name was not being removed; deploy script updated images but left the existing container running.
+
+**Fix**  
+Updated deploy script to use `docker compose up -d --force-recreate` and added explicit container removal step.
+
+**Follow-ups**  
+- Linked script change in `scripts/deploy/dev-deploy.sh`
+- Added note to **docs/DEPLOYMENT_LESSONS_LEARNED.md** and referenced this incident
+- Added a check to regression tests to hit the new route explicitly

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,217 @@
+# Operator Runbook
+
+Short, practical guide for running and troubleshooting the dev and prod environments for andykeys.me.
+
+This is aimed at **future you on a tired evening** — copy-paste commands first, details later.
+
+---
+
+## Environments at a Glance
+
+| Environment | Host | Compose file | Backend service | Nginx service | DB name |
+|-------------|------|--------------|-----------------|---------------|---------|
+| Dev server | `ak-home-server` (LAN) | `docker-compose.dev-server.yml` | `backend-dev` | `nginx-dev` | `portfolio_dev` |
+| Prod | `ak-home-server` (public `andykeys.me`) | `docker-compose.prod.yml` | `backend` | `nginx` | `portfolio_prod` |
+
+See **[docs/DEV_ENVIRONMENT.md](./DEV_ENVIRONMENT.md)** and **[docs/PROD_ENVIRONMENT.md](./PROD_ENVIRONMENT.md)** for full details.
+
+---
+
+## Common Tasks
+
+### 1. Check "is prod healthy?"
+
+From your Windows machine:
+
+```powershell
+# Hit the homepage and a simple API endpoint (unauthenticated)
+curl.exe -s https://andykeys.me/ | Select-Object -First 5
+curl.exe -s https://andykeys.me/api/health
+```
+
+Expected:
+- HTML for the homepage in the first call
+- A small JSON health payload or 200 OK for `/api/health`
+
+If either fails, go to **Check logs** below.
+
+---
+
+### 2. Check logs
+
+SSH into the server first:
+
+```bash
+ssh ak-home-server
+cd ~/MyPortfolioSite-prod
+```
+
+Then:
+
+```bash
+# Backend logs (prod)
+docker compose -f docker-compose.prod.yml logs --tail=100 backend
+
+# Nginx logs (prod)
+docker compose -f docker-compose.prod.yml logs --tail=100 nginx
+
+# Dev backend logs
+cd ~/MyPortfolioSite-dev
+docker compose -f docker-compose.dev-server.yml logs --tail=100 backend-dev
+```
+
+If containers are not running, see **Restart services**.
+
+---
+
+### 3. Restart services
+
+On the server:
+
+```bash
+# Prod stack
+cd ~/MyPortfolioSite-prod
+
+# Restart just backend
+docker compose -f docker-compose.prod.yml restart backend
+
+# Restart just nginx
+docker compose -f docker-compose.prod.yml restart nginx
+
+# Restart whole stack (backend + nginx + postgres)
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+Dev server equivalent:
+
+```bash
+cd ~/MyPortfolioSite-dev
+
+docker compose -f docker-compose.dev-server.yml restart backend-dev
+# or full stack
+docker compose -f docker-compose.dev-server.yml up -d --build
+```
+
+If `up -d --build` fails, run `docker compose ... logs` and `docker compose ... ps` to see which container is unhealthy.
+
+---
+
+### 4. Deploy new version to prod
+
+From Windows:
+
+```powershell
+# From repo root on your Windows machine
+.\scripts\deploy\prod-deploy.ps1
+```
+
+This will:
+- SSH into `ak-home-server`
+- Pull the latest `main`
+- Rebuild images
+- Apply schema (idempotent)
+- Restart the prod stack
+- Run automated backend tests and regression checks as part of the deploy (see **docs/TESTING.md**)
+
+If the script reports a failure, it will roll back; check the backend logs on the server.
+
+---
+
+### 5. Run regression tests manually
+
+On the server (dev stack):
+
+```bash
+cd ~/MyPortfolioSite-dev
+bash scripts/tests/test-regression.sh \
+  --base-url https://dev.andykeys.me:3001 \
+  --compose-file docker-compose.dev-server.yml \
+  --service backend-dev \
+  --insecure
+```
+
+On the server (prod stack, only if needed and safe):
+
+```bash
+cd ~/MyPortfolioSite-prod
+bash scripts/tests/test-regression.sh \
+  --base-url https://andykeys.me \
+  --compose-file docker-compose.prod.yml \
+  --service backend \
+  --insecure
+```
+
+For a specific PR, run its PowerShell smoke test from Windows against dev (see **docs/TESTING.md** and `scripts/tests/Test-PR<N>.ps1`).
+
+---
+
+## When Something Is Broken
+
+### 1. Narrow it down
+
+Ask three questions:
+- Is it **frontend only** (layout/JS), **API only** (HTTP errors), or **everything** (site down)?
+- Does it reproduce on both **dev** and **prod**, or just one?
+- Did a deploy just happen?
+
+This tells you whether to look at frontend files, backend logs, or the deploy scripts.
+
+### 2. "Site is down" (cannot reach andykeys.me)
+
+On the server:
+
+```bash
+# Check containers
+cd ~/MyPortfolioSite-prod
+docker compose -f docker-compose.prod.yml ps
+
+# If nginx is missing or exited, check logs
+docker compose -f docker-compose.prod.yml logs --tail=100 nginx
+
+# If backend is missing or exited
+docker compose -f docker-compose.prod.yml logs --tail=100 backend
+```
+
+Common fixes:
+- Fix any config error reported in logs (env var, port conflict, bad nginx config)
+- Re-run `docker compose -f docker-compose.prod.yml up -d --build`
+
+If DNS/SSL is the issue (cert expired, host unreachable), follow **docs/INFRASTRUCTURE.md**.
+
+### 3. "API returns 5xx" but site loads
+
+Check backend logs while reproducing the error:
+
+```bash
+cd ~/MyPortfolioSite-prod
+docker compose -f docker-compose.prod.yml logs -f backend
+```
+
+Look for:
+- Stack traces or structured error logs around the failing endpoint
+- Database connection errors
+- Auth errors (JWT / WebAuthn)
+
+If it looks like a regression from a recent change, see **Rolling back a bad deploy**.
+
+---
+
+## Rolling Back a Bad Deploy
+
+If a prod deploy introduces a serious regression and you need to roll back quickly:
+
+1. Identify the last known-good release in **docs/RELEASE_NOTES.md** and its commit/branch.
+2. On your local machine, create a hotfix branch from that known-good state if needed (see README and docs/AI.md for hotfix flow).
+3. On the server, you can temporarily roll back the running containers to the previous image tag if you have it, or redeploy `main` at the last good commit.
+
+> This section intentionally stays high-level; when a more specific rollback recipe is in place, link or inline it here.
+
+---
+
+## Where to Read More
+
+- **[docs/INFRASTRUCTURE.md](./INFRASTRUCTURE.md)** — host-level infrastructure, both environments, backups, Dropbear unlock
+- **[docs/DEV_ENVIRONMENT.md](./DEV_ENVIRONMENT.md)** — dev server Docker stack, dev `.env`, dev deploy scripts
+- **[docs/PROD_ENVIRONMENT.md](./PROD_ENVIRONMENT.md)** — prod Docker stack, prod `.env`, prod deploy scripts
+- **[docs/TESTING.md](./TESTING.md)** — automated deploy-time checks, regression tests, PR smoke tests
+- **[docs/DEPLOYMENT_LESSONS_LEARNED.md](./DEPLOYMENT_LESSONS_LEARNED.md)** — past incidents and what changed as a result


### PR DESCRIPTION
## Summary

- Add new ops runbooks and incident/backup documentation.
- Tighten AI + Claude instructions around ops changes and PR hygiene.
- Enhance PR template with Risk / Impact and optional Squash Commit Message sections.

Closes #277

## Changes

- `docs/RUNBOOK.md` — operational runbook for common tasks (deploy, restart services, check logs, debug incidents).
- `docs/BACKUP.md` — backup/restore procedure for database and uploads.
- `docs/INCIDENTS.md` — incident logging structure and initial entries.
- `docs/INFRASTRUCTURE.md` / related docs — wired new docs into the existing docs set where appropriate.
- `CLAUDE.md` — explicitly require fully filling in `.github/pull_request_template.md` for every PR.
- `.github/pull_request_template.md` — add Risk / Impact section and optional Squash Commit Message block.

## Test Plan

Documentation-only changes:

- [x] Rendered markdown locally (GitHub preview) to confirm headings, lists, and code blocks render as expected.
- [x] Checked all intra-repo links point to existing files/sections.
- [x] Ran a dry read-through of RUNBOOK/BACKUP/INCIDENTS to ensure they match the current infra (Ubuntu Server + Docker Compose) and do not reference the old Pi/PM2 setup.

## Documentation

- [x] New ops docs added (`docs/RUNBOOK.md`, `docs/BACKUP.md`, `docs/INCIDENTS.md`).
- [x] CLAUDE/AI instructions updated to reflect stricter PR template usage.
- [x] PR template updated to encourage risk/impact notes and standard squash commit messages.
- [x] N/A — no code behaviour changes.

## Notes for Reviewer

- This PR is intentionally docs-only; no application behaviour changes.
- Focus review on:
  - Whether RUNBOOK/BACKUP/INCIDENTS cover the real-world tasks you actually perform.
  - Whether any remaining references to the Pi/PM2 era slipped through in the new docs.
  - Whether the new PR template fields feel like the right level of strictness vs ceremony.
