### PR TITLE
docs(ai): document AI-managed issue labelling lifecycle and types (issue #284)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,12 @@ gh pr create --base dev --title "Title" --body "Description. Closes #N"
 
 **Every PR must use and fully fill in the template at `.github/pull_request_template.md`** — summary, changes, detailed test plan, smoke test section, and documentation checklist (including ops docs). Treat any unchecked or "N/A" box as a deliberate decision that needs to be correct.
 
+**Issue labelling (AI-managed):**
+- When starting work on an issue: apply the `in progress` label.
+- When opening a PR to `dev` for that issue: switch the label to `awaiting review`.
+- After the PR is merged to `dev` but before it is released to `main`: switch the label to `awaiting release`.
+- After the change is deployed to production (release PR merged to `main`): switch the label to `released`.
+
 ### Deployment (From Windows)
 
 ```powershell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,10 +132,20 @@ gh pr create --base dev --title "Title" --body "Description. Closes #N"
 **Every PR must use and fully fill in the template at `.github/pull_request_template.md`** — summary, changes, detailed test plan, smoke test section, and documentation checklist (including ops docs). Treat any unchecked or "N/A" box as a deliberate decision that needs to be correct.
 
 **Issue labelling (AI-managed):**
-- When starting work on an issue: apply the `in progress` label.
-- When opening a PR to `dev` for that issue: switch the label to `awaiting review`.
-- After the PR is merged to `dev` but before it is released to `main`: switch the label to `awaiting release`.
-- After the change is deployed to production (release PR merged to `main`): switch the label to `released`.
+- **State labels**
+  - When starting work on an issue: apply the `in progress` label.
+  - When opening a PR to `dev` for that issue: switch the label to `awaiting review`.
+  - After the PR is merged to `dev` but before it is released to `main`: switch the label to `awaiting release`.
+  - After the change is deployed to production (release PR merged to `main`): switch the label to `released`.
+- **Type labels** (add all that apply)
+  - `bug` / `feature` — based on the issue template or description.
+  - `security`, `auth` — auth, WebAuthn, JWT, token, crypto, or sensitive data handling changes.
+  - `ops` — deployment scripts, Docker/Compose, CI/test pipeline, server/infra changes.
+  - `documentation` — docs-only or docs-heavy work (CHANGELOG, SECURITY, AI/CLAUDE, TESTING, RUNBOOK, etc.).
+  - `workflow`, `meta` — process, templates, automation, AI instructions.
+  - `high priority` — issues explicitly called out as urgent or blocking.
+  - `regression` — re-breaks of previously fixed behaviour, or bugs primarily caught by regression tests.
+  - `UI` — CSS/HTML/JS changes that primarily affect layout, styling, or interaction.
 
 ### Deployment (From Windows)
 

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -96,6 +96,28 @@ If the issue doesn't exist yet, create it on GitHub with:
 
 Use the appropriate issue template from `.github/ISSUE_TEMPLATE/` — `bug_report.md` for bugs, `feature_request.md` for new functionality.
 
+**Issue labelling (AI-managed):**
+
+Always apply both a **state label** and any relevant **type labels**:
+
+- **State labels**
+  - When starting work on an issue: apply `in progress`.
+  - When opening a PR to `dev` for that issue: switch to `awaiting review`.
+  - After the PR is merged to `dev` but before it is released to `main`: switch to `awaiting release`.
+  - After the change is deployed to production (release PR merged to `main`): switch to `released`.
+
+- **Type labels** (add all that apply)
+  - `bug` / `feature` — based on the issue template or description.
+  - `security`, `auth` — auth, WebAuthn, JWT, token, crypto, or sensitive data handling changes.
+  - `ops` — deployment scripts, Docker/Compose, CI/test pipeline, server/infra changes.
+  - `documentation` — docs-only or docs-heavy work (CHANGELOG, SECURITY, AI/CLAUDE, TESTING, RUNBOOK, etc.).
+  - `workflow`, `meta` — process, templates, automation, AI instructions.
+  - `high priority` — issues explicitly called out as urgent or blocking.
+  - `regression` — re-breaks of previously fixed behaviour, or bugs primarily caught by regression tests.
+  - `UI` — CSS/HTML/JS changes that primarily affect layout, styling, or interaction.
+
+The AI is responsible for adding/removing these labels as the issue moves through its lifecycle; do not wait for a separate prompt to update them.
+
 ### 2. Planning
 Before writing code:
 1. Read the issue and any linked context
@@ -118,7 +140,8 @@ Once implementation is complete:
 2. Link the issue number (`Closes #N`)
 3. Include a clear summary of what changed and why
 4. Fill in the PR template at `.github/pull_request_template.md` in full — summary, changes, test plan, smoke test checkbox, and documentation checklist
-5. Wait for review, testing, and approval before merging
+5. Update the linked issue's state label to `awaiting review` (if not already set)
+6. Wait for review, testing, and approval before merging
 
 The AI does not merge PRs — you will review, test locally, and merge when ready.
 
@@ -157,6 +180,8 @@ The AI will:
    - Links to all related PRs merged since last release
 4. Append an entry to `docs/RELEASE_NOTES.md` (see [Doc Lifecycle](#doc-lifecycle) below)
 5. Archive or clean up any planning docs whose work is now fully shipped (see [Doc Lifecycle](#doc-lifecycle) below)
+6. Update all linked issues:
+   - Change state label from `awaiting release` to `released`.
 
 You will:
 1. Review the release summary
@@ -173,6 +198,7 @@ If a critical bug is discovered on production:
 4. After merging to `main`, instruct: `Merge hotfix into dev to keep branches in sync`
 5. The AI will merge `main` back to `dev`
 6. A hotfix entry is appended to `docs/RELEASE_NOTES.md`
+7. Update the linked issue's state label to `released` once the hotfix is live on `main`.
 
 ### Branching diagram
 
@@ -416,6 +442,7 @@ For urgent production bugs that can't wait for the normal release cycle:
 2. Fix, commit, and raise a PR → `main` with a hotfix summary
 3. After merging to `main`, merge back to `dev` to keep branches in sync
 4. Append a hotfix entry to `docs/RELEASE_NOTES.md`
+5. Update the linked issue's state label to `released` once the hotfix is live on `main`.
 
 Pattern: `hotfix/issue-N-* → main` (you approve), then `main → dev`
 


### PR DESCRIPTION
## Summary

Document AI-managed issue labelling so that both state and type labels are applied consistently without additional prompts.

Closes #284

## Changes

- `docs/AI.md` — will be updated to add an explicit "Issue labelling" subsection under "Expected AI Workflow" describing:
  - State labels managed by AI (`in progress`, `awaiting review`, `awaiting release`, `released`)
  - Type labels that must be applied when applicable (e.g. `bug`, `feature`, `security`, `auth`, `ops`, `documentation`, `workflow`, `meta`, `high priority`, `regression`, `UI`).
- `CLAUDE.md` — already updated to document the AI-managed state labels lifecycle and the use of `released` as the final deployed state.

## Test Plan

Documentation-only behavioural change:

- [x] Confirm `CLAUDE.md` clearly documents the state label lifecycle, including `released`.
- [ ] Update `docs/AI.md` to introduce the new "Issue labelling" subsection and re-run a render/preview to ensure headings and lists render correctly.
- [ ] Sanity-check label names against the actual labels configured in the repo; adjust wording in `docs/AI.md` if any differ.

## Documentation

- [x] `CLAUDE.md` updated for AI-managed state labels.
- [ ] `docs/AI.md` to be updated for both state and type labels as part of this PR.
- [x] N/A — no code behaviour changes.

## Notes for Reviewer

- This PR is strictly about documenting and standardising behaviour that mostly already happens in practice: AI-managed issue labels for lifecycle and classification.
- Review with an eye to whether the chosen label names (`in progress`, `awaiting review`, `awaiting release`, `released` and the type labels) match how you actually want to view the board at a glance.
