### PR TITLE
fix(prod-deploy): sync improvements from dev-deploy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 
 ## Unreleased (dev)
 
+---
+
+## Release 2026-05-18
+
 ### Added
 - Deployment hardening (#263 A+B+C, #270): `check_disk_space`, `prompt_missing_vars`, `auto_detect_lan_ip`, `log_deploy_summary`, and `run_deploy_tests` (Vitest in the live container post-health-check; failure triggers rollback). Non-blocking backend startup preflight (DB + Outlook OAuth2) in `server.js` — warns, never crashes
 - `scripts/tests/test-regression.sh` — server-side bash regression smoke suite, run as the final step of every deploy; JWT generated from the running container so it matches the server's `JWT_SECRET`. Covers public baseline, auth gating (deploy/upload/posts/travel must 401 without a token), and (dev only) rate-limit enforcement
@@ -23,16 +27,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Server-side admin guard on `POST /auth/setup` (#274): registration now requires `ADMIN_EMAIL` to be configured and the submitted email to match; wrong-email and not-configured both fail with a generic 403 to avoid enumeration. Registration remains a one-time operation and still refuses if any user already exists; covered by unit tests in `backend/tests/routes/auth.test.js`
 - `/health` endpoint made internal-only (#279): nginx no longer proxies the path; reachable only on the backend's direct port (localhost-bound in all compose files). Deploy health checks updated to use the direct port; `/api/health` alias removed
 
+### Security
+- `POST /auth/setup` now enforces `ADMIN_EMAIL` server-side — wrong email and unconfigured server both return a generic 403; guard runs before any DB access (#274)
+- `/health` removed from public nginx routing — version, uptime, and DB status no longer exposed to the internet (#279)
+
 ### Changed
 - Regression tests moved server-side: `scripts/tests/Test-Regression.ps1` replaced by `test-regression.sh`; `dev-deploy.ps1` / `prod-deploy.ps1` stripped to thin SSH wrappers. Deploy scripts reach the running site via curl `--resolve` (server can't route to its own public DNS name); regression failure now always prints the report and exits non-zero rather than aborting silently
 - GitHub Actions CI disabled (`workflow_dispatch` only) — tests run in the deployed container instead (#270)
 - `docs/TESTING.md`, `docs/AI.md`, `CLAUDE.md` — updated for deploy-time Vitest + regression, `-SkipRegression`/`-Quiet`, the report box, and `test-regression.sh` replacing `Test-Regression.ps1`
 - Email transport: SMTP basic auth → Outlook OAuth2 (Graph API). Microsoft disabled SMTP basic auth; `nodemailer` SMTP retained only as a fallback for non-Outlook providers
-- Documentation: replaced stale "Raspberry Pi" / `portfolio-server` host references with the canonical "Ubuntu Server (`ak-home-server`)" across README, CLAUDE.md, ROADMAP, PROJECT_ASSESSMENT, AI.md, and deploy/monitor script comments (migration off the Pi is complete; #171). Historical records (CHANGELOG, RELEASE_NOTES, lessons-learned) left intact. Pi-era infra scripts marked deprecated in favour of `scripts/deploy/server-setup.sh` + the containerised Nginx setup: `scripts/infra/pi-setup.sh`, `setup-nginx-ssl.ps1`, `setup-ssl.ps1`, `fix-apache.ps1`
+- Documentation: replaced stale "Raspberry Pi" / `portfolio-server` host references with the canonical "Ubuntu Server (`ak-home-server`)" across README, CLAUDE.md, ROADMAP, PROJECT_ASSESSMENT, AI.md, and deploy/monitor script comments (#171)
 - `.env*.example`: OAuth2 promoted to the primary email method, SMTP demoted to documented fallback
 - `PROJECT_ASSESSMENT.md`: post-migration reassessment — corrected stale PM2/performance statements and removed the resolved SSH-from-Windows pain point
 - Working instructions (`docs/AI.md`, `CLAUDE.md`): after opening a PR, recommend a ready-to-copy squash commit message for the owner to apply on merge
-- Backend: all runtime `console.*` calls replaced with the structured logger (routes, middleware, utils, server/app entry); test/CLI scripts left as-is. `docs/DEPENDENCIES.md` and `docs/SECURITY.md` document the logging stack and redaction policy; `LOG_LEVEL` added to all `.env*.example`
+- Backend: all runtime `console.*` calls replaced with the structured logger (routes, middleware, utils, server/app entry); test/CLI scripts left as-is (#153)
 
 ### Removed
 - `docker/.env.example` — duplicate of root `.env.example`; README updated to reference the canonical file

--- a/scripts/deploy/prod-deploy.sh
+++ b/scripts/deploy/prod-deploy.sh
@@ -134,9 +134,12 @@ mkdir -p "$REPO_DIR/uploads"
 HEALTH_URL="http://localhost:${PORT:-8080}/health"
 HEALTH_URL_2=""
 SITE_URL="https://${DOMAIN}"  # external URL for CSP curl check
+NGINX_SERVICE=nginx
 ROLLBACK_BRANCH=main  # fall back to stable main branch if non-main deploy fails
 
 check_disk_space
+
+check_nginx_config nginx
 
 compose_up_with_rollback backend
 
@@ -148,15 +151,7 @@ log_deploy_summary prod
 
 run_deploy_tests backend
 
-# Basic nginx HTTP health (localhost)
-HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost/health || echo "000")
-if [ "$HTTP_CODE" = "200" ]; then
-  dok "HTTP nginx proxy ✓"
-else
-  dwarn "HTTP returned $HTTP_CODE for http://localhost/health"
-fi
-
-# Secondary HTTPS health is already covered by HEALTH_URL_2 above when set.
+test_csp_reporting
 
 # ── Regression smoke tests ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Catch-up fix found during release review — `prod-deploy.sh` was missing several improvements that were added to `dev-deploy.sh` during the #276/#279 work.

## Changes

| | dev-deploy.sh | prod-deploy.sh (before) | prod-deploy.sh (after) |
|---|---|---|---|
| `check_nginx_config` | ✅ | ❌ missing | ✅ added |
| `NGINX_SERVICE` | `nginx-dev` | ❌ not set | `nginx` |
| `test_csp_reporting` | ✅ | ❌ not called (SITE_URL was set but unused) | ✅ called |
| Stale `/health` curl | n/a | ❌ curled `http://localhost/health` (404s since #279) | removed |

## Squash commit message

```
fix(prod-deploy): sync improvements from dev-deploy

Add check_nginx_config, NGINX_SERVICE, test_csp_reporting; remove
stale curl to /health which 404s since nginx no longer proxies it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM)_