### PR TITLE
fix(security): rate-limit email/verify; escape XSS in token generator

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -123,6 +123,7 @@ router.get('/me', authenticate, async (req, res) => {
 
 // ── Passkey registration ───────────────────────────────────────────────────────
 
+// lgtm[js/missing-rate-limiting] -- passkeyRateLimit middleware applied
 router.post('/passkey/register/start', passkeyRateLimit, authenticate, async (req, res) => {
   try {
     const userId = req.user.id;
@@ -168,6 +169,7 @@ router.post('/passkey/register/start', passkeyRateLimit, authenticate, async (re
   }
 });
 
+// lgtm[js/missing-rate-limiting] -- passkeyRateLimit middleware applied
 router.post('/passkey/register/finish', passkeyRateLimit, authenticate, validate(PasskeyRegisterFinishSchema), async (req, res) => {
   try {
     const { response, sessionKey, passkeyName } = req.body;
@@ -220,6 +222,7 @@ router.post('/passkey/register/finish', passkeyRateLimit, authenticate, validate
 
 // ── Passkey authentication ────────────────────────────────────────────────────
 
+// lgtm[js/missing-rate-limiting] -- passkeyRateLimit middleware applied
 router.post('/passkey/login/start', passkeyRateLimit, async (req, res) => {
   try {
     const { email } = req.body;
@@ -262,6 +265,7 @@ router.post('/passkey/login/start', passkeyRateLimit, async (req, res) => {
   }
 });
 
+// lgtm[js/missing-rate-limiting] -- passkeyRateLimit middleware applied
 router.post('/passkey/login/finish', passkeyRateLimit, validate(PasskeyLoginFinishSchema), async (req, res) => {
   try {
     const { response, sessionKey } = req.body;
@@ -321,6 +325,7 @@ router.post('/passkey/login/finish', passkeyRateLimit, validate(PasskeyLoginFini
 
 // ── Email magic link ──────────────────────────────────────────────────────────
 
+// lgtm[js/missing-rate-limiting] -- emailRateLimit middleware applied
 router.post('/email/send', emailRateLimit, validate(EmailSendSchema), async (req, res) => {
   try {
     const { email } = req.body;
@@ -378,6 +383,7 @@ router.post('/email/send', emailRateLimit, validate(EmailSendSchema), async (req
   }
 });
 
+// lgtm[js/missing-rate-limiting] -- emailRateLimit middleware applied
 router.get('/email/verify', emailRateLimit, async (req, res) => {
   try {
     const { token } = req.query;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -378,7 +378,7 @@ router.post('/email/send', emailRateLimit, validate(EmailSendSchema), async (req
   }
 });
 
-router.get('/email/verify', async (req, res) => {
+router.get('/email/verify', emailRateLimit, async (req, res) => {
   try {
     const { token } = req.query;
     // Never log the raw token — it is a bearer credential.

--- a/backend/routes/contact.js
+++ b/backend/routes/contact.js
@@ -12,6 +12,7 @@ const contactRateLimit = createRateLimiter({
   message: 'Too many requests. Please try again later.',
 });
 
+// lgtm[js/missing-rate-limiting] -- contactRateLimit middleware applied
 router.post('/', contactRateLimit, validate(ContactSchema), async (req, res) => {
   // Honeypot: bots fill in the hidden website field — silently accept
   if (req.body.website) {

--- a/scripts/generate-outlook-refresh-token.js
+++ b/scripts/generate-outlook-refresh-token.js
@@ -68,8 +68,9 @@ async function main() {
       await exchangeCodeForToken(CLIENT_ID, CLIENT_SECRET);
       server.close();
     } else if (query.error) {
+      const esc = (s) => String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
       res.writeHead(400, { 'Content-Type': 'text/html' });
-      res.end(`<h1>✗ Authorization failed</h1><p>Error: ${query.error}</p>`);
+      res.end(`<h1>✗ Authorization failed</h1><p>Error: ${esc(query.error)}</p>`);
       console.error('\n✗ Authorization failed:', query.error);
       if (query.error_description) {
         console.error('Description:', query.error_description);


### PR DESCRIPTION
Addresses the two genuine CodeQL findings on PR #289.

## Fixes

### ✅ Missing rate limit on `GET /email/verify` (CodeQL #68 / line 454)
`/email/send` was rate-limited but `/email/verify` was not — an attacker with a valid user ID could brute-force the UUID token space. Added `emailRateLimit` (5/hr/IP) to the verify route.

### ✅ Reflected XSS in `generate-outlook-refresh-token.js` (CodeQL #60 / line 72)
`query.error` from the OAuth2 callback URL was interpolated directly into an HTML response. Escaped with a minimal inline `esc()` function (no dependency needed for a CLI script).

## False positives on PR #289 (no fix needed)

The remaining 7 CodeQL findings flag routes that are already rate-limited — CodeQL cannot see through the Express middleware chain:

| Line | Route | Middleware present |
|------|-------|--------------------|
| 126 | `POST /passkey/register/start` | `passkeyRateLimit` |
| 171 | `POST /passkey/register/finish` | `passkeyRateLimit` |
| 223 | `POST /passkey/login/start` | `passkeyRateLimit` |
| 265 | `POST /passkey/login/finish` | `passkeyRateLimit` |
| 322/359 | `POST /email/send` | `emailRateLimit` |
| contact:15 | `POST /` | `contactRateLimit` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM)_