### PR TITLE
feat: restore dev-env visual indicators for dev server (#209)

### DIFF
--- a/resources/js/dev-env.js
+++ b/resources/js/dev-env.js
@@ -1,3 +1,10 @@
+/**
+ * dev-env.js — Visual indicator for non-production environments.
+ * Prepends [DEV] to the page title, tints the A|K nav logo orange,
+ * and tints the favicon when running on localhost, 127.0.0.1, or
+ * port 3001 (dev server), so the browser tab and nav are immediately
+ * distinguishable from the live site.
+ */
 (function () {
     const isDev =
         location.hostname === 'localhost' ||

--- a/resources/js/dev-env.js
+++ b/resources/js/dev-env.js
@@ -1,18 +1,17 @@
-/**
- * dev-env.js — Visual indicator for non-production environments.
- * Prepends [DEV] to the page title and tints the favicon
- * when running on localhost or 127.0.0.1, so the browser tab is
- * immediately distinguishable from the live site.
- */
 (function () {
-    const isLocal =
+    const isDev =
         location.hostname === 'localhost' ||
-        location.hostname === '127.0.0.1';
+        location.hostname === '127.0.0.1' ||
+        location.port === '3001';
 
-    if (!isLocal) return;
+    if (!isDev) return;
 
     // Prefix page title
     document.title = '[DEV] ' + document.title;
+
+    // Tint the A|K nav logo orange
+    const navLabel = document.querySelector('.nav-toggle-label');
+    if (navLabel) navLabel.style.color = 'darkorange';
 
     // Tint favicon so the tab icon is visually distinct
     const favicon = document.querySelector('link[rel*="icon"]');
@@ -24,7 +23,6 @@
             canvas.width = img.naturalWidth || 32;
             canvas.height = img.naturalHeight || 32;
             const ctx = canvas.getContext('2d');
-            // Draw original favicon with an orange tint overlay
             ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
             ctx.globalCompositeOperation = 'source-atop';
             ctx.fillStyle = 'rgba(255, 140, 0, 0.55)';

--- a/setup/index.html
+++ b/setup/index.html
@@ -50,5 +50,6 @@
 
     <script type="module" src="/resources/js/setup.js"></script>
     <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/dev-env.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `dev-env.js` previously only detected `localhost`/`127.0.0.1`, so indicators were invisible on the Ubuntu dev server (`dev.andykeys.me:3001`)
- Add `location.port === '3001'` to the detection condition
- Orange `A|K` nav label and `[DEV]` title prefix now appear on all dev server pages
- Add `dev-env.js` to `setup/index.html` — the only page not already loading it

## Changes

- `resources/js/dev-env.js` — extend detection to port 3001; add orange tint to `.nav-toggle-label`
- `setup/index.html` — add missing `dev-env.js` script tag

## Test plan

Deploy to dev server and visit each page via `https://dev.andykeys.me:3001`:

```bash
# Verify [DEV] prefix appears in browser tab title and A|K nav label is orange
# Check each page:
# https://dev.andykeys.me:3001/
# https://dev.andykeys.me:3001/blog/
# https://dev.andykeys.me:3001/travel/
# https://dev.andykeys.me:3001/admin/
# https://dev.andykeys.me:3001/login/
# https://dev.andykeys.me:3001/setup/
```

Expected: `[DEV] <Page Title>` in tab, orange `A|K` in nav, orange-tinted favicon.

```bash
# Verify production site is unaffected (no [DEV] prefix, no orange logo)
# https://andykeys.me/
```

Expected: normal title, normal nav colour.

## Documentation

- N/A: behaviour change only; no operator docs affected.

Closes #209

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM)_