### PR TITLE
fix: shared box-drawing helpers — dynamic widths across all deploy and ops scripts (#312)

### DIFF
--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1069,10 +1069,13 @@ print_deploy_report() {
   local label="${1:-unknown}"
   local width=72  # inner content width (between ║  and  ║)
   local border; border=$(printf '═%.0s' $(seq 1 $((width + 4))))
+  local _title _title_pad
+  _title="Deploy Report — ${label} — $(date '+%Y-%m-%d %H:%M:%S')"
+  _title_pad=$(( width + 2 - ${#_title} ))  # fill to same total width as content rows
 
   echo ""
   echo "╔${border}╗"
-  printf "║  %-${width}s  ║\n" "Deploy Report — ${label} — $(date '+%Y-%m-%d %H:%M:%S')"
+  printf "║  %s%*s║\n" "$_title" "$_title_pad" ""
   echo "╠${border}╣"
   # Only this run's lines (log is append-only across deploys), and only
   # checkpoint lines anchored at column 0 — so prose / commit-message text

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -52,32 +52,8 @@ fi
 
 _deploy_timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
 
-# Return the visual (terminal column) width of a plain-text string.
-# ${#s} counts Unicode code points; wide emoji render as 2 columns, so add 1 per occurrence.
-_visual_width() {
-  local s="$1" width
-  width=${#s}
-  local e
-  for e in 🚀 ✅ ❌ 🧪 🔷 ↩️; do
-    local stripped="${s//$e/}"
-    local count=$(( ${#s} - ${#stripped} ))
-    width=$(( width + count ))
-  done
-  echo "$width"
-}
-
-# Print a single-line banner box sized dynamically to fit content.
-# Usage: _print_box <colour> <plain_text_content>
-_print_box() {
-  local colour="$1" content="$2"
-  local inner_width; inner_width=$(_visual_width "$content")
-  local border; border=$(printf '═%.0s' $(seq 1 $(( inner_width + 4 ))))
-  echo "" | tee -a "$LOG_FILE"
-  echo -e "${colour}╔${border}╗${DEPLOY_RESET}" | tee -a "$LOG_FILE"
-  echo -e "${colour}║  ${content}  ║${DEPLOY_RESET}" | tee -a "$LOG_FILE"
-  echo -e "${colour}╚${border}╝${DEPLOY_RESET}" | tee -a "$LOG_FILE"
-  echo "" | tee -a "$LOG_FILE"
-}
+# shellcheck source=output-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/output-lib.sh"
 
 # Redact sensitive info from logs (IP addresses, usernames, service names, hostnames)
 # See docs/LOGGING.md for what should be redacted and why

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -52,6 +52,33 @@ fi
 
 _deploy_timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
 
+# Return the visual (terminal column) width of a plain-text string.
+# ${#s} counts Unicode code points; wide emoji render as 2 columns, so add 1 per occurrence.
+_visual_width() {
+  local s="$1" width
+  width=${#s}
+  local e
+  for e in 🚀 ✅ ❌ 🧪 🔷 ↩️; do
+    local stripped="${s//$e/}"
+    local count=$(( ${#s} - ${#stripped} ))
+    width=$(( width + count ))
+  done
+  echo "$width"
+}
+
+# Print a single-line banner box sized dynamically to fit content.
+# Usage: _print_box <colour> <plain_text_content>
+_print_box() {
+  local colour="$1" content="$2"
+  local inner_width; inner_width=$(_visual_width "$content")
+  local border; border=$(printf '═%.0s' $(seq 1 $(( inner_width + 4 ))))
+  echo "" | tee -a "$LOG_FILE"
+  echo -e "${colour}╔${border}╗${DEPLOY_RESET}" | tee -a "$LOG_FILE"
+  echo -e "${colour}║  ${content}  ║${DEPLOY_RESET}" | tee -a "$LOG_FILE"
+  echo -e "${colour}╚${border}╝${DEPLOY_RESET}" | tee -a "$LOG_FILE"
+  echo "" | tee -a "$LOG_FILE"
+}
+
 # Redact sensitive info from logs (IP addresses, usernames, service names, hostnames)
 # See docs/LOGGING.md for what should be redacted and why
 _redact_sensitive() {
@@ -178,11 +205,7 @@ init_log_banner() {
   # only includes checkpoints from THIS deploy, not every prior run.
   DEPLOY_LOG_START=$([ -f "$LOG_FILE" ] && wc -l < "$LOG_FILE" || echo 0)
   # Always printed regardless of DEPLOY_QUIET — provides run context in all modes
-  echo "" | tee -a "$LOG_FILE"
-  echo -e "${DEPLOY_CYAN}${DEPLOY_BOLD}╔══════════════════════════════════════════╗${DEPLOY_RESET}" | tee -a "$LOG_FILE"
-  echo -e "${DEPLOY_CYAN}${DEPLOY_BOLD}║  🚀 ${title} — $(_deploy_timestamp)  ║${DEPLOY_RESET}" | tee -a "$LOG_FILE"
-  echo -e "${DEPLOY_CYAN}${DEPLOY_BOLD}╚══════════════════════════════════════════╝${DEPLOY_RESET}" | tee -a "$LOG_FILE"
-  echo "" | tee -a "$LOG_FILE"
+  _print_box "${DEPLOY_CYAN}${DEPLOY_BOLD}" "🚀 ${title} — $(_deploy_timestamp)"
 }
 
 # Pipe command output to the log. In verbose mode also echoes to terminal.
@@ -1059,11 +1082,7 @@ print_deploy_status() {
     "ROLLED BACK") colour="${DEPLOY_YELLOW}${DEPLOY_BOLD}"; icon="↩️ " ;;
     *)             colour="${DEPLOY_RED}${DEPLOY_BOLD}";    icon="❌" ;;
   esac
-  echo "" | tee -a "$LOG_FILE"
-  echo -e "${colour}╔══════════════════════════════════════════════════════════╗${DEPLOY_RESET}" | tee -a "$LOG_FILE"
-  echo -e "${colour}║  ${icon}  DEPLOY ${status} — ${label} — $(_deploy_timestamp)${DEPLOY_RESET}" | tee -a "$LOG_FILE"
-  echo -e "${colour}╚══════════════════════════════════════════════════════════╝${DEPLOY_RESET}" | tee -a "$LOG_FILE"
-  echo "" | tee -a "$LOG_FILE"
+  _print_box "$colour" "${icon}  DEPLOY ${status} — ${label} — $(_deploy_timestamp)"
 }
 
 # Print a human-readable final deploy report by extracting all [deploy:*] and

--- a/scripts/deploy/dev-server-deploy.sh
+++ b/scripts/deploy/dev-server-deploy.sh
@@ -72,6 +72,9 @@ else
     RED=''; YELLOW=''; GREEN=''; CYAN=''; BOLD=''; RESET=''
 fi
 
+# shellcheck source=output-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/output-lib.sh"
+
 timestamp() { date '+%Y-%m-%d %H:%M:%S'; }
 log()     { echo -e "[$(timestamp)] $*" | tee -a "$LOG_FILE"; }
 info()    { log "${CYAN}${BOLD}[INFO]${RESET}  $*"; }
@@ -164,9 +167,7 @@ _check_or_generate_dev_certs() {
 # ── Entry point ─────────────────────────────────────────────────────────────────────────
 
 log ""
-log "${BOLD}╔══════════════════════════════════════════╗${RESET}"
-log "${BOLD}║     Dev Server Deploy — $(timestamp)   ║${RESET}"
-log "${BOLD}╚══════════════════════════════════════════╝${RESET}"
+_print_box "${BOLD}" "Dev Server Deploy — $(timestamp)"
 log ""
 # log "[DEBUG] Script header: DEPLOY_BRANCH='$DEPLOY_BRANCH' DEV_REPO='$DEV_REPO' COMPOSE_FILE='$COMPOSE_FILE'" | tee -a "$LOG_FILE"
 
@@ -590,9 +591,7 @@ info "Container status:"
 docker compose -f "$COMPOSE_FILE" ps 2>&1 | tee -a "$LOG_FILE"
 
 log ""
-log "${BOLD}╔══════════════════════════════════════════╗${RESET}"
-log "${BOLD}║           Dev deploy complete ✓          ║${RESET}"
-log "${BOLD}╚══════════════════════════════════════════╝${RESET}"
+_print_box "${BOLD}" "Dev deploy complete ✓"
 log ""
 
 # ── Section 9: Post-deploy configuration setup ──────────────────────────────────────────────

--- a/scripts/deploy/output-lib.sh
+++ b/scripts/deploy/output-lib.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# output-lib.sh — Shared box-drawing helpers for deploy, test, and ops scripts.
+#
+# Source this file to get _visual_width, _print_box, and _print_multi_box.
+# Callers supply their own colour escape strings; this lib provides _OUT_RESET.
+#
+# Log-file tee: if $LOG_FILE is set and non-empty in the calling script,
+# all box output is automatically tee'd to that file.
+
+# ── Colour reset (detected once at source time) ───────────────────────────────
+
+if [ -t 1 ]; then
+  _OUT_RESET='\033[0m'
+  _OUT_BOLD='\033[1m'
+else
+  _OUT_RESET=''
+  _OUT_BOLD=''
+fi
+
+# ── Internal emit helpers ─────────────────────────────────────────────────────
+
+# Emit a line — tee to $LOG_FILE if set, otherwise plain stdout.
+_out_emit() {
+  if [ -n "${LOG_FILE:-}" ]; then
+    echo -e "$*" | tee -a "$LOG_FILE"
+  else
+    echo -e "$*"
+  fi
+}
+
+# printf variant of _out_emit — passes all args straight to printf.
+_out_printf() {
+  if [ -n "${LOG_FILE:-}" ]; then
+    printf "$@" | tee -a "$LOG_FILE"
+  else
+    printf "$@"
+  fi
+}
+
+# ── Width helper ──────────────────────────────────────────────────────────────
+
+# Return the visual (terminal column) width of a plain-text string.
+# ${#s} counts Unicode code points; wide emoji render as 2 columns, so add 1
+# per occurrence to get the true display width.
+_visual_width() {
+  local s="$1" width
+  width=${#s}
+  local e
+  for e in 🚀 ✅ ❌ 🧪 🔷 ↩️; do
+    local stripped="${s//$e/}"
+    local count=$(( ${#s} - ${#stripped} ))
+    width=$(( width + count ))
+  done
+  echo "$width"
+}
+
+# ── Box primitives ────────────────────────────────────────────────────────────
+
+# Print a single-line banner box sized dynamically to fit content.
+# Usage: _print_box <colour> <plain_text_content>
+# Example: _print_box "${CYAN}${BOLD}" "🚀 Deploy — 2026-05-19 21:37:00"
+_print_box() {
+  local colour="$1" content="$2"
+  local inner_width; inner_width=$(_visual_width "$content")
+  local border; border=$(printf '═%.0s' $(seq 1 $(( inner_width + 4 ))))
+  _out_emit ""
+  _out_emit "${colour}╔${border}╗${_OUT_RESET}"
+  _out_emit "${colour}║  ${content}  ║${_OUT_RESET}"
+  _out_emit "${colour}╚${border}╝${_OUT_RESET}"
+  _out_emit ""
+}
+
+# Print a multi-line box: title row, divider, then one or more content rows.
+# Content rows are left-padded with 2 spaces and right-padded to content_width.
+# The title is padded to fill the same inner width.
+# Usage: _print_multi_box <colour> <content_width> <title> [row ...]
+# Example: _print_multi_box "$C" 60 "🧪 Regression — OK" "Passed : 20 / 20"
+_print_multi_box() {
+  local colour="$1" content_w="$2" title="$3"
+  shift 3
+  local inner_w=$(( content_w + 2 ))  # border width = content + 2 leading spaces
+  local title_w; title_w=$(_visual_width "$title")
+  local title_pad=$(( content_w - title_w ))  # pad fills content_w; leading 2 spaces are outside
+  local border; border=$(printf '═%.0s' $(seq 1 $inner_w))
+  _out_emit ""
+  _out_emit "${colour}╔${border}╗${_OUT_RESET}"
+  _out_printf "${colour}║  %s%*s║${_OUT_RESET}\n" "$title" "$title_pad" ""
+  _out_emit "${colour}╠${border}╣${_OUT_RESET}"
+  local row
+  for row in "$@"; do
+    _out_printf "${colour}║  %-${content_w}s║${_OUT_RESET}\n" "$row"
+  done
+  _out_emit "${colour}╚${border}╝${_OUT_RESET}"
+  _out_emit ""
+}

--- a/scripts/ops/gather-infrastructure-info.sh
+++ b/scripts/ops/gather-infrastructure-info.sh
@@ -6,10 +6,11 @@
 
 set +e  # Don't exit on errors — collect what we can
 
-echo "╔════════════════════════════════════════════════════════════════╗"
-echo "║  INFRASTRUCTURE INFO GATHERING                                 ║"
-echo "║  Run this on the Ubuntu Server, pipe output to a file or copy ║"
-echo "╚════════════════════════════════════════════════════════════════╝"
+# shellcheck source=../deploy/output-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../deploy/output-lib.sh"
+
+_print_multi_box "" 60 "INFRASTRUCTURE INFO GATHERING" \
+  "Run this on the Ubuntu Server, pipe output to a file or copy"
 echo ""
 
 # ── System Info ────────────────────────────────────────────────────────────

--- a/scripts/ops/security-debug-report.sh
+++ b/scripts/ops/security-debug-report.sh
@@ -16,10 +16,10 @@ red()    { echo -e "\033[0;31m✗  $*\033[0m"; ((FAIL++)); }
 yellow() { echo -e "\033[1;33m⚠  $*\033[0m"; ((WARN++)); }
 section(){ echo ""; echo "──────────────────────────────────────────────"; echo "  $*"; echo "──────────────────────────────────────────────"; }
 
-echo "╔══════════════════════════════════════════════╗"
-echo "║  SECURITY DEBUG REPORT                       ║"
-echo "║  Target: $HOST"
-echo "╚══════════════════════════════════════════════╝"
+# shellcheck source=../deploy/output-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../deploy/output-lib.sh"
+
+_print_multi_box "" 40 "SECURITY DEBUG REPORT" "Target: $HOST"
 
 # ── Fetch headers ─────────────────────────────────────────────────────────────
 section "1. HTTP Response Headers"

--- a/scripts/setup/nuclear-rebuild.sh
+++ b/scripts/setup/nuclear-rebuild.sh
@@ -28,10 +28,11 @@ for arg in "$@"; do
     esac
 done
 
-echo ""
-echo "╔══════════════════════════════════════════════════════╗"
-echo "║         NUCLEAR REBUILD — DEV STACK                  ║"
-echo "╚══════════════════════════════════════════════════════╝"
+
+# shellcheck source=../deploy/output-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../deploy/output-lib.sh"
+
+_print_box "" "NUCLEAR REBUILD — DEV STACK"
 echo ""
 echo "This will (DEV STACK ONLY — does not affect production):"
 echo "  ✓ Stop all dev containers"

--- a/scripts/tests/test-regression.sh
+++ b/scripts/tests/test-regression.sh
@@ -24,6 +24,20 @@ else
   C_RED=''; C_YELLOW=''; C_GREEN=''; C_CYAN=''; C_BOLD=''; C_DIM=''; C_RESET=''
 fi
 
+# Return the visual (terminal column) width of a plain-text string.
+# Wide emoji render as 2 columns but ${#s} counts them as 1 — add 1 per occurrence.
+_visual_width() {
+  local s="$1" width
+  width=${#s}
+  local e
+  for e in 🚀 ✅ ❌ 🧪 🔷; do
+    local stripped="${s//$e/}"
+    local count=$(( ${#s} - ${#stripped} ))
+    width=$(( width + count ))
+  done
+  echo "$width"
+}
+
 # Honour the deploy's quiet mode (exported by dev/prod-deploy.sh). In quiet
 # mode, suppress the header box, section headers, INFO lines and per-test
 # PASS/SKIP rows — but ALWAYS keep FAIL rows, the final results box and the
@@ -165,12 +179,19 @@ check_auth() {
 # ── Header ───────────────────────────────────────────────────────────────────────
 
 if [ "$QUIET" != "1" ]; then
+  local _ts; _ts=$(date '+%Y-%m-%d %H:%M:%S')
+  local _title="🧪 Regression Test Run — ${_ts}"
+  local _content_w=60  # printf %-60s content width for detail lines
+  local _inner_w=$(( _content_w + 2 ))  # 2 leading spaces
+  local _title_w; _title_w=$(_visual_width "$_title")
+  local _title_pad=$(( _inner_w - _title_w ))
+  local _border; _border=$(printf '═%.0s' $(seq 1 $_inner_w))
   echo ""
-  echo -e "${C_CYAN}${C_BOLD}╔════════════════════════════════════════════════════════════╗${C_RESET}"
-  echo -e "${C_CYAN}${C_BOLD}║  🧪 Regression Test Run — $(date '+%Y-%m-%d %H:%M:%S')  ║${C_RESET}"
-  printf "${C_CYAN}${C_BOLD}║  %-60s║${C_RESET}\n" "Base URL : $BASE_URL"
-  printf "${C_CYAN}${C_BOLD}║  %-60s║${C_RESET}\n" "Token    : $([ -n "$TOKEN" ] && echo 'auto-generated from container' || echo 'not provided — auth tests skipped')"
-  echo -e "${C_CYAN}${C_BOLD}╚════════════════════════════════════════════════════════════╝${C_RESET}"
+  echo -e "${C_CYAN}${C_BOLD}╔${_border}╗${C_RESET}"
+  printf "${C_CYAN}${C_BOLD}║  %s%*s║${C_RESET}\n" "$_title" "$_title_pad" ""
+  printf "${C_CYAN}${C_BOLD}║  %-${_content_w}s║${C_RESET}\n" "Base URL : $BASE_URL"
+  printf "${C_CYAN}${C_BOLD}║  %-${_content_w}s║${C_RESET}\n" "Token    : $([ -n "$TOKEN" ] && echo 'auto-generated from container' || echo 'not provided — auth tests skipped')"
+  echo -e "${C_CYAN}${C_BOLD}╚${_border}╝${C_RESET}"
   echo ""
 fi
 
@@ -294,14 +315,20 @@ else
   RESULT_ICON="❌"
 fi
 
+_res_content_w=60
+_res_inner_w=$(( _res_content_w + 2 ))
+_res_title="${RESULT_ICON} Regression Results — ${STATUS}"
+_res_title_w=$(_visual_width "$_res_title")
+_res_title_pad=$(( _res_inner_w - _res_title_w ))
+_res_border=$(printf '═%.0s' $(seq 1 $_res_inner_w))
 echo ""
-echo -e "${RESULT_COLOUR}╔════════════════════════════════════════════════════════════╗${C_RESET}"
-echo -e "${RESULT_COLOUR}║  ${RESULT_ICON} Regression Results — ${STATUS}$(printf '%*s' $((36 - ${#STATUS})) '')║${C_RESET}"
-echo -e "${RESULT_COLOUR}╠════════════════════════════════════════════════════════════╣${C_RESET}"
-printf "${RESULT_COLOUR}║  %-60s║${C_RESET}\n" "Passed : $PASS / $TOTAL"
-[ "$SKIP" -gt 0 ] && printf "${C_YELLOW}${C_BOLD}║  %-60s║${C_RESET}\n" "Skipped: $SKIP"
-[ "$FAIL" -gt 0 ] && printf "${C_RED}${C_BOLD}║  %-60s║${C_RESET}\n" "Failed : $FAIL"
-echo -e "${RESULT_COLOUR}╚════════════════════════════════════════════════════════════╝${C_RESET}"
+echo -e "${RESULT_COLOUR}╔${_res_border}╗${C_RESET}"
+printf "${RESULT_COLOUR}║  %s%*s║${C_RESET}\n" "$_res_title" "$_res_title_pad" ""
+echo -e "${RESULT_COLOUR}╠${_res_border}╣${C_RESET}"
+printf "${RESULT_COLOUR}║  %-${_res_content_w}s║${C_RESET}\n" "Passed : $PASS / $TOTAL"
+[ "$SKIP" -gt 0 ] && printf "${C_YELLOW}${C_BOLD}║  %-${_res_content_w}s║${C_RESET}\n" "Skipped: $SKIP"
+[ "$FAIL" -gt 0 ] && printf "${C_RED}${C_BOLD}║  %-${_res_content_w}s║${C_RESET}\n" "Failed : $FAIL"
+echo -e "${RESULT_COLOUR}╚${_res_border}╝${C_RESET}"
 echo ""
 
 # Machine-readable summary line — parsed by print_deploy_report, no colour codes

--- a/scripts/tests/test-regression.sh
+++ b/scripts/tests/test-regression.sh
@@ -24,19 +24,8 @@ else
   C_RED=''; C_YELLOW=''; C_GREEN=''; C_CYAN=''; C_BOLD=''; C_DIM=''; C_RESET=''
 fi
 
-# Return the visual (terminal column) width of a plain-text string.
-# Wide emoji render as 2 columns but ${#s} counts them as 1 — add 1 per occurrence.
-_visual_width() {
-  local s="$1" width
-  width=${#s}
-  local e
-  for e in 🚀 ✅ ❌ 🧪 🔷; do
-    local stripped="${s//$e/}"
-    local count=$(( ${#s} - ${#stripped} ))
-    width=$(( width + count ))
-  done
-  echo "$width"
-}
+# shellcheck source=../deploy/output-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../deploy/output-lib.sh"
 
 # Honour the deploy's quiet mode (exported by dev/prod-deploy.sh). In quiet
 # mode, suppress the header box, section headers, INFO lines and per-test
@@ -179,20 +168,11 @@ check_auth() {
 # ── Header ───────────────────────────────────────────────────────────────────────
 
 if [ "$QUIET" != "1" ]; then
-  local _ts; _ts=$(date '+%Y-%m-%d %H:%M:%S')
-  local _title="🧪 Regression Test Run — ${_ts}"
-  local _content_w=60  # printf %-60s content width for detail lines
-  local _inner_w=$(( _content_w + 2 ))  # 2 leading spaces
-  local _title_w; _title_w=$(_visual_width "$_title")
-  local _title_pad=$(( _inner_w - _title_w ))
-  local _border; _border=$(printf '═%.0s' $(seq 1 $_inner_w))
-  echo ""
-  echo -e "${C_CYAN}${C_BOLD}╔${_border}╗${C_RESET}"
-  printf "${C_CYAN}${C_BOLD}║  %s%*s║${C_RESET}\n" "$_title" "$_title_pad" ""
-  printf "${C_CYAN}${C_BOLD}║  %-${_content_w}s║${C_RESET}\n" "Base URL : $BASE_URL"
-  printf "${C_CYAN}${C_BOLD}║  %-${_content_w}s║${C_RESET}\n" "Token    : $([ -n "$TOKEN" ] && echo 'auto-generated from container' || echo 'not provided — auth tests skipped')"
-  echo -e "${C_CYAN}${C_BOLD}╚${_border}╝${C_RESET}"
-  echo ""
+  _reg_token_text=$([ -n "$TOKEN" ] && echo 'auto-generated from container' || echo 'not provided — auth tests skipped')
+  _print_multi_box "${C_CYAN}${C_BOLD}" 60 \
+    "🧪 Regression Test Run — $(date '+%Y-%m-%d %H:%M:%S')" \
+    "Base URL : $BASE_URL" \
+    "Token    : $_reg_token_text"
 fi
 
 # Clean slate so contact validation checks aren't tripped by counters left
@@ -316,18 +296,17 @@ else
 fi
 
 _res_content_w=60
-_res_inner_w=$(( _res_content_w + 2 ))
 _res_title="${RESULT_ICON} Regression Results — ${STATUS}"
 _res_title_w=$(_visual_width "$_res_title")
-_res_title_pad=$(( _res_inner_w - _res_title_w ))
-_res_border=$(printf '═%.0s' $(seq 1 $_res_inner_w))
+_res_title_pad=$(( _res_content_w - _res_title_w ))  # leading 2 spaces already in format string
+_res_border=$(printf '═%.0s' $(seq 1 $(( _res_content_w + 2 ))))
 echo ""
-echo -e "${RESULT_COLOUR}╔${_res_border}╗${C_RESET}"
-printf "${RESULT_COLOUR}║  %s%*s║${C_RESET}\n" "$_res_title" "$_res_title_pad" ""
-echo -e "${RESULT_COLOUR}╠${_res_border}╣${C_RESET}"
-printf "${RESULT_COLOUR}║  %-${_res_content_w}s║${C_RESET}\n" "Passed : $PASS / $TOTAL"
-[ "$SKIP" -gt 0 ] && printf "${C_YELLOW}${C_BOLD}║  %-${_res_content_w}s║${C_RESET}\n" "Skipped: $SKIP"
-[ "$FAIL" -gt 0 ] && printf "${C_RED}${C_BOLD}║  %-${_res_content_w}s║${C_RESET}\n" "Failed : $FAIL"
+echo -e "${RESULT_COLOUR}╔${_res_border}╗${_OUT_RESET}"
+printf "${RESULT_COLOUR}║  %s%*s║${_OUT_RESET}\n" "$_res_title" "$_res_title_pad" ""
+echo -e "${RESULT_COLOUR}╠${_res_border}╣${_OUT_RESET}"
+printf "${RESULT_COLOUR}║  %-${_res_content_w}s║${_OUT_RESET}\n" "Passed : $PASS / $TOTAL"
+[ "$SKIP" -gt 0 ] && printf "${C_YELLOW}${C_BOLD}║  %-${_res_content_w}s║${_OUT_RESET}\n" "Skipped: $SKIP"
+[ "$FAIL" -gt 0 ] && printf "${C_RED}${C_BOLD}║  %-${_res_content_w}s║${_OUT_RESET}\n" "Failed : $FAIL"
 echo -e "${RESULT_COLOUR}╚${_res_border}╝${C_RESET}"
 echo ""
 


### PR DESCRIPTION
## Summary

Reopened with updated scope. Phase 1 of the output standardisation effort (#314).

Extracts `_visual_width` and `_print_box` from `deploy-lib.sh` into a minimal shared `scripts/deploy/output-lib.sh` (box helpers only — no message function changes). All scripts with hardcoded banner boxes source it, replacing their hardcoded `═` counts with dynamically-sized borders.

**Phase 2** (standardising all message functions — `dlog`, `dinfo`, etc.) remains in #314.

Closes #312

## Scripts migrated

- `scripts/deploy/output-lib.sh` — new shared file: `_visual_width`, `_print_box`, `_print_multi_box`
- `scripts/deploy/deploy-lib.sh` — source `output-lib.sh`; remove inline `_visual_width`/`_print_box`
- `scripts/tests/test-regression.sh` — source `output-lib.sh`; remove inline `_visual_width`
- `scripts/deploy/dev-server-deploy.sh` — source `output-lib.sh`; replace hardcoded boxes
- `scripts/ops/security-debug-report.sh` — source `output-lib.sh`; replace hardcoded box
- `scripts/ops/gather-infrastructure-info.sh` — source `output-lib.sh`; replace hardcoded boxes
- `scripts/setup/nuclear-rebuild.sh` — source `output-lib.sh`; replace hardcoded box

## Test plan

### Happy path

```bash
# Deploy to dev server and verify all banner boxes align correctly
# . scripts\deploy\dev-deploy.ps1

# Expected: all ╔═╗ borders match their content width — no trailing gaps or overrun
```

### Regression checks

- [ ] All 20 regression tests still pass post-deploy
- [ ] Deploy report box still renders correctly
- [ ] Regression results box still renders correctly

### Setup required before testing

- None

## Smoke Test

- [ ] N/A — no backend changes in this PR

## Documentation

- [ ] N/A — internal tooling only

## Risk / Impact

- Low — box-drawing helpers only; no change to message functions, log format, or deploy logic

## Squash Commit Message

```text
fix: shared output-lib.sh for dynamic box widths across all scripts

Extract _visual_width and _print_box into scripts/deploy/output-lib.sh
and source it from all scripts with hardcoded banner boxes. Removes
duplicated emoji-aware width logic and ensures all deploy, test, and
ops script banners size their borders from content length. Phase 1
of #314.

Closes #312

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

`output-lib.sh` is sourced using a path relative to each script's own location (`$(dirname "${BASH_SOURCE[0]}")`) so it resolves correctly whether the script runs on the server, inside Docker, or locally.