### PR TITLE
chore: add comment-preservation rule; make squash commit message mandatory

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -64,11 +64,11 @@ Closes #<!-- issue number -->
 
 - 
 
-## Squash Commit Message (optional)
+## Squash Commit Message
 
-<!-- If this PR will be squash-merged, add a ready-to-paste commit message here.
-     Format: short imperative summary (≤50 chars), blank line, short why/what body,
-     then Co-Authored-By footer. -->
+<!-- Mandatory — repo squash-merges, so this becomes the permanent history entry.
+     Format: short imperative summary (≤50 chars), blank line, short why/what body
+     (focus on WHY, not what — the diff shows what), then Co-Authored-By footer. -->
 
 ```text
 <summary>

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -13,6 +13,7 @@ For high-level direction and current priorities, AI models may treat `ROADMAP.md
   - **If significant** (e.g. a larger refactor, architectural change, new abstraction): raise a new GitHub issue instead and continue with the original scope only. Ask the owner before proceeding with the improvement
   - **If unclear whether it's within scope**: ask before acting
 - Never convert literal Unicode characters to escape sequences — `—`, `…`, `©`, `✏`, `✈`, `☾`, `−` etc. must stay as-is in source files
+- **Preserve existing comments when editing files.** Only remove a comment if it is factually wrong or entirely redundant with the new code. Do not strip comments just because you are rewriting nearby lines — if the comment explained a non-obvious WHY before your edit, it still explains it after.
 - If a change requires touching more than the requested lines, flag it and ask first — do not proceed
 - Ask before acting if anything is unclear or the scope is ambiguous
 - **One PR per issue**, unless issues are explicitly related:


### PR DESCRIPTION
## Summary

Two small process fixes prompted by the PR #311 session where a JSDoc block was stripped during a file rewrite and squash messages were being omitted from PRs.

Closes N/A — process improvement, no linked issue.

## Changes

- `docs/AI.md` — add explicit rule: preserve existing comments when editing files; only remove if factually wrong or fully redundant
- `.github/pull_request_template.md` — remove "(optional)" from squash commit section and clarify it is mandatory (repo squash-merges)

## Test Plan

### Happy path

1. Review the diff — changes are docs/template only, no code affected.

### Regression checks

- [ ] N/A — no code changes

### Setup required before testing

- None

## Smoke Test

- [ ] N/A — no backend changes in this PR

## Documentation

- [ ] N/A — this PR IS the documentation change

## Risk / Impact

- None — docs and template only.

## Squash Commit Message

```text
chore: add comment-preservation rule; make squash message mandatory

Add rule to docs/AI.md to preserve existing comments when editing
nearby lines. Remove "(optional)" from PR template squash section
— it is mandatory since the repo squash-merges.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

The squash commit message rule was already in docs/AI.md (line 163) but wasn't being followed consistently. The template change reinforces it at the point of PR creation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UYZZLgCUMjWTrMYFGeDMLM)_