### PR TITLE
hotfix: prod health check SSL mismatch — use SITE_HOST + --resolve

### DIFF
--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1021,6 +1021,7 @@ _poll_health() {
   local attempts=0
   local curl_flags=()
   [ "${HEALTH_INSECURE:-0}" = "1" ] && curl_flags+=("--insecure")
+  [ -n "${HEALTH_RESOLVE:-}" ]      && curl_flags+=("--resolve" "${HEALTH_RESOLVE}")
 
   while [ "$attempts" -lt "$max_attempts" ]; do
     local http_code
@@ -1224,9 +1225,9 @@ wait_for_health() {
   local url2="${HEALTH_URL_2:-}"
   local timeout="${HEALTH_TIMEOUT:-60}"
   local interval="${HEALTH_INTERVAL:-5}"
-  # Set HEALTH_INSECURE=1 in caller to skip SSL cert verification (e.g. dev self-signed certs)
   local curl_opts=""
   [ "${HEALTH_INSECURE:-0}" = "1" ] && curl_opts="--insecure"
+  [ -n "${HEALTH_RESOLVE:-}" ]      && curl_opts="$curl_opts --resolve ${HEALTH_RESOLVE}"
 
   dsection "Phase 6: HTTP/HTTPS health checks"
 

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -212,18 +212,20 @@ else
   HEALTH_INSECURE=0
 fi
 
-# Health check through nginx rather than the backend port directly. This lets
-# us remove the host-port binding from the backend container, eliminating the
-# port conflict on server restart. Nginx proxies /api/health to the backend,
-# so a 200 from nginx confirms both services are up.
-# Protocol follows CERT_MODE: self-signed (dev) means nginx speaks HTTPS even
-# on non-443 ports, so we must use https:// regardless of port number.
+# Health check URL and curl flags.
+# - self-signed (dev): curl localhost with --insecure (cert isn't trusted)
+# - letsencrypt (prod): curl via SITE_HOST so the cert CN matches; use
+#   --resolve to force local resolution and avoid hairpin NAT
 if [ "${CERT_MODE:-}" = "self-signed" ]; then
   HEALTH_URL="https://localhost:${NGINX_PORT}/api/health"
+  HEALTH_INSECURE=1
 elif [ "${NGINX_PORT}" = "443" ]; then
-  HEALTH_URL="https://localhost/api/health"
+  HEALTH_URL="https://${SITE_HOST}/api/health"
+  HEALTH_RESOLVE="${SITE_HOST}:443:127.0.0.1"
+  HEALTH_INSECURE=0
 else
   HEALTH_URL="http://localhost:${NGINX_PORT}/api/health"
+  HEALTH_INSECURE=0
 fi
 
 # Docker-internal nginx URL used by the error-logger test (puppeteer inside the


### PR DESCRIPTION
## Summary

Prod deploy failed at `[deploy:health]` with HTTP 000. Backend and nginx were both up and serving real traffic — the deploy succeeded but the health check caused a false rollback.

**Root cause:** `curl https://localhost/api/health` fails SSL verification on prod because the Let's Encrypt cert is issued for `andykeys.me`, not `localhost`. curl returns 000 (SSL handshake error).

## Changes (`scripts/deploy/deploy.sh`, `scripts/deploy/deploy-lib.sh`)

For prod (`CERT_MODE=letsencrypt`, `NGINX_PORT=443`):
- `HEALTH_URL` → `https://${SITE_HOST}/api/health` so the cert CN matches
- `HEALTH_RESOLVE=${SITE_HOST}:443:127.0.0.1` so curl hits the local container directly without hairpin NAT

Applied to both `wait_for_health` and `_poll_health` (rollback health checks).

Self-signed (dev) and plain HTTP paths unchanged.

## Test plan

```powershell
.\scripts\deploy\prod-deploy.ps1
```
Expected: `[deploy:health] status=ok url=https://andykeys.me/api/health`

## Squash commit message

```
hotfix: prod health check — use SITE_HOST + --resolve to avoid SSL mismatch

curl https://localhost/api/health fails on prod because the Let's Encrypt
cert is for the domain name, not localhost. Use https://${SITE_HOST}/api/health
with --resolve to hit the local container without hairpin NAT.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FW7jvozMeS2YouBJmkyQM8)_