### PR TITLE
fix: harden error-logger — recursion-safe delivery, resource capture, buffering

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:error-logger": "node ./scripts/tests/test-error-logger.js",
-    "test:error-logger:all-pages": "node ./scripts/tests/test-error-logger-all-pages.js"
+    "test:error-logger:all-pages": "node ./scripts/tests/test-error-logger-all-pages.js",
+    "test:error-logger:browser": "node ./scripts/tests/test-error-logger-browser.js"
   },
   "dependencies": {
     "@simplewebauthn/server": "^7.4.0",

--- a/backend/scripts/tests/test-error-logger-browser.js
+++ b/backend/scripts/tests/test-error-logger-browser.js
@@ -1,183 +1,153 @@
 #!/usr/bin/env node
 /**
- * Self-contained browser test for resources/js/error-logger.js.
+ * Error-logger contract tests against the LIVE deployed site.
  *
- * Spins up a lightweight HTTP server serving the real module files plus a mock
- * /api/debug/errors endpoint, then drives headless Chromium to verify the key
- * behavioural contracts of the error logger:
+ * Loads real pages from the running nginx and uses Puppeteer request
+ * interception to capture POSTs to /api/debug/errors and simulate the backend
+ * being up or down — so the buffering/drain behaviour can be exercised without
+ * actually taking the backend down. Verifies the actually-deployed
+ * error-logger.js, and runs inside the backend container post-deploy (Chromium
+ * ships in the image).
  *
- *   1. Resource-load failures captured (#332) — the capture-phase listener
+ * Contracts verified:
+ *   1. Resource-load failures captured (#332) — capture-phase listener
  *   2. Runtime errors logged exactly once (no duplication from capture listener)
  *   3. Reports buffered in localStorage when backend unreachable (#334)
- *   4. Buffer drained and emptied after backend returns
+ *   4. Buffer drained and emptied after backend returns (#334)
  *   5. No browser hang under error storm against failing backend (#331)
  *
- * Does NOT require a running dev server, Docker, or Postgres. Node + Chromium only.
- *
  * Usage:
- *   node backend/scripts/tests/test-error-logger-browser.js
- *   npm run test:error-logger:browser   (from backend/)
+ *   node test-error-logger-browser.js <base-url>
+ *   npm run test:error-logger:browser -- https://nginx-dev:3001
  */
 
-import http from 'node:http';
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import puppeteer from 'puppeteer';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
-
-// ── Mock server ───────────────────────────────────────────────────────────────
-
-const received = [];   // payloads accepted by the mock /api/debug/errors
-let backendUp = true;  // toggle to simulate backend unavailability
-
-const server = http.createServer(async (req, res) => {
-  // Mock ingestion endpoint
-  if (req.url === '/api/debug/errors' && req.method === 'POST') {
-    if (!backendUp) {
-      res.writeHead(503).end('{"error":"down"}');
-      return;
-    }
-    let body = '';
-    req.on('data', chunk => (body += chunk));
-    req.on('end', () => {
-      try { received.push(JSON.parse(body)); } catch { received.push({ parseError: body }); }
-      res.writeHead(200, { 'Content-Type': 'application/json' }).end('{"received":true}');
-    });
-    return;
-  }
-
-  // Test page
-  if (req.url === '/') {
-    res.writeHead(200, { 'Content-Type': 'text/html' }).end(`
-<!DOCTYPE html><html><head>
-<script type="module" src="/resources/js/error-logger.js"></script>
-</head><body><h1>error-logger test harness</h1></body></html>`);
-    return;
-  }
-
-  // Serve JS modules from the repo (config.js, error-logger.js, etc.)
-  if (req.url.startsWith('/resources/js/')) {
-    try {
-      const filePath = path.join(REPO_ROOT, req.url.split('?')[0]);
-      const data = await readFile(filePath);
-      res.writeHead(200, { 'Content-Type': 'application/javascript' }).end(data);
-    } catch {
-      res.writeHead(404).end('not found'); // intentional 404 for resource-error test
-    }
-    return;
-  }
-
-  res.writeHead(404).end('not found');
-});
-
-// ── Test helpers ──────────────────────────────────────────────────────────────
+const baseUrl = process.argv[2];
+if (!baseUrl) {
+  console.error('Usage: node test-error-logger-browser.js <base-url>');
+  process.exit(1);
+}
 
 const passed = [];
 const failed = [];
-
-function check(name, condition) {
-  if (condition) {
-    console.log(`  ✅ ${name}`);
-    passed.push(name);
-  } else {
-    console.log(`  ❌ ${name}`);
-    failed.push(name);
-  }
-}
-
+const check = (name, cond) => {
+  if (cond) { console.log(`  ✅ ${name}`); passed.push(name); }
+  else { console.log(`  ❌ ${name}`); failed.push(name); }
+};
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
-// ── Main ──────────────────────────────────────────────────────────────────────
-
-console.log('\n🧪 error-logger browser tests (self-contained)\n');
-
-await new Promise(r => server.listen(0, r));
-const { port } = server.address();
-const base = `http://127.0.0.1:${port}`;
-console.log(`🌐 Mock server listening on ${base}\n`);
+console.log('\n🧪 error-logger contract tests (against live site)');
+console.log(`📍 Base URL: ${baseUrl}\n`);
 
 let browser;
 try {
   browser = await puppeteer.launch({
-    headless: true,
-    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+    headless: 'new',
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--ignore-certificate-errors', // self-signed dev certs
+    ],
   });
   const page = await browser.newPage();
-  await page.goto(base, { waitUntil: 'networkidle0' });
 
-  // ── Test 1: resource-load failure captured ────────────────────────────────
-  console.log('📍 Test 1 — resource-load failures captured (#332)');
-  received.length = 0;
+  // Intercept /api/debug/errors: capture payloads and simulate up/down.
+  let backendUp = true;
+  let delivered = 0;     // count of reports we accepted with 200
+  const captured = [];   // parsed POST bodies seen
+
+  await page.setRequestInterception(true);
+  page.on('request', (req) => {
+    if (req.method() === 'POST' && req.url().includes('/api/debug/errors')) {
+      const data = req.postData();
+      if (data) { try { captured.push(JSON.parse(data)); } catch { captured.push({ raw: data }); } }
+      if (backendUp) {
+        delivered++;
+        req.respond({ status: 200, contentType: 'application/json', body: '{"received":true}' });
+      } else {
+        req.respond({ status: 503, contentType: 'application/json', body: '{"error":"down"}' });
+      }
+      return;
+    }
+    req.continue();
+  });
+
+  await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle0', timeout: 20000 });
+  // Clear any buffer left from a previous run on this origin.
+  await page.evaluate(() => { try { localStorage.removeItem('errlog:buffer'); } catch {} });
+
+  // ── Test 1: resource-load capture ──────────────────────────────────────────
+  console.log('📍 Test 1 — resource-load failure captured (#332)');
+  captured.length = 0;
   await page.evaluate(() => {
     const s = document.createElement('script');
-    s.src = '/resources/js/does-not-exist.js';
+    s.src = '/resources/js/does-not-exist-' + Date.now() + '.js'; // genuine 404
     document.head.appendChild(s);
   });
-  await sleep(400);
-  const resourceReport = received.find(r => r.type === 'resource-error');
-  check('resource-error report received', !!resourceReport);
-  check('message field describes the failure',
-    /Failed to load <script>/i.test(resourceReport?.message || ''));
-  check('filename field contains the failing URL',
-    /does-not-exist\.js/.test(resourceReport?.filename || ''));
+  await sleep(600);
+  const rc = captured.find(r => r.type === 'resource-error');
+  check('resource-error report captured', !!rc);
+  check('message names the failed load', /Failed to load <script>/i.test(rc?.message || ''));
 
-  // ── Test 2: runtime error logged exactly once (no duplication) ────────────
-  console.log('\n📍 Test 2 — runtime errors not duplicated by capture listener (#332)');
-  received.length = 0;
-  await page.evaluate(() => setTimeout(() => { throw new Error('runtime-test'); }, 0));
-  await sleep(400);
-  // Puppeteer evaluate context masks thrown messages as "Script error." (cross-origin
-  // sandbox) — check count/type rather than message text.
-  const runtimeReports = received.filter(r => r.type === 'uncaught-error');
-  check('runtime error reported exactly once', runtimeReports.length === 1);
+  // ── Test 2: runtime error not duplicated by capture listener ───────────────
+  // NB: Puppeteer's evaluate sandbox masks the thrown message as "Script error.",
+  // so we assert on count/type, not message text — the point is that the new
+  // capture-phase listener must not duplicate the bubble-phase runtime report.
+  console.log('\n📍 Test 2 — runtime error reported exactly once (#332)');
+  captured.length = 0;
+  await page.evaluate(() => setTimeout(() => { throw new Error('pr331-runtime'); }, 0));
+  await sleep(600);
+  const rt = captured.filter(r => r.type === 'uncaught-error');
+  check('runtime error reported exactly once (no duplication)', rt.length === 1);
 
-  // ── Test 3: reports buffered when backend down ────────────────────────────
-  console.log('\n📍 Test 3 — reports buffered in localStorage when backend unreachable (#334)');
-  received.length = 0;
+  // ── Test 3: buffered when backend down ─────────────────────────────────────
+  console.log('\n📍 Test 3 — reports buffered when backend unreachable (#334)');
+  captured.length = 0;
+  const deliveredBefore = delivered;
   backendUp = false;
-  await page.evaluate(() => console.error('offline-marker'));
-  await sleep(400);
-  check('nothing delivered to backend while down', received.length === 0);
+  const offlineMarker = 'offline-' + Date.now();
+  await page.evaluate((m) => console.error(m), offlineMarker);
+  await sleep(600);
+  check('not delivered to backend while down', delivered === deliveredBefore);
   const bufLen = await page.evaluate(
     () => JSON.parse(localStorage.getItem('errlog:buffer') || '[]').length,
   );
   check('report persisted in localStorage buffer', bufLen >= 1);
 
-  // ── Test 4: buffer drained after backend returns ──────────────────────────
+  // ── Test 4: buffer drains after backend returns ────────────────────────────
   console.log('\n📍 Test 4 — buffer drains when backend returns (#334)');
   backendUp = true;
-  received.length = 0;
-  await page.reload({ waitUntil: 'networkidle0' });
-  await sleep(600);
-  const flushed = received.find(r => /offline-marker/.test(r.message || ''));
+  captured.length = 0;
+  await page.reload({ waitUntil: 'networkidle0', timeout: 20000 });
+  await sleep(800);
+  const flushed = captured.find(r => String(r.message || '').includes(offlineMarker));
   check('buffered report delivered after reload', !!flushed);
   const bufAfter = await page.evaluate(
     () => JSON.parse(localStorage.getItem('errlog:buffer') || '[]').length,
   );
   check('localStorage buffer emptied after flush', bufAfter === 0);
 
-  // ── Test 5: no hang under error storm against failing backend ─────────────
-  console.log('\n📍 Test 5 — no browser hang on error storm while backend is down (#331)');
+  // ── Test 5: no hang under error storm against failing backend ──────────────
+  console.log('\n📍 Test 5 — no browser hang on error storm while down (#331)');
   backendUp = false;
-  const completed = await page.evaluate(async () => {
+  const done = await page.evaluate(async () => {
     for (let i = 0; i < 5; i++) console.error('storm-' + i);
     await new Promise(r => setTimeout(r, 400));
     return 'done';
   });
-  check('page remains responsive after 5-error storm', completed === 'done');
+  check('page remains responsive after 5-error storm', done === 'done');
+
+  // Best-effort cleanup so we don't leave buffered junk on the origin.
+  await page.evaluate(() => { try { localStorage.removeItem('errlog:buffer'); } catch {} });
 
 } catch (err) {
   console.error('\n💥 Test runner crashed:', err.message);
   failed.push(`Runner crashed: ${err.message}`);
 } finally {
   if (browser) await browser.close();
-  server.close();
 }
-
-// ── Summary ───────────────────────────────────────────────────────────────────
 
 const total = passed.length + failed.length;
 console.log('\n' + '='.repeat(60));
@@ -187,10 +157,7 @@ if (failed.length) {
   failed.forEach(n => console.log(`   • ${n}`));
 }
 console.log('='.repeat(60));
-
-// Machine-parseable summary for deploy scripts / CI
 const status = failed.length === 0 ? 'OK' : 'FAIL';
-console.log(`[error-logger-browser] status=${status} passed=${passed.length} failed=${failed.length}`);
-console.log('');
+console.log(`[error-logger-browser] status=${status} passed=${passed.length} failed=${failed.length}\n`);
 
 process.exit(failed.length ? 1 : 0);

--- a/backend/scripts/tests/test-error-logger-browser.js
+++ b/backend/scripts/tests/test-error-logger-browser.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * Self-contained browser test for resources/js/error-logger.js.
+ *
+ * Spins up a lightweight HTTP server serving the real module files plus a mock
+ * /api/debug/errors endpoint, then drives headless Chromium to verify the key
+ * behavioural contracts of the error logger:
+ *
+ *   1. Resource-load failures captured (#332) — the capture-phase listener
+ *   2. Runtime errors logged exactly once (no duplication from capture listener)
+ *   3. Reports buffered in localStorage when backend unreachable (#334)
+ *   4. Buffer drained and emptied after backend returns
+ *   5. No browser hang under error storm against failing backend (#331)
+ *
+ * Does NOT require a running dev server, Docker, or Postgres. Node + Chromium only.
+ *
+ * Usage:
+ *   node backend/scripts/tests/test-error-logger-browser.js
+ *   npm run test:error-logger:browser   (from backend/)
+ */
+
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+// ── Mock server ───────────────────────────────────────────────────────────────
+
+const received = [];   // payloads accepted by the mock /api/debug/errors
+let backendUp = true;  // toggle to simulate backend unavailability
+
+const server = http.createServer(async (req, res) => {
+  // Mock ingestion endpoint
+  if (req.url === '/api/debug/errors' && req.method === 'POST') {
+    if (!backendUp) {
+      res.writeHead(503).end('{"error":"down"}');
+      return;
+    }
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try { received.push(JSON.parse(body)); } catch { received.push({ parseError: body }); }
+      res.writeHead(200, { 'Content-Type': 'application/json' }).end('{"received":true}');
+    });
+    return;
+  }
+
+  // Test page
+  if (req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/html' }).end(`
+<!DOCTYPE html><html><head>
+<script type="module" src="/resources/js/error-logger.js"></script>
+</head><body><h1>error-logger test harness</h1></body></html>`);
+    return;
+  }
+
+  // Serve JS modules from the repo (config.js, error-logger.js, etc.)
+  if (req.url.startsWith('/resources/js/')) {
+    try {
+      const filePath = path.join(REPO_ROOT, req.url.split('?')[0]);
+      const data = await readFile(filePath);
+      res.writeHead(200, { 'Content-Type': 'application/javascript' }).end(data);
+    } catch {
+      res.writeHead(404).end('not found'); // intentional 404 for resource-error test
+    }
+    return;
+  }
+
+  res.writeHead(404).end('not found');
+});
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+const passed = [];
+const failed = [];
+
+function check(name, condition) {
+  if (condition) {
+    console.log(`  ✅ ${name}`);
+    passed.push(name);
+  } else {
+    console.log(`  ❌ ${name}`);
+    failed.push(name);
+  }
+}
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+console.log('\n🧪 error-logger browser tests (self-contained)\n');
+
+await new Promise(r => server.listen(0, r));
+const { port } = server.address();
+const base = `http://127.0.0.1:${port}`;
+console.log(`🌐 Mock server listening on ${base}\n`);
+
+let browser;
+try {
+  browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+  const page = await browser.newPage();
+  await page.goto(base, { waitUntil: 'networkidle0' });
+
+  // ── Test 1: resource-load failure captured ────────────────────────────────
+  console.log('📍 Test 1 — resource-load failures captured (#332)');
+  received.length = 0;
+  await page.evaluate(() => {
+    const s = document.createElement('script');
+    s.src = '/resources/js/does-not-exist.js';
+    document.head.appendChild(s);
+  });
+  await sleep(400);
+  const resourceReport = received.find(r => r.type === 'resource-error');
+  check('resource-error report received', !!resourceReport);
+  check('message field describes the failure',
+    /Failed to load <script>/i.test(resourceReport?.message || ''));
+  check('filename field contains the failing URL',
+    /does-not-exist\.js/.test(resourceReport?.filename || ''));
+
+  // ── Test 2: runtime error logged exactly once (no duplication) ────────────
+  console.log('\n📍 Test 2 — runtime errors not duplicated by capture listener (#332)');
+  received.length = 0;
+  await page.evaluate(() => setTimeout(() => { throw new Error('runtime-test'); }, 0));
+  await sleep(400);
+  // Puppeteer evaluate context masks thrown messages as "Script error." (cross-origin
+  // sandbox) — check count/type rather than message text.
+  const runtimeReports = received.filter(r => r.type === 'uncaught-error');
+  check('runtime error reported exactly once', runtimeReports.length === 1);
+
+  // ── Test 3: reports buffered when backend down ────────────────────────────
+  console.log('\n📍 Test 3 — reports buffered in localStorage when backend unreachable (#334)');
+  received.length = 0;
+  backendUp = false;
+  await page.evaluate(() => console.error('offline-marker'));
+  await sleep(400);
+  check('nothing delivered to backend while down', received.length === 0);
+  const bufLen = await page.evaluate(
+    () => JSON.parse(localStorage.getItem('errlog:buffer') || '[]').length,
+  );
+  check('report persisted in localStorage buffer', bufLen >= 1);
+
+  // ── Test 4: buffer drained after backend returns ──────────────────────────
+  console.log('\n📍 Test 4 — buffer drains when backend returns (#334)');
+  backendUp = true;
+  received.length = 0;
+  await page.reload({ waitUntil: 'networkidle0' });
+  await sleep(600);
+  const flushed = received.find(r => /offline-marker/.test(r.message || ''));
+  check('buffered report delivered after reload', !!flushed);
+  const bufAfter = await page.evaluate(
+    () => JSON.parse(localStorage.getItem('errlog:buffer') || '[]').length,
+  );
+  check('localStorage buffer emptied after flush', bufAfter === 0);
+
+  // ── Test 5: no hang under error storm against failing backend ─────────────
+  console.log('\n📍 Test 5 — no browser hang on error storm while backend is down (#331)');
+  backendUp = false;
+  const completed = await page.evaluate(async () => {
+    for (let i = 0; i < 5; i++) console.error('storm-' + i);
+    await new Promise(r => setTimeout(r, 400));
+    return 'done';
+  });
+  check('page remains responsive after 5-error storm', completed === 'done');
+
+} catch (err) {
+  console.error('\n💥 Test runner crashed:', err.message);
+  failed.push(`Runner crashed: ${err.message}`);
+} finally {
+  if (browser) await browser.close();
+  server.close();
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+const total = passed.length + failed.length;
+console.log('\n' + '='.repeat(60));
+console.log(`✅ Passed : ${passed.length} / ${total}`);
+if (failed.length) {
+  console.log(`❌ Failed : ${failed.length}`);
+  failed.forEach(n => console.log(`   • ${n}`));
+}
+console.log('='.repeat(60));
+
+// Machine-parseable summary for deploy scripts / CI
+const status = failed.length === 0 ? 'OK' : 'FAIL';
+console.log(`[error-logger-browser] status=${status} passed=${passed.length} failed=${failed.length}`);
+console.log('');
+
+process.exit(failed.length ? 1 : 0);

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -92,42 +92,50 @@ docker compose exec backend npm run test:coverage
 
 ## Browser-Level Tests (frontend error-logger)
 
-`backend/scripts/tests/test-error-logger-browser.js` verifies the behavioural contracts of `resources/js/error-logger.js` in a real headless browser. Unlike the server-based `test-error-logger.js` (which requires a running dev stack), this test is **self-contained** — it spins up its own HTTP server and mock `/api/debug/errors` endpoint.
+Three Puppeteer scripts exercise `resources/js/error-logger.js` against the live deployed site. **All three run automatically inside the backend container after every dev/prod deploy** (gated by `RUN_ERROR_LOGGER=1`; the backend image ships Chromium). They reach nginx by its docker-internal service name (`NGINX_URL`).
 
-### What it tests
+| Script | npm script | What it verifies |
+|---|---|---|
+| `test-error-logger.js` | `test:error-logger` | Error logger initialises and reports on the `/api/debug/test-errors` page |
+| `test-error-logger-all-pages.js` | `test:error-logger:all-pages` | Logger initialises on every public page (`/`, `/blog/`, `/travel/`, `/login/`) |
+| `test-error-logger-browser.js` | `test:error-logger:browser` | Behavioural **contracts** (see below) via request interception |
 
-| # | Test | Related issue |
+### Contract test (`test-error-logger-browser.js`)
+
+Uses Puppeteer request interception to capture POSTs to `/api/debug/errors` and simulate the backend being up/down — so buffering can be exercised without actually taking the backend down. Verifies the *deployed* `error-logger.js`:
+
+| # | Contract | Related issue |
 |---|------|---------------|
-| 1 | Resource-load failures (broken `<script src>`) are captured via the capture-phase listener | #332 |
-| 2 | Runtime errors are logged exactly once — capture-phase listener does not duplicate them | #332 |
-| 3 | Reports are persisted to `localStorage` when the backend is unreachable | #334 |
-| 4 | Buffered reports are flushed and `localStorage` is cleared once the backend returns | #334 |
+| 1 | Resource-load failures (broken `<script src>`) captured via the capture-phase listener | #332 |
+| 2 | Runtime errors logged exactly once — capture-phase listener does not duplicate them | #332 |
+| 3 | Reports persisted to `localStorage` when the backend is unreachable | #334 |
+| 4 | Buffered reports flushed and `localStorage` cleared once the backend returns | #334 |
 | 5 | No browser hang when five errors fire against a failing backend | #331 |
 
-### Running
+It prints a machine-parseable summary line collected into the deploy report:
+```
+[error-logger-browser] status=OK passed=8 failed=0
+```
 
-Because it is self-contained (no dev stack, DB, or network), this test runs wherever Node + Chromium are available — **CI** (issue #98) or **on the dev server** from the deployed checkout:
+### Failure policy
+
+The error-logger tests are **warn-only** — a failure is surfaced loudly inline in the deploy report but does **not** roll the deploy back (unlike Vitest, which does). This avoids a frontend timing flake blocking a deploy. Treat a `status=failed` line as a must-fix even though the deploy proceeded.
+
+### Running manually
+
+These tests need a base URL (the running site). Run them on the dev server from the deployed checkout, or against any reachable instance:
 
 ```bash
-# On the dev server, against the freshly deployed branch:
-cd ~/MyPortfolioSite-dev/backend
-npm install
-npx puppeteer browsers install chrome   # first time only
-npm run test:error-logger:browser
-```
-
-The test prints a machine-parseable summary line at the end:
-```
-[error-logger-browser] status=OK passed=9 failed=0
+# Dev: NGINX_SERVICE=nginx, NGINX_PORT=3001 → docker-internal URL https://nginx:3001
+cd ~/MyPortfolioSite-dev
+docker compose -f docker-compose.yml -p portfolio_dev exec -T backend \
+  npm run test:error-logger:browser -- https://nginx:3001
 ```
 
 ### When to run
 
-- After any change to `resources/js/error-logger.js`
-- After any change to `backend/routes/debug.js` that alters the `/debug/errors` contract
-- As part of the PR verification when either file is touched (alongside the dev-server deploy)
-
-The existing `test:error-logger` and `test:error-logger:all-pages` scripts complement this test — they connect to the running dev server and verify the full end-to-end flow (nginx, auth, real DB). This contract test isolates the frontend logic (buffering, capture-phase listener, recursion safety) that is awkward to exercise against a live server.
+- Automatically: every dev/prod deploy
+- Manually after any change to `resources/js/error-logger.js`, or to `backend/routes/debug.js` if it alters the `/debug/errors` contract
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -86,6 +86,61 @@ docker compose exec backend npm run test:watch
 docker compose exec backend npm run test:coverage
 ```
 
+### Running without Docker (host-side)
+
+The Vitest suite mocks `pg` and `nodemailer`, so it does **not** need a running database or Docker. You can run it directly on the host with Node ≥ 18:
+
+```bash
+cd backend
+PUPPETEER_SKIP_DOWNLOAD=true npm install   # skip Chromium; not needed for Vitest
+npm test
+```
+
+This is the fastest feedback loop when iterating on backend logic. The full Docker stack is still the authoritative test environment — always do a dev-server deploy before raising a PR.
+
+---
+
+## Browser-Level Tests (frontend error-logger)
+
+`backend/scripts/tests/test-error-logger-browser.js` verifies the behavioural contracts of `resources/js/error-logger.js` in a real headless browser. Unlike the server-based `test-error-logger.js` (which requires a running dev stack), this test is **self-contained** — it spins up its own HTTP server and mock `/api/debug/errors` endpoint.
+
+### What it tests
+
+| # | Test | Related issue |
+|---|------|---------------|
+| 1 | Resource-load failures (broken `<script src>`) are captured via the capture-phase listener | #332 |
+| 2 | Runtime errors are logged exactly once — capture-phase listener does not duplicate them | #332 |
+| 3 | Reports are persisted to `localStorage` when the backend is unreachable | #334 |
+| 4 | Buffered reports are flushed and `localStorage` is cleared once the backend returns | #334 |
+| 5 | No browser hang when five errors fire against a failing backend | #331 |
+
+### Running
+
+```bash
+# Requires Node + Chromium (Puppeteer)
+cd backend
+
+# First-time setup: install deps including Chromium
+npm install
+npx puppeteer browsers install chrome
+
+# Run the test
+npm run test:error-logger:browser
+```
+
+The test prints a machine-parseable summary line at the end:
+```
+[error-logger-browser] status=OK passed=9 failed=0
+```
+
+### When to run
+
+- After any change to `resources/js/error-logger.js`
+- After any change to `backend/routes/debug.js` that alters the `/debug/errors` contract
+- As part of the PR test plan when either file is touched
+
+The existing `test:error-logger` and `test:error-logger:all-pages` scripts complement this test — they connect to a running dev server and verify the full end-to-end flow (nginx, auth, real DB). Run both when doing a full integration verification.
+
 ---
 
 ## Fallback: Local Testing (Windows)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -86,17 +86,7 @@ docker compose exec backend npm run test:watch
 docker compose exec backend npm run test:coverage
 ```
 
-### Running without Docker (host-side)
-
-The Vitest suite mocks `pg` and `nodemailer`, so it does **not** need a running database or Docker. You can run it directly on the host with Node ≥ 18:
-
-```bash
-cd backend
-PUPPETEER_SKIP_DOWNLOAD=true npm install   # skip Chromium; not needed for Vitest
-npm test
-```
-
-This is the fastest feedback loop when iterating on backend logic. The full Docker stack is still the authoritative test environment — always do a dev-server deploy before raising a PR.
+> **Note:** The Vitest suite runs automatically inside the deployed container on every dev/prod deploy (see "Automatic tests during deploy" above) — that is the canonical path. The suite mocks `pg` and `nodemailer` so it needs no database, which is also what lets CI run it host-side (`cd backend && npm install && npm test`, see [CI](#ci)). Day-to-day verification is done by deploying to the dev server, not by running tests locally.
 
 ---
 
@@ -116,15 +106,13 @@ This is the fastest feedback loop when iterating on backend logic. The full Dock
 
 ### Running
 
+Because it is self-contained (no dev stack, DB, or network), this test runs wherever Node + Chromium are available — **CI** (issue #98) or **on the dev server** from the deployed checkout:
+
 ```bash
-# Requires Node + Chromium (Puppeteer)
-cd backend
-
-# First-time setup: install deps including Chromium
+# On the dev server, against the freshly deployed branch:
+cd ~/MyPortfolioSite-dev/backend
 npm install
-npx puppeteer browsers install chrome
-
-# Run the test
+npx puppeteer browsers install chrome   # first time only
 npm run test:error-logger:browser
 ```
 
@@ -137,9 +125,9 @@ The test prints a machine-parseable summary line at the end:
 
 - After any change to `resources/js/error-logger.js`
 - After any change to `backend/routes/debug.js` that alters the `/debug/errors` contract
-- As part of the PR test plan when either file is touched
+- As part of the PR verification when either file is touched (alongside the dev-server deploy)
 
-The existing `test:error-logger` and `test:error-logger:all-pages` scripts complement this test — they connect to a running dev server and verify the full end-to-end flow (nginx, auth, real DB). Run both when doing a full integration verification.
+The existing `test:error-logger` and `test:error-logger:all-pages` scripts complement this test — they connect to the running dev server and verify the full end-to-end flow (nginx, auth, real DB). This contract test isolates the frontend logic (buffering, capture-phase listener, recursion safety) that is awkward to exercise against a live server.
 
 ---
 

--- a/resources/js/error-logger.js
+++ b/resources/js/error-logger.js
@@ -17,6 +17,11 @@
 
 import { API_BASE } from './config.js';
 
+// Load signal — a plain console.log (console.log is not overridden, so no
+// recursion). The post-deploy error-logger test greps for this line to confirm
+// the module initialised on every page.
+console.log('[error-logger] Initializing global error logger');
+
 const ENDPOINT = `${API_BASE}/debug/errors`;
 
 // Suppress duplicate reports within a page view.

--- a/resources/js/error-logger.js
+++ b/resources/js/error-logger.js
@@ -81,3 +81,36 @@ window.addEventListener('securitypolicyviolation', (event) => {
     'column-number': event.columnNumber,
   });
 });
+
+// console.error/warn overrides — capture caught errors that developers
+// explicitly log (e.g. inside try/catch blocks). These never reach window.onerror
+// so without this override they would be invisible in prod logs.
+//
+// Safe because logToBackend now swallows its own errors silently (no internal
+// console.error call) and the `sending` guard prevents re-entrant calls, so
+// there is no recursion path even if the backend is unreachable.
+const _origError = console.error;
+const _origWarn  = console.warn;
+
+console.error = function (...args) {
+  _origError.apply(console, args);
+  const message = args.map(a => (typeof a === 'object' ? JSON.stringify(a) : String(a))).join(' ');
+  dedupAndLog(`console-error:${message.slice(0, 100)}`, {
+    type: 'console-error',
+    timestamp: new Date().toISOString(),
+    message,
+    url: window.location.href,
+    stack: new Error().stack,
+  });
+};
+
+console.warn = function (...args) {
+  _origWarn.apply(console, args);
+  const message = args.map(a => (typeof a === 'object' ? JSON.stringify(a) : String(a))).join(' ');
+  dedupAndLog(`console-warn:${message.slice(0, 100)}`, {
+    type: 'console-warn',
+    timestamp: new Date().toISOString(),
+    message,
+    url: window.location.href,
+  });
+};

--- a/resources/js/error-logger.js
+++ b/resources/js/error-logger.js
@@ -1,33 +1,101 @@
 /**
- * Global error logger — captures uncaught JS errors, unhandled rejections,
- * and CSP violations, forwarding them to the backend for debugging.
+ * Global error logger — forwards client-side problems to /debug/errors so
+ * prod issues are diagnosable without manual devtools inspection.
  *
- * Deliberately does NOT override console.error/warn — that pattern creates
- * recursion risk (a failed fetch calls console.error → triggers the override
- * → fires another fetch) and interferes with browser devtools. Use the
- * window 'error' event for production-visible errors instead.
+ * Captures:
+ *   - uncaught JS errors            (window 'error', bubble phase)
+ *   - resource-load failures        (window 'error', capture phase — #332)
+ *   - unhandled promise rejections  (window 'unhandledrejection')
+ *   - CSP violations                (securitypolicyviolation)
+ *   - explicit console.error/warn   (caught errors devs log by hand)
+ *
+ * Delivery is resilient (#334): failed sends are buffered in localStorage
+ * (bounded) and flushed on load + after each successful send. logToBackend
+ * swallows its own errors silently and a `sending` guard prevents re-entrant
+ * fetch storms, so there is no recursion path even with the backend down.
  */
 
 import { API_BASE } from './config.js';
 
-// Track seen keys to suppress duplicate reports.
+const ENDPOINT = `${API_BASE}/debug/errors`;
+
+// Suppress duplicate reports within a page view.
 const seenErrors = new Set();
 const MAX_STORED_ERRORS = 100;
 
-// Guard to prevent re-entrant calls (e.g., logToBackend itself throwing).
+// Persisted buffer for reports that fail to send (e.g. backend unreachable).
+// Bounded so it can never grow without limit.
+const BUFFER_KEY = 'errlog:buffer';
+const BUFFER_MAX = 20;
+
 let sending = false;
 
-async function logToBackend(errorData) {
-  if (sending) return;
-  sending = true;
+function readBuffer() {
   try {
-    await fetch(`${API_BASE}/debug/errors`, {
+    return JSON.parse(localStorage.getItem(BUFFER_KEY) || '[]');
+  } catch (_) {
+    return [];
+  }
+}
+
+function writeBuffer(items) {
+  try {
+    localStorage.setItem(BUFFER_KEY, JSON.stringify(items.slice(-BUFFER_MAX)));
+  } catch (_) {
+    // localStorage full or disabled — drop silently.
+  }
+}
+
+function buffer(payload) {
+  const items = readBuffer();
+  items.push(payload);
+  writeBuffer(items);
+}
+
+// Single fetch attempt. Returns true only on a 2xx response. keepalive lets
+// the report survive page unload/navigation.
+async function send(payload) {
+  try {
+    const res = await fetch(ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(errorData),
+      body: JSON.stringify(payload),
+      keepalive: true,
     });
+    return res.ok;
   } catch (_) {
-    // Swallow — no console.error here to avoid recursion.
+    return false;
+  }
+}
+
+// Best-effort drain of the persisted buffer. Entries that still fail are
+// re-buffered for the next attempt. Uses send() directly (not logToBackend)
+// so it bypasses the dedup/guard machinery.
+async function flushBuffer() {
+  const items = readBuffer();
+  if (!items.length) return;
+  const remaining = [];
+  for (const item of items) {
+    if (!(await send(item))) remaining.push(item);
+  }
+  writeBuffer(remaining);
+}
+
+async function logToBackend(payload) {
+  // A send is already in flight — buffer rather than drop (#334). The guard
+  // still prevents concurrent fetch storms from cascading errors.
+  if (sending) {
+    buffer(payload);
+    return;
+  }
+  sending = true;
+  try {
+    if (await send(payload)) {
+      // Connectivity is good — opportunistically drain any backlog.
+      await flushBuffer();
+    } else {
+      buffer(payload);
+    }
   } finally {
     sending = false;
   }
@@ -40,6 +108,7 @@ function dedupAndLog(key, payload) {
   logToBackend(payload);
 }
 
+// Uncaught runtime errors (bubble phase). event.target is window here.
 window.addEventListener('error', (event) => {
   const key = `${event.filename}:${event.lineno}:${event.message}`;
   dedupAndLog(key, {
@@ -53,6 +122,26 @@ window.addEventListener('error', (event) => {
     url: window.location.href,
   });
 });
+
+// Resource-load failures (script/img/link/css that 404 or fail to fetch) fire
+// an 'error' event ON THE ELEMENT and do NOT bubble, so they are only visible
+// in the capture phase — the bubble listener above never sees them. This is
+// the exact class of failure behind #330. (#332)
+window.addEventListener('error', (event) => {
+  const target = event.target;
+  if (!target || !(target instanceof HTMLElement)) return; // runtime errors handled above
+  const resourceUrl = target.src || target.href;
+  if (!resourceUrl) return;
+  const tag = target.tagName.toLowerCase();
+  dedupAndLog(`resource:${tag}:${resourceUrl}`, {
+    type: 'resource-error',
+    timestamp: new Date().toISOString(),
+    // message + filename map onto the fields /debug/errors already logs.
+    message: `Failed to load <${tag}>: ${resourceUrl}`,
+    filename: resourceUrl,
+    url: window.location.href,
+  });
+}, true); // capture: true — required for non-bubbling resource errors
 
 window.addEventListener('unhandledrejection', (event) => {
   const key = `promise:${String(event.reason).slice(0, 100)}`;
@@ -82,15 +171,12 @@ window.addEventListener('securitypolicyviolation', (event) => {
   });
 });
 
-// console.error/warn overrides — capture caught errors that developers
-// explicitly log (e.g. inside try/catch blocks). These never reach window.onerror
-// so without this override they would be invisible in prod logs.
-//
-// Safe because logToBackend now swallows its own errors silently (no internal
-// console.error call) and the `sending` guard prevents re-entrant calls, so
-// there is no recursion path even if the backend is unreachable.
+// console.error/warn overrides — capture caught errors devs log explicitly
+// (e.g. inside try/catch). These never reach window.onerror, so without the
+// override they would be invisible in prod. Safe because send() swallows its
+// own failures and the `sending` guard blocks re-entrancy.
 const _origError = console.error;
-const _origWarn  = console.warn;
+const _origWarn = console.warn;
 
 console.error = function (...args) {
   _origError.apply(console, args);
@@ -114,3 +200,7 @@ console.warn = function (...args) {
     url: window.location.href,
   });
 };
+
+// Drain any reports buffered from a previous page view where the backend was
+// unreachable. (#334)
+flushBuffer();

--- a/resources/js/error-logger.js
+++ b/resources/js/error-logger.js
@@ -1,46 +1,48 @@
 /**
- * Global error logger — captures all console errors/warnings and sends to backend
- * Useful for debugging production issues without requiring manual console inspection
+ * Global error logger — captures uncaught JS errors, unhandled rejections,
+ * and CSP violations, forwarding them to the backend for debugging.
+ *
+ * Deliberately does NOT override console.error/warn — that pattern creates
+ * recursion risk (a failed fetch calls console.error → triggers the override
+ * → fires another fetch) and interferes with browser devtools. Use the
+ * window 'error' event for production-visible errors instead.
  */
 
 import { API_BASE } from './config.js';
 
-console.log('[error-logger] Initializing global error logger');
-
-// Track errors to avoid logging duplicates (same error multiple times)
+// Track seen keys to suppress duplicate reports.
 const seenErrors = new Set();
 const MAX_STORED_ERRORS = 100;
 
-// Send error to backend
+// Guard to prevent re-entrant calls (e.g., logToBackend itself throwing).
+let sending = false;
+
 async function logToBackend(errorData) {
+  if (sending) return;
+  sending = true;
   try {
-    console.log(`[error-logger] Sending ${errorData.type} to ${API_BASE}/debug/errors`);
-    const response = await fetch(`${API_BASE}/debug/errors`, {
+    await fetch(`${API_BASE}/debug/errors`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(errorData),
     });
-
-    if (!response.ok) {
-      console.error(`[error-logger] Server responded with HTTP ${response.status}: ${response.statusText}`);
-      const text = await response.text();
-      if (text) console.error(`[error-logger] Response body: ${text}`);
-    } else {
-      console.log(`[error-logger] ${errorData.type} sent successfully`);
-    }
-  } catch (e) {
-    console.error('[error-logger] Fetch failed:', e.message);
+  } catch (_) {
+    // Swallow — no console.error here to avoid recursion.
+  } finally {
+    sending = false;
   }
 }
 
-// Capture uncaught JavaScript errors
-window.addEventListener('error', (event) => {
-  const errorKey = `${event.filename}:${event.lineno}:${event.message}`;
-  if (seenErrors.has(errorKey)) return;
-  seenErrors.add(errorKey);
+function dedupAndLog(key, payload) {
+  if (seenErrors.has(key)) return;
+  seenErrors.add(key);
   if (seenErrors.size > MAX_STORED_ERRORS) seenErrors.clear();
+  logToBackend(payload);
+}
 
-  logToBackend({
+window.addEventListener('error', (event) => {
+  const key = `${event.filename}:${event.lineno}:${event.message}`;
+  dedupAndLog(key, {
     type: 'uncaught-error',
     timestamp: new Date().toISOString(),
     message: event.message,
@@ -52,14 +54,9 @@ window.addEventListener('error', (event) => {
   });
 });
 
-// Capture unhandled promise rejections
 window.addEventListener('unhandledrejection', (event) => {
-  const errorKey = `promise:${String(event.reason).slice(0, 100)}`;
-  if (seenErrors.has(errorKey)) return;
-  seenErrors.add(errorKey);
-  if (seenErrors.size > MAX_STORED_ERRORS) seenErrors.clear();
-
-  logToBackend({
+  const key = `promise:${String(event.reason).slice(0, 100)}`;
+  dedupAndLog(key, {
     type: 'unhandled-rejection',
     timestamp: new Date().toISOString(),
     reason: String(event.reason),
@@ -68,66 +65,12 @@ window.addEventListener('unhandledrejection', (event) => {
   });
 });
 
-// Intercept console.error and console.warn
-const originalError = console.error;
-const originalWarn = console.warn;
-
-console.error = function(...args) {
-  originalError.apply(console, args);
-
-  const message = args.map(arg => {
-    if (typeof arg === 'object') return JSON.stringify(arg);
-    return String(arg);
-  }).join(' ');
-
-  const errorKey = `console-error:${message.slice(0, 100)}`;
-  if (!seenErrors.has(errorKey)) {
-    seenErrors.add(errorKey);
-    if (seenErrors.size > MAX_STORED_ERRORS) seenErrors.clear();
-
-    logToBackend({
-      type: 'console-error',
-      timestamp: new Date().toISOString(),
-      message: message,
-      url: window.location.href,
-      stack: new Error().stack,
-    });
-  }
-};
-
-console.warn = function(...args) {
-  originalWarn.apply(console, args);
-
-  const message = args.map(arg => {
-    if (typeof arg === 'object') return JSON.stringify(arg);
-    return String(arg);
-  }).join(' ');
-
-  const errorKey = `console-warn:${message.slice(0, 100)}`;
-  if (!seenErrors.has(errorKey)) {
-    seenErrors.add(errorKey);
-    if (seenErrors.size > MAX_STORED_ERRORS) seenErrors.clear();
-
-    logToBackend({
-      type: 'console-warn',
-      timestamp: new Date().toISOString(),
-      message: message,
-      url: window.location.href,
-    });
-  }
-};
-
-// Capture CSP (Content-Security-Policy) violations
-// These occur when a resource is blocked by security policy (e.g., loading from disallowed domain)
+// CSP violations — ISP-injected inline scripts will trigger this. That is
+// expected behaviour (blocking 3rd-party injection is correct). The report
+// is forwarded so we have a server-side record when it occurs.
 window.addEventListener('securitypolicyviolation', (event) => {
-  const cspKey = `csp:${event.violatedDirective}:${event.blockedURI}`;
-  if (seenErrors.has(cspKey)) return;
-  seenErrors.add(cspKey);
-  if (seenErrors.size > MAX_STORED_ERRORS) seenErrors.clear();
-
-  console.warn(`CSP Violation: ${event.violatedDirective} blocked ${event.blockedURI}`);
-
-  logToBackend({
+  const key = `csp:${event.violatedDirective}:${event.blockedURI}`;
+  dedupAndLog(key, {
     type: 'csp-violation',
     timestamp: new Date().toISOString(),
     'violated-directive': event.violatedDirective,

--- a/scripts/config/nginx-security-headers.conf
+++ b/scripts/config/nginx-security-headers.conf
@@ -11,6 +11,10 @@
 #   - *.tile.openstreetmap.org: OpenStreetMap tiles (travel map)
 #   - nominatim.openstreetmap.org: Geocoding API (admin travel form: photo GPS auto-fill, location search)
 #   - api.github.com: GitHub API (repos widget)
+# NOTE: ISP-injected inline scripts (e.g. MBTSS_NOTIFICATION) will trigger
+# CSP violations because 'unsafe-inline' is intentionally absent from
+# script-src. This is correct behaviour — third-party injection is blocked.
+# Violations are forwarded to /api/debug/csp-violations for server-side logging.
 add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://unpkg.com https://cdn.jsdelivr.net https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api.github.com https://nominatim.openstreetmap.org; frame-ancestors 'none'; report-uri /api/debug/csp-violations;" always;
 
 # Prevent MIME-type sniffing (forces content-type header respect)

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1357,6 +1357,40 @@ test_error_logger_all_pages() {
   fi
 }
 
+# ── Error Logger Contract Test ──────────────────────────────────────────────────
+
+# Verify the deployed error-logger.js behavioural contracts against the live
+# site: resource-load capture (#332), no runtime-error duplication, localStorage
+# buffering + drain when the backend is unreachable (#334), and recursion safety
+# under an error storm (#331). Uses Puppeteer request interception to simulate
+# the backend being up/down without actually taking it down.
+#
+# Warn-only (matches test_error_logger_all_pages) — a frontend contract
+# regression is surfaced loudly inline but does not roll back the deploy.
+test_error_logger_contracts() {
+  dsection "Testing error logger behavioural contracts"
+
+  local base_url="${NGINX_URL:-}"
+  if [ -z "$base_url" ]; then
+    dwarn "NGINX_URL not set — skipping error logger contract test"
+    dstatus error-logger-contracts status=skipped reason=no-nginx-url
+    return
+  fi
+
+  dinfo "Running contract test (capture, buffering, recursion safety)..."
+
+  local test_output
+  if test_output=$(docker compose -f "$COMPOSE_FILE" exec -T "$BACKEND_SERVICE" npm run test:error-logger:browser -- "$base_url" 2>&1); then
+    dstatus error-logger-contracts status=ok
+    dok "Error logger contract test passed ✓"
+  else
+    dstatus error-logger-contracts status=failed
+    dwarn "Error logger contract test output:"
+    echo "$test_output" | tee -a "$LOG_FILE"
+    dwarn "Error logger contract test failed — output above"
+  fi
+}
+
 # ── CSP Violation Test ────────────────────────────────────────────────────────
 
 test_csp_reporting() {

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -352,6 +352,7 @@ check_outlook_token "$BACKEND_SERVICE"
 # ── Post-deployment tests ─────────────────────────────────────────────────────
 
 [ "$RUN_ERROR_LOGGER" = "1" ] && test_error_logger_all_pages
+[ "$RUN_ERROR_LOGGER" = "1" ] && test_error_logger_contracts
 
 test_csp_reporting
 


### PR DESCRIPTION
## Summary

Hardens the frontend error logger (`resources/js/error-logger.js`), closes three observability blindspots surfaced while debugging #330, and wires the error-logger contract checks into the deploy pipeline so they run automatically. Grew from the original recursion fix into the full error-logger scope of the logging audit; the remaining audit blindspots are tracked separately (see below) and deliberately **not** bundled here.

## What changed

**Recursion safety (original #330 fix)**
- Removed the `console.error`-in-catch path that could loop (failed fetch → `console.error` → override → another fetch). `send()` now swallows its own errors silently.
- Added a `sending` re-entrancy guard.
- `console.error`/`console.warn` overrides are retained — they capture caught errors devs log by hand, which never reach `window.onerror`.
- Kept the `'[error-logger] Initializing'` load log (a plain `console.log`, not overridden, so no recursion) — the post-deploy all-pages test greps for it.

**Resource-load capture — closes #332**
- The bubble-phase `window 'error'` listener cannot see failed `<script>`/`<img>`/`<link>` loads (they fire on the element and don't bubble). This is the exact class of failure behind #330 — the logger couldn't even capture its own load failure.
- Added a **capture-phase** listener reporting `type=resource-error`, mapped onto the `message`/`filename` fields `/debug/errors` already logs (no backend change needed).

**Delivery resilience — closes #334**
- Reports previously vanished when the backend was unreachable. Added a bounded `localStorage` buffer (max 20, oldest dropped), flushed on load and after each successful send. `fetch(..., { keepalive: true })` so reports survive page unload.

**Auto-testing in the deploy pipeline**
- New contract test `backend/scripts/tests/test-error-logger-browser.js` verifies the *deployed* `error-logger.js` against live nginx using Puppeteer **request interception** (captures `/api/debug/errors` POSTs, simulates backend up/down — so buffering is exercised without taking the backend down). Confirmed `keepalive` fetches are interceptable.
- Wired into `deploy.sh`/`deploy-lib.sh` (`test_error_logger_contracts`) to run inside the backend container after the existing all-pages test, gated by `RUN_ERROR_LOGGER`. **Warn-only**, matching the sibling error-logger test — failure is surfaced inline in the deploy report but does not roll back.
- `docs/TESTING.md` updated: documents all three error-logger tests, the contract list, the warn-only policy, and manual invocation; testing framed around the dev-server workflow.

**CSP documentation**
- Comment in `nginx-security-headers.conf` noting ISP-injected inline scripts (e.g. `MBTSS_NOTIFICATION`) correctly trigger CSP violations — expected, not a bug.

## Root cause of #330's "Loading failed" cascade
Two conflated issues: (a) CSP correctly blocking an ISP-injected inline script, and (b) all `'self'` scripts failing — a network-level failure, almost certainly the browser fetching resources during the deploy's `docker compose down → up` window. Firefox caches the connection-refused failures. **A hard refresh (Ctrl+Shift+R) clears it.** No server-side fix prevents this without zero-downtime deploys (out of scope). The logger changes here ensure that if it recurs, we'd actually capture it.

## Files changed
| File | Change |
|---|---|
| `resources/js/error-logger.js` | Recursion-safe delivery, capture-phase resource listener, localStorage buffer |
| `backend/scripts/tests/test-error-logger-browser.js` | New contract test (live-site, request interception) |
| `backend/package.json` | `test:error-logger:browser` script |
| `scripts/deploy/deploy-lib.sh` | `test_error_logger_contracts` runner |
| `scripts/deploy/deploy.sh` | Call contract test post-deploy (gated by `RUN_ERROR_LOGGER`) |
| `scripts/config/nginx-security-headers.conf` | CSP ISP-injection comment |
| `docs/TESTING.md` | Document the three error-logger tests + policy |

## Logging audit — issues raised
| # | Blindspot | Status |
|---|-----------|--------|
| #332 | Resource-load failures invisible | **Fixed here** |
| #334 | Frontend reports dropped when backend down | **Fixed here** |
| #333 | No log persistence / alerting | Tracked |
| #335 | Test coverage gaps (deploy/upload/cv/debug + WebAuthn) | Tracked |
| #336 | No request-ID correlation | Tracked |
| #337 | Deprecated CSP `report-uri`; in-memory rate limiter | Tracked |
| #338 | No metrics (counters/percentiles) | Tracked |

## Test plan

Testing is on the Ubuntu **dev server** (canonical environment). The deploy runs Vitest, HTTP regression smoke tests, and **all three error-logger tests** automatically in-container.

```powershell
# 1. Deploy this branch to the dev server.
.\scripts\deploy\dev-deploy.ps1
# Expected in the deploy report:
#   [deploy:vitest] status=ok
#   [regression] status=OK passed=N failed=0
#   [deploy:error-logger] status=ok                 (all-pages)
#   [deploy:error-logger-contracts] status=ok       (capture/buffer/recursion)
```

```bash
# 2. (Optional) Re-run the contract test manually inside the backend container.
#    Dev: NGINX_SERVICE=nginx, NGINX_PORT=3001 → https://nginx:3001
cd ~/MyPortfolioSite-dev
docker compose -f docker-compose.yml -p portfolio_dev exec -T backend \
  npm run test:error-logger:browser -- https://nginx:3001
# Expected final line:
#   [error-logger-browser] status=OK passed=8 failed=0
```

Manual integration verification against the live dev site (`https://dev.andykeys.me:3001`), devtools console open:

```js
// 3. Resource-load capture (#332) — inject a broken script src:
var s=document.createElement('script'); s.src='/resources/js/nope.js'; document.head.appendChild(s)
```
```bash
docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml -p portfolio_dev logs --tail=30 backend | grep "debug/errors"
# Expected: "[debug/errors] Frontend error — Failed to load <script>: .../nope.js"
```

```js
// 4. Runtime error logged exactly once:
setTimeout(() => { throw new Error('pr331-runtime'); }, 0)
```
```bash
docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml -p portfolio_dev logs --tail=30 backend | grep "debug/errors"
# Expected: exactly ONE new [debug/errors] line for this error.
```

> Buffering (#334) is covered by the automated contract test (step 1/2, tests 3–4) — taking the backend down on the shared dev server is disruptive, so it is exercised via request interception rather than manually.

## Documentation
- `docs/TESTING.md` updated (three error-logger tests, contract list, warn-only policy, manual run).
- `/debug/errors` contract unchanged (resource errors reuse existing `message`/`filename` fields) — no API/operator-behaviour change.

Closes #330, #332, #334

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>