### PR TITLE
docs: make CSP allowlist maintenance a standing dev-cycle rule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -56,6 +56,7 @@ Closes #<!-- issue number -->
 - [ ] `docs/CHANGELOG.md` updated with an entry under `[Unreleased]`
 - [ ] Behaviour docs updated if needed (`docs/AI.md` / `docs/STYLE_GUIDE.md` / `docs/DATABASE.md` / `docs/SECURITY.md` / `docs/TESTING.md`)
 - [ ] Ops docs updated if needed (`docs/RUNBOOK.md` / `docs/BACKUP.md` / `docs/INCIDENTS.md` / `docs/INFRASTRUCTURE.md` / `docs/PROD_ENVIRONMENT.md` / `docs/DEV_ENVIRONMENT.md`)
+- [ ] CSP allowlist (`scripts/config/nginx-security-headers.conf`) updated if any external resource or inline script was added/moved — or N/A
 - [ ] N/A — behaviour and operator docs already match the change (no updates needed)
 
 ## Risk / Impact

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,6 +348,7 @@ const result = await pool.query(`SELECT * FROM posts WHERE id = ${postId}`);
 | `resources/js/admin.js` | Mirrors admin/index.html complexity; form logic for multiple post types | Test CRUD flows for blog + travel; check date field handling |
 | `docker-compose.yml` | Volume mounts, env vars, networking — errors break the entire dev environment | Test `docker compose up/down/reset` after changes |
 | `backend/db/schema.sql` | Idempotent, no migration tool — altering existing columns requires careful planning | Always use IF NOT EXISTS / IF NOT; test schema changes on a clean DB |
+| `scripts/config/nginx-security-headers.conf` (CSP) | One directive line governs a whole class of resources; a missing allowlist entry breaks a feature in prod only (enforced CSP) and is invisible to Vitest | When adding/moving any external resource (script, style, font, image, API origin) or inline script, update the allowlist in the same PR and verify it loads in a browser |
 
 ---
 

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -449,6 +449,7 @@ Every PR that touches backend code **must** include a `scripts/tests/Test-PRN.ps
 - Use parameterized queries for SQL
 - Validate user input at system entry points only
 - Never log or commit sensitive data (`.env`, tokens, API keys)
+- **Keep the CSP allowlist in lockstep.** Any change that adds or moves an external resource — a `<script>`/`<link>`/font/image source, an inline script or style, or a `fetch`/XHR to a new origin — must update `scripts/config/nginx-security-headers.conf` in the **same PR** and be verified to load in a browser. A missed entry is blocked **only in prod** (where the CSP is enforced) and breaks that feature silently; Vitest cannot catch it. Enforcement is per-resource (one violation blocks one resource, not the whole page), but a single directive line governs a whole *class* of resources — so a wrong or over-tightened line (e.g. dropping `'self'` from `script-src`) has site-wide blast radius. Treat edits to this file as high-risk. (Prior incidents: Nominatim geocoding, #330.)
 
 ## Hotfixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 
 ## Unreleased (dev)
 
+### Added
+- CSP maintenance is now a standing dev-cycle rule (#339): adding or moving any external resource (script/style/font/image source, inline script, or a `fetch` to a new origin) must update `scripts/config/nginx-security-headers.conf` in the same PR. Documented in `docs/AI.md` (Security), `CLAUDE.md` (High-Risk Areas), and a new PR-template checklist item. Prevents prod-only CSP breakage (invisible to Vitest) like the prior Nominatim incident and #330.
+
 ### Changed
 - Unified bash deploy scripts (#300): `dev-deploy.sh` and `prod-deploy.sh` replaced by a single `deploy.sh --env dev|prod`. Both PS1 wrappers now follow the same pattern — `switch-branch.sh` handles all git updates before `deploy.sh` runs. Env-specific behaviour (Vitest, dev certs, UFW check, LAN IP detection, DDNS check, uploads dir, regression flags) is gated by feature flags set in the environment config block.
 - Project structure reorg (#307): HTML pages moved into feature subfolders (`blog/`, `travel/`, `admin/`, `login/`, `setup/`) giving clean URLs (`/blog/`, `/travel/` etc.); `resources/java/` renamed to `resources/js/`; `PROJECT_ASSESSMENT.md` and `ROADMAP.md` moved into `docs/`. No Nginx changes required — `try_files` + `index.html` handles directory routing. All internal links, JS redirects, and the magic link email URL updated to new paths.


### PR DESCRIPTION
## Summary

Makes maintaining the CSP allowlist a deliberate, documented part of the development cycle. Adding or moving an external resource without updating `scripts/config/nginx-security-headers.conf` breaks the feature **in prod only** (the enforced `Content-Security-Policy` header) and is **invisible to Vitest** — a gap that has already caused breakage (the Nominatim geocoding incident referenced in `docs/AI.md`) and resurfaced during the #330 investigation.

Closes #339

## Changes

- **`docs/AI.md` (Security):** working rule — any change adding/moving an external resource (script/style/font/image source, inline script/style, or a `fetch` to a new origin) must update the CSP allowlist in the same PR and be verified in a browser. Clarifies that enforcement is per-resource (one violation blocks one resource — *not* a cascade), but a single directive line governs a whole class, so edits have site-wide blast radius.
- **`CLAUDE.md` (High-Risk Areas):** adds `scripts/config/nginx-security-headers.conf` (CSP) as a high-risk file with mitigation.
- **`.github/pull_request_template.md`:** new Documentation checklist item for the CSP allowlist.
- **`docs/CHANGELOG.md`:** records the process addition under Unreleased → Added.

## Test Plan

### Happy path
1. Docs-only change — render-check the three files on GitHub and confirm the new content reads correctly and tables render.

### Edge cases
- [x] N/A — no code or behaviour change

### Regression checks
- [x] N/A — no runtime impact

### Setup required before testing
- None

## Smoke Test
- [x] N/A — no backend changes in this PR

## Documentation
- [x] `docs/CHANGELOG.md` updated with an entry under `[Unreleased]`
- [x] Behaviour docs updated (`docs/AI.md`, `CLAUDE.md`)
- [x] N/A — no ops docs affected
- [x] CSP allowlist — N/A (this PR documents the rule; no resource added)

## Risk / Impact
- Documentation/process only; zero runtime impact. Reduces the chance of future prod-only CSP breakage.

## Squash Commit Message

```text
docs: make CSP allowlist maintenance a dev-cycle rule

Adding/moving an external resource without updating the CSP allowlist
breaks the feature in prod only and is invisible to Vitest. Documents the
rule in AI.md, CLAUDE.md high-risk areas, and the PR template.

Closes #339

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer
- Pairs with PR #331 (which added the explanatory CSP comment to `nginx-security-headers.conf`). This PR is the process counterpart and is intentionally docs-only.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01FW7jvozMeS2YouBJmkyQM8)_