### PR TITLE
Add automated CSP violation scan on every deploy (#341)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "test:coverage": "vitest run --coverage",
     "test:error-logger": "node ./scripts/tests/test-error-logger.js",
     "test:error-logger:all-pages": "node ./scripts/tests/test-error-logger-all-pages.js",
-    "test:error-logger:browser": "node ./scripts/tests/test-error-logger-browser.js"
+    "test:error-logger:browser": "node ./scripts/tests/test-error-logger-browser.js",
+    "test:csp-violations": "node ./scripts/tests/test-csp-violations.js"
   },
   "dependencies": {
     "@simplewebauthn/server": "^7.4.0",

--- a/backend/scripts/tests/test-csp-violations.js
+++ b/backend/scripts/tests/test-csp-violations.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * CSP violation detection across all served pages (#341).
+ *
+ * Loads each public page in a real browser (Puppeteer) and listens for
+ * `securitypolicyviolation` events. Filters out known ISP-injected noise
+ * (inline scripts we don't control) and flags any first-party resource that is
+ * blocked — indicating a missing or stale CSP allowlist entry.
+ *
+ * "First-party" means: the blocked URI is same-origin, or it is a CDN/API we
+ * deliberately use but haven't added to the allowlist. ISP-injected inline
+ * scripts appear as blockedURI='inline' with no documentURI match to our
+ * resources — these are filtered.
+ *
+ * Runs inside the backend container post-deploy. Uses NGINX_URL (docker-internal
+ * address, e.g. https://nginx:3001) so Puppeteer can reach nginx directly.
+ * Warn-only: violations are surfaced but exit code 1 so the deploy flag can
+ * decide whether to block.
+ *
+ * Usage:
+ *   node test-csp-violations.js <base-url>
+ *   npm run test:csp-violations -- https://nginx:3001
+ *
+ * Output (machine-parseable):
+ *   [csp-violations] status=OK pages=6 violations=0
+ *   [csp-violations] status=FAIL pages=6 violations=2
+ */
+
+import puppeteer from 'puppeteer';
+
+const baseUrl = process.argv[2];
+if (!baseUrl) {
+  console.error('Usage: node test-csp-violations.js <base-url>');
+  process.exit(1);
+}
+
+// Pages to test — all routes served by nginx.
+// Admin/setup/login pages load static resources without requiring auth.
+const PAGES = ['/', '/blog/', '/travel/', '/login/', '/admin/', '/setup/'];
+
+// ISP-injected inline scripts arrive as blockedURI='inline' but there is no
+// reliable way to tell them from our own inline scripts beyond noting that our
+// pages intentionally have no inline scripts at all (CSP is 'self' only).
+// We flag ALL violations including inline so that if we accidentally add an
+// inline script it's caught — ISP noise is expected and documented.
+// To suppress known-noise ISP violations, maintainers should record the
+// violatedDirective + sourceFile pattern here:
+const KNOWN_NOISE = [
+  // Example — uncomment and adjust if ISP injection becomes too noisy:
+  // { blockedURI: 'inline', violatedDirective: 'script-src-elem', sourceFile: '' },
+];
+
+function isKnownNoise(v) {
+  return KNOWN_NOISE.some(
+    n =>
+      n.blockedURI === v.blockedURI &&
+      n.violatedDirective === v.violatedDirective &&
+      (n.sourceFile === undefined || n.sourceFile === v.sourceFile),
+  );
+}
+
+const allViolations = []; // { page, blockedURI, violatedDirective, sourceFile, lineNumber }
+const pageResults = [];   // { page, count }
+
+console.log('\n🔒 CSP violation detection (#341) — all pages');
+console.log(`📍 Base URL: ${baseUrl}\n`);
+
+let browser;
+try {
+  browser = await puppeteer.launch({
+    headless: 'new',
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--ignore-certificate-errors', // self-signed dev certs
+    ],
+  });
+
+  for (const path of PAGES) {
+    const url = `${baseUrl}${path}`;
+    const violations = [];
+
+    const page = await browser.newPage();
+
+    // Capture securitypolicyviolation events from the page context.
+    await page.evaluateOnNewDocument(() => {
+      window.__cspViolations = [];
+      document.addEventListener('securitypolicyviolation', (e) => {
+        window.__cspViolations.push({
+          blockedURI: e.blockedURI,
+          violatedDirective: e.violatedDirective,
+          effectiveDirective: e.effectiveDirective,
+          sourceFile: e.sourceFile || '',
+          lineNumber: e.lineNumber || 0,
+          columnNumber: e.columnNumber || 0,
+          sample: e.sample || '',
+        });
+      });
+    });
+
+    try {
+      await page.goto(url, { waitUntil: 'networkidle0', timeout: 20000 });
+      // Brief extra wait: some violations fire slightly after networkidle.
+      await new Promise(r => setTimeout(r, 500));
+
+      const raw = await page.evaluate(() => window.__cspViolations || []);
+      for (const v of raw) {
+        if (!isKnownNoise(v)) violations.push(v);
+      }
+    } catch (err) {
+      console.warn(`  ⚠️  ${path} — navigation error: ${err.message}`);
+    } finally {
+      await page.close();
+    }
+
+    const icon = violations.length === 0 ? '✅' : '❌';
+    console.log(`  ${icon} ${path} — ${violations.length} violation(s)`);
+    for (const v of violations) {
+      console.log(`       blocked: ${v.blockedURI}`);
+      console.log(`       directive: ${v.violatedDirective} (${v.effectiveDirective})`);
+      if (v.sourceFile) console.log(`       source: ${v.sourceFile}:${v.lineNumber}`);
+      if (v.sample) console.log(`       sample: ${v.sample.slice(0, 120)}`);
+    }
+
+    allViolations.push(...violations.map(v => ({ page: path, ...v })));
+    pageResults.push({ page: path, count: violations.length });
+  }
+} catch (err) {
+  console.error('\n💥 Test runner crashed:', err.message);
+  allViolations.push({ page: 'runner', blockedURI: err.message, violatedDirective: 'crash' });
+} finally {
+  if (browser) await browser.close();
+}
+
+const totalViolations = allViolations.length;
+const status = totalViolations === 0 ? 'OK' : 'FAIL';
+
+console.log('\n' + '='.repeat(60));
+if (totalViolations === 0) {
+  console.log(`✅ No CSP violations detected across ${PAGES.length} pages`);
+} else {
+  console.log(`❌ ${totalViolations} CSP violation(s) detected across ${PAGES.length} pages`);
+  console.log('\nSummary:');
+  for (const r of pageResults.filter(r => r.count > 0)) {
+    console.log(`  • ${r.page}: ${r.count} violation(s)`);
+  }
+  console.log('\nAction required: update scripts/config/nginx-security-headers.conf');
+  console.log('  Add the blocked resource to the appropriate CSP directive.');
+  console.log('  See docs/AI.md → Security for the CSP maintenance rule.');
+}
+console.log('='.repeat(60));
+console.log(
+  `[csp-violations] status=${status} pages=${PAGES.length} violations=${totalViolations}\n`,
+);
+
+process.exit(totalViolations > 0 ? 1 : 0);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 
 ### Added
 - CSP maintenance is now a standing dev-cycle rule (#339): adding or moving any external resource (script/style/font/image source, inline script, or a `fetch` to a new origin) must update `scripts/config/nginx-security-headers.conf` in the same PR. Documented in `docs/AI.md` (Security), `CLAUDE.md` (High-Risk Areas), and a new PR-template checklist item. Prevents prod-only CSP breakage (invisible to Vitest) like the prior Nominatim incident and #330.
+- Automated browser CSP violation scan on every deploy (#341): `backend/scripts/tests/test-csp-violations.js` loads all served pages (`/`, `/blog/`, `/travel/`, `/login/`, `/admin/`, `/setup/`) in Puppeteer and flags any `securitypolicyviolation` event indicating a missing allowlist entry. Runs inside the backend container after error-logger checks (`RUN_ERROR_LOGGER=1`), warn-only. Machine-parseable `[csp-violations]` summary line in the deploy report. Added `check_csp_violations()` to `deploy-lib.sh`, wired into `deploy.sh`, and documented in `docs/TESTING.md`.
 
 ### Changed
 - Unified bash deploy scripts (#300): `dev-deploy.sh` and `prod-deploy.sh` replaced by a single `deploy.sh --env dev|prod`. Both PS1 wrappers now follow the same pattern — `switch-branch.sh` handles all git updates before `deploy.sh` runs. Env-specific behaviour (Vitest, dev certs, UFW check, LAN IP detection, DDNS check, uploads dir, regression flags) is gated by feature flags set in the environment config block.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -90,15 +90,16 @@ docker compose exec backend npm run test:coverage
 
 ---
 
-## Browser-Level Tests (frontend error-logger)
+## Browser-Level Tests
 
-Three Puppeteer scripts exercise `resources/js/error-logger.js` against the live deployed site. **All three run automatically inside the backend container after every dev/prod deploy** (gated by `RUN_ERROR_LOGGER=1`; the backend image ships Chromium). They reach nginx by its docker-internal service name (`NGINX_URL`).
+Puppeteer scripts run automatically inside the backend container after every dev/prod deploy (gated by `RUN_ERROR_LOGGER=1`; the backend image ships Chromium). They reach nginx by its docker-internal service name (`NGINX_URL`).
 
 | Script | npm script | What it verifies |
 |---|---|---|
 | `test-error-logger.js` | `test:error-logger` | Error logger initialises and reports on the `/api/debug/test-errors` page |
 | `test-error-logger-all-pages.js` | `test:error-logger:all-pages` | Logger initialises on every public page (`/`, `/blog/`, `/travel/`, `/login/`) |
 | `test-error-logger-browser.js` | `test:error-logger:browser` | Behavioural **contracts** (see below) via request interception |
+| `test-csp-violations.js` | `test:csp-violations` | No first-party CSP violations on any page — catches missing allowlist entries (#341) |
 
 ### Contract test (`test-error-logger-browser.js`)
 
@@ -132,10 +133,26 @@ docker compose -f docker-compose.yml -p portfolio_dev exec -T backend \
   npm run test:error-logger:browser -- https://nginx:3001
 ```
 
+### CSP violation scan (`test-csp-violations.js`)
+
+Loads every served page (`/`, `/blog/`, `/travel/`, `/login/`, `/admin/`, `/setup/`) in a real browser and listens for `securitypolicyviolation` events (#341). Reports any blocked resource with the directive, source, and remediation instruction. ISP-injected inline-script noise is expected; maintainers can record known-noise patterns in the `KNOWN_NOISE` array inside the script to suppress specific entries.
+
+Machine-parseable summary:
+```
+[csp-violations] status=OK pages=6 violations=0
+```
+
 ### When to run
 
 - Automatically: every dev/prod deploy
-- Manually after any change to `resources/js/error-logger.js`, or to `backend/routes/debug.js` if it alters the `/debug/errors` contract
+- Manually after any change to `resources/js/error-logger.js` or `backend/routes/debug.js`
+- Manually after adding or moving any external resource (script, style, font, image, API origin) — verifies the CSP allowlist update is correct
+- Run against the dev server before raising a PR that touches CSP or external resources:
+  ```bash
+  cd ~/MyPortfolioSite-dev
+  docker compose -f docker-compose.yml exec -T backend \
+    npm run test:csp-violations -- https://nginx:3001
+  ```
 
 ---
 

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1391,6 +1391,39 @@ test_error_logger_contracts() {
   fi
 }
 
+# ── CSP Browser Violation Detection (#341) ────────────────────────────────────
+
+# Load every served page in a real browser and listen for securitypolicyviolation
+# events. Filters known ISP-injected noise and flags any blocked resource that
+# indicates a missing or stale CSP allowlist entry. Runs inside the backend
+# container (Chromium available) using NGINX_URL (docker-internal address) so
+# Puppeteer can reach nginx directly.
+# Warn-only — violations are surfaced loudly but do not roll back the deploy.
+check_csp_violations() {
+  dsection "Browser CSP violation scan (#341)"
+
+  local base_url="${NGINX_URL:-}"
+  if [ -z "$base_url" ]; then
+    dwarn "NGINX_URL not set — skipping CSP violation scan"
+    dstatus csp-violations status=skipped reason=no-nginx-url
+    return
+  fi
+
+  dinfo "Loading all pages in headless browser to detect CSP violations..."
+
+  local test_output
+  if test_output=$(docker compose -f "$COMPOSE_FILE" exec -T "$BACKEND_SERVICE" \
+      npm run test:csp-violations -- "$base_url" 2>&1); then
+    dstatus csp-violations status=ok
+    dok "CSP violation scan passed — no first-party violations ✓"
+  else
+    dstatus csp-violations status=failed
+    dwarn "CSP violation scan output:"
+    echo "$test_output" | tee -a "$LOG_FILE"
+    dwarn "CSP violations detected — update nginx-security-headers.conf and re-deploy"
+  fi
+}
+
 # ── CSP Violation Test ────────────────────────────────────────────────────────
 
 test_csp_reporting() {

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -326,7 +326,7 @@ if [ "$DRY_RUN" = "1" ]; then
   dinfo "  service:      $BACKEND_SERVICE"
   dinfo "  health URL:   $HEALTH_URL"
   [ "$RUN_VITEST"        = "1" ] && dinfo "  vitest:        would run after health check"
-  [ "$RUN_ERROR_LOGGER"  = "1" ] && dinfo "  error-logger:  would run after vitest"
+  [ "$RUN_ERROR_LOGGER"  = "1" ] && dinfo "  error-logger:  would run after vitest (incl. CSP violation scan)"
   [ "$SKIP_REGRESSION"   = "0" ] && dinfo "  regression:    would run smoke tests"
   [ "$RUN_BACKUP_CHECK"  = "1" ] && dinfo "  backup check:  would warn if backups absent/stale"
   dinfo ""
@@ -353,6 +353,7 @@ check_outlook_token "$BACKEND_SERVICE"
 
 [ "$RUN_ERROR_LOGGER" = "1" ] && test_error_logger_all_pages
 [ "$RUN_ERROR_LOGGER" = "1" ] && test_error_logger_contracts
+[ "$RUN_ERROR_LOGGER" = "1" ] && check_csp_violations
 
 test_csp_reporting
 


### PR DESCRIPTION
## Summary

Adds a Puppeteer-based CSP violation scan that runs after every deploy, loading all six served pages in a real browser and flagging any `securitypolicyviolation` event. Catches missing or stale CSP allowlist entries before they reach users — the exact failure mode of #330.

Closes #341

## Changes

- `backend/scripts/tests/test-csp-violations.js` — new Puppeteer test: loads `/`, `/blog/`, `/travel/`, `/login/`, `/admin/`, `/setup/`; listens for `securitypolicyviolation` events; filters ISP-injected noise; reports blocked resource, directive, source file, and remediation guidance
- `backend/package.json` — adds `test:csp-violations` npm script
- `scripts/deploy/deploy-lib.sh` — adds `check_csp_violations()` function (warn-only, matches sibling error-logger pattern)
- `scripts/deploy/deploy.sh` — calls `check_csp_violations` after error-logger tests, gated by `RUN_ERROR_LOGGER=1`; dry-run info line updated
- `docs/TESTING.md` — documents the new test in the Browser-Level Tests table and adds a CSP violation scan section with contracts and manual invocation command
- `docs/CHANGELOG.md` — Unreleased entry

## Test Plan

### Happy path

1. Deploy any branch to the dev server — check deploy report includes `[deploy:csp-violations]` checkpoint line
2. Confirm `[csp-violations] status=OK pages=6 violations=0` in the deploy output

### Edge cases

- [x] NGINX_URL not set → scan skipped with `status=skipped reason=no-nginx-url` (no crash)
- [x] Page navigation error → warning logged, test runner continues with remaining pages

### Regression checks

- [x] All existing error-logger tests (`test:error-logger:all-pages`, `test:error-logger:browser`) still run unchanged
- [x] `test_csp_reporting` (curl-based CSP header check) still runs unchanged after the new scan

### Setup required before testing

- Dev server deployed with `RUN_ERROR_LOGGER=1` (already default for dev/prod)

## Smoke Test

- [ ] `scripts/tests/test-regression.sh` run and passing
- [x] N/A — no backend route changes; this is a deploy-pipeline test addition only

## Documentation

- [x] `docs/CHANGELOG.md` updated with an entry under `[Unreleased]`
- [x] `docs/TESTING.md` updated — new table row and CSP violation scan section
- [x] CSP allowlist (`scripts/config/nginx-security-headers.conf`) updated if any external resource or inline script was added/moved — N/A (this PR adds no new external resources)
- [x] N/A — no behaviour or ops doc changes beyond TESTING.md

## Risk / Impact

- Warn-only: a detection failure surfaces in the deploy report but does not roll back the deploy (matches error-logger policy; avoids a flake blocking a release)
- Covers all six served pages including login/admin/setup — catching CSP breakage in non-public routes that the error-logger all-pages test skips
- No change to nginx config or backend routes

## Squash Commit Message

```text
add automated CSP violation scan on every deploy (#341)

New Puppeteer test loads all six served pages in a headless browser and
captures securitypolicyviolation events. Flags any blocked resource with
the directive, source, and remediation steps. Runs warn-only post-deploy
(check_csp_violations in deploy-lib.sh, gated by RUN_ERROR_LOGGER=1).
Catches the prod-only CSP breakage class seen in #330 automatically.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

The `KNOWN_NOISE` array in `test-csp-violations.js` is intentionally empty — all violations including ISP-injected `blockedURI='inline'` are flagged. This is deliberate: our pages have no intentional inline scripts, so any inline violation is either a genuine problem or ISP noise worth knowing about. If ISP noise becomes operationally noisy, maintainers can add a pattern entry to `KNOWN_NOISE` with a comment explaining why.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FW7jvozMeS2YouBJmkyQM8)_