### PR TITLE
sync: backport prod health check hotfix from main (#329)

### DIFF
--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1021,6 +1021,7 @@ _poll_health() {
   local attempts=0
   local curl_flags=()
   [ "${HEALTH_INSECURE:-0}" = "1" ] && curl_flags+=("--insecure")
+  [ -n "${HEALTH_RESOLVE:-}" ]      && curl_flags+=("--resolve" "${HEALTH_RESOLVE}")
 
   while [ "$attempts" -lt "$max_attempts" ]; do
     local http_code
@@ -1224,9 +1225,9 @@ wait_for_health() {
   local url2="${HEALTH_URL_2:-}"
   local timeout="${HEALTH_TIMEOUT:-60}"
   local interval="${HEALTH_INTERVAL:-5}"
-  # Set HEALTH_INSECURE=1 in caller to skip SSL cert verification (e.g. dev self-signed certs)
   local curl_opts=""
   [ "${HEALTH_INSECURE:-0}" = "1" ] && curl_opts="--insecure"
+  [ -n "${HEALTH_RESOLVE:-}" ]      && curl_opts="$curl_opts --resolve ${HEALTH_RESOLVE}"
 
   dsection "Phase 6: HTTP/HTTPS health checks"
 

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -212,18 +212,20 @@ else
   HEALTH_INSECURE=0
 fi
 
-# Health check through nginx rather than the backend port directly. This lets
-# us remove the host-port binding from the backend container, eliminating the
-# port conflict on server restart. Nginx proxies /api/health to the backend,
-# so a 200 from nginx confirms both services are up.
-# Protocol follows CERT_MODE: self-signed (dev) means nginx speaks HTTPS even
-# on non-443 ports, so we must use https:// regardless of port number.
+# Health check URL and curl flags.
+# - self-signed (dev): curl localhost with --insecure (cert isn't trusted)
+# - letsencrypt (prod): curl via SITE_HOST so the cert CN matches; use
+#   --resolve to force local resolution and avoid hairpin NAT
 if [ "${CERT_MODE:-}" = "self-signed" ]; then
   HEALTH_URL="https://localhost:${NGINX_PORT}/api/health"
+  HEALTH_INSECURE=1
 elif [ "${NGINX_PORT}" = "443" ]; then
-  HEALTH_URL="https://localhost/api/health"
+  HEALTH_URL="https://${SITE_HOST}/api/health"
+  HEALTH_RESOLVE="${SITE_HOST}:443:127.0.0.1"
+  HEALTH_INSECURE=0
 else
   HEALTH_URL="http://localhost:${NGINX_PORT}/api/health"
+  HEALTH_INSECURE=0
 fi
 
 # Docker-internal nginx URL used by the error-logger test (puppeteer inside the


### PR DESCRIPTION
## Summary

Backports the prod health check hotfix (commit `c8d699d` on `main`) to `dev` so both environments stay in sync.

The release commit `f73fc66` was not cherry-picked — it is a squash-merge of dev's own work and is already fully present on `dev`. Only the hotfix that was applied directly to `main` after the release is missing.

## Changes

- `scripts/deploy/deploy-lib.sh` — `_poll_health()` and `wait_for_health()` now pick up `HEALTH_RESOLVE` env var and pass it as `--resolve` to curl
- `scripts/deploy/deploy.sh` — prod health check URL changed from `https://localhost/api/health` to `https://${SITE_HOST}/api/health` with `HEALTH_RESOLVE="${SITE_HOST}:443:127.0.0.1"` so curl resolves locally without hairpin NAT

## Why this was needed

`curl https://localhost/api/health` fails on prod because the Let's Encrypt cert is issued for the domain name, not `localhost` — curl rejects it with an SSL mismatch error. Using `SITE_HOST` as the URL and `--resolve` to force local resolution fixes this without needing hairpin NAT.

## Test Plan

### Happy path

1. Deploy to dev server — health check phase should pass as before (dev uses self-signed certs and `localhost`, unaffected by this change)
2. On prod deploy — health check phase should now correctly use `https://andykeys.me/api/health --resolve andykeys.me:443:127.0.0.1`

### Regression checks

- [ ] Dev deploy health check still passes (unchanged path for `CERT_MODE=self-signed`)
- [ ] No new required env vars — `HEALTH_RESOLVE` is set internally by `deploy.sh`, not from `.env`

### Setup required before testing

- None

## Smoke Test

- [ ] N/A — no backend route changes; deploy pipeline only

## Documentation

- [x] N/A — no behaviour or docs changes; pure bug fix backport

## Squash Commit Message

```text
sync: backport prod health check hotfix to dev (#329)

curl https://localhost/api/health fails on prod (Let's Encrypt cert is
for the domain, not localhost). Hotfix already applied to main — brings
dev in sync. No dev behaviour change (self-signed path unchanged).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01FW7jvozMeS2YouBJmkyQM8)_