### PR TITLE
fix: auto-create backup dir, install cron, run initial backup, separate dev/prod paths (#352)

### DIFF
--- a/.env.dev-server.example
+++ b/.env.dev-server.example
@@ -36,7 +36,7 @@ UPLOADS_VOLUME_NAME=
 # ── Deploy ───────────────────────────────────────────────────────────────────
 CERT_MODE=self-signed
 ROLLBACK_BRANCH=dev
-BACKUP_DIR=/home/ak/backups
+BACKUP_DIR=~/backups
 
 # ── Database ─────────────────────────────────────────────────────────────────
 DB_NAME=portfolio_dev

--- a/.env.dev-server.example
+++ b/.env.dev-server.example
@@ -36,7 +36,7 @@ UPLOADS_VOLUME_NAME=
 # ── Deploy ───────────────────────────────────────────────────────────────────
 CERT_MODE=self-signed
 ROLLBACK_BRANCH=dev
-BACKUP_DIR=~/backups
+BACKUP_DIR=~/backups/dev
 
 # ── Database ─────────────────────────────────────────────────────────────────
 DB_NAME=portfolio_dev

--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ UPLOADS_VOLUME_NAME=
 # ── Deploy ───────────────────────────────────────────────────────────────────
 CERT_MODE=letsencrypt
 ROLLBACK_BRANCH=main
-BACKUP_DIR=/home/ak/backups
+BACKUP_DIR=~/backups
 
 # ── Database ─────────────────────────────────────────────────────────────────
 DB_NAME=portfolio_prod

--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ UPLOADS_VOLUME_NAME=
 # ── Deploy ───────────────────────────────────────────────────────────────────
 CERT_MODE=letsencrypt
 ROLLBACK_BRANCH=main
-BACKUP_DIR=~/backups
+BACKUP_DIR=~/backups/prod
 
 # ── Database ─────────────────────────────────────────────────────────────────
 DB_NAME=portfolio_prod

--- a/scripts/backup/db-backup.sh
+++ b/scripts/backup/db-backup.sh
@@ -5,7 +5,7 @@
 set -e
 
 REPO_DIR="$HOME/MyPortfolioSite"
-BACKUP_DIR="$HOME/backups"
+BACKUP_DIR="${BACKUP_DIR:-$HOME/backups/prod}"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 
 mkdir -p "$BACKUP_DIR"

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1849,12 +1849,19 @@ check_backup_health() {
     fi
 
     if [ "$create" = "1" ]; then
-      mkdir -p "$backup_dir"
-      dstatus backup-files status=created dir="$backup_dir"
-      dok "Created backup directory: ${backup_dir}"
-      dinfo "Add the backup cron job if not already present:"
-      dinfo "  crontab -e"
-      dinfo "  ${cron_line}"
+      if mkdir -p "$backup_dir" 2>/dev/null; then
+        dstatus backup-files status=created dir="$backup_dir"
+        dok "Created backup directory: ${backup_dir}"
+        dinfo "Add the backup cron job if not already present:"
+        dinfo "  crontab -e"
+        dinfo "  ${cron_line}"
+      else
+        dstatus backup-files status=warn dir="$backup_dir"
+        dwarn "Could not create ${backup_dir} — permission denied."
+        dwarn "BACKUP_DIR in .env may point to another user's home (running as: $(whoami))."
+        dwarn "Set BACKUP_DIR to a path under \$HOME, e.g. ${HOME}/backups"
+        ok=0
+      fi
     else
       dstatus backup-files status=warn dir="$backup_dir"
       dwarn "Backup directory ${backup_dir} does not exist — backups not configured (#164)"

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1811,7 +1811,33 @@ check_backup_health() {
     ok=0
   fi
 
-  # ── Check 2: recent backup files exist ──────────────────────────────────
+  # ── Check 2: backup directory exists (create if missing) (#352) ─────────
+  local cron_line="0 2 * * * \${HOME}/MyPortfolioSite/scripts/backup/db-backup.sh >> \${HOME}/backup.log 2>&1"
+  if [ ! -d "$backup_dir" ]; then
+    local create=0
+    if [ "${AUTO_YES:-0}" = "1" ]; then
+      create=1
+    elif [ -t 0 ]; then
+      printf "\n[backup] Backup directory %s does not exist. Create it now? [Y/n] " "$backup_dir"
+      read -r answer
+      [[ "$answer" =~ ^[Yy]?$ ]] && create=1
+    fi
+
+    if [ "$create" = "1" ]; then
+      mkdir -p "$backup_dir"
+      dstatus backup-files status=created dir="$backup_dir"
+      dok "Created backup directory: ${backup_dir}"
+      dinfo "Add the backup cron job if not already present:"
+      dinfo "  crontab -e"
+      dinfo "  ${cron_line}"
+    else
+      dstatus backup-files status=warn dir="$backup_dir"
+      dwarn "Backup directory ${backup_dir} does not exist — backups not configured (#164)"
+      ok=0
+    fi
+  fi
+
+  # ── Check 3: recent backup files exist ───────────────────────────────────
   if [ -d "$backup_dir" ]; then
     local recent
     recent=$(find "$backup_dir" -maxdepth 2 -name "*.sql*" -o -name "*.dump" -o -name "*.tar*" \
@@ -1832,10 +1858,6 @@ check_backup_health() {
       dwarn "No backup files found in ${backup_dir} — backups may never have run (#164)"
       ok=0
     fi
-  else
-    dstatus backup-files status=warn dir="$backup_dir"
-    dwarn "Backup directory ${backup_dir} does not exist — backups not configured (#164)"
-    ok=0
   fi
 
   if [ "$ok" = "0" ]; then

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -461,7 +461,19 @@ sync_env_from_template() {
       else
         printf '%s\n' "$line" >> "$tmp_env"
         new_keys+=("$key")
-        placeholder_keys+=("$key")
+        # Only flag as a placeholder requiring action if the template value
+        # matches a known placeholder pattern (e.g. "change-me", "your-").
+        # An empty template value (KEY=) means the key is optional —
+        # add it to .env silently and do not block the deploy (#352).
+        local is_ph=0
+        local pat
+        for pat in "${PLACEHOLDER_PATTERNS[@]}"; do
+          if [[ "$template_value" == *"$pat"* ]]; then
+            is_ph=1
+            break
+          fi
+        done
+        [ "$is_ph" = "1" ] && placeholder_keys+=("$key")
       fi
     else
       # Comment, blank line, section header — copy verbatim from template
@@ -496,11 +508,24 @@ sync_env_from_template() {
   dok "Rebuilt $ENV_FILE from template (backup: $backup)"
   dlog "  carried over: $carried_count keys"
   if [ "${#new_keys[@]}" -gt 0 ]; then
-    dwarn "  new keys (template default in place — review and set real values):"
+    # Split new keys into required-action (placeholder) vs optional (empty template value).
+    local required_keys=() optional_keys=()
     local k
     for k in "${new_keys[@]}"; do
-      dwarn "    + $k"
+      if printf '%s\n' "${placeholder_keys[@]:-}" | grep -qx "$k"; then
+        required_keys+=("$k")
+      else
+        optional_keys+=("$k")
+      fi
     done
+    if [ "${#required_keys[@]}" -gt 0 ]; then
+      dwarn "  new keys (template default in place — review and set real values):"
+      for k in "${required_keys[@]}"; do dwarn "    + $k"; done
+    fi
+    if [ "${#optional_keys[@]}" -gt 0 ]; then
+      dinfo "  new optional keys added (empty by default — configure only if needed):"
+      for k in "${optional_keys[@]}"; do dinfo "    + $k"; done
+    fi
   fi
   if [ "${#dropped_keys[@]}" -gt 0 ]; then
     dlog "  dropped keys (not in template — preserved only in backup):"

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1827,18 +1827,34 @@ check_backup_health() {
     cron_found=1
   fi
 
+  local cron_entry="0 2 * * * ${REPO_DIR}/scripts/backup/db-backup.sh >> ${HOME}/backup.log 2>&1"
+
   if [ "$cron_found" = "1" ]; then
     dstatus backup-schedule status=ok
     dok "Backup schedule: cron/timer found ✓"
   else
-    dstatus backup-schedule status=warn
-    dwarn "No backup cron job or systemd timer found — automated backups may not be configured (#164)"
-    ok=0
+    local install_cron=0
+    if [ "${AUTO_YES:-0}" = "1" ]; then
+      install_cron=1
+    elif [ -t 0 ]; then
+      printf "\n[backup] No backup cron job found. Install one now? [Y/n] "
+      read -r answer
+      [[ "$answer" =~ ^[Yy]?$ ]] && install_cron=1
+    fi
+
+    if [ "$install_cron" = "1" ]; then
+      (crontab -l 2>/dev/null; echo "$cron_entry") | crontab -
+      dstatus backup-schedule status=installed
+      dok "Installed backup cron: ${cron_entry}"
+    else
+      dstatus backup-schedule status=warn
+      dwarn "No backup cron job found — add manually: crontab -e"
+      dwarn "  ${cron_entry}"
+      ok=0
+    fi
   fi
 
   # ── Check 2: backup directory exists (create if missing) (#352) ─────────
-  local cron_line="0 2 * * * \${HOME}/MyPortfolioSite/scripts/backup/db-backup.sh >> \${HOME}/backup.log 2>&1"
-
   # Sanity check: BACKUP_DIR must be under the current user's home. A path
   # like /home/ak/backups synced from a template with a hardcoded username
   # will fail mkdir for any other SSH user — catch it early with a clear fix.
@@ -1863,7 +1879,7 @@ check_backup_health() {
         dok "Created backup directory: ${backup_dir}"
         dinfo "Add the backup cron job if not already present:"
         dinfo "  crontab -e"
-        dinfo "  ${cron_line}"
+        dinfo "  ${cron_entry}"
       else
         dstatus backup-files status=warn dir="$backup_dir"
         dwarn "Could not create ${backup_dir} — permission denied."
@@ -1894,9 +1910,36 @@ check_backup_health() {
         ok=0
       fi
     else
-      dstatus backup-files status=warn dir="$backup_dir"
-      dwarn "No backup files found in ${backup_dir} — backups may never have run (#164)"
-      ok=0
+      local run_backup=0
+      if [ "${AUTO_YES:-0}" = "1" ]; then
+        run_backup=1
+      elif [ -t 0 ]; then
+        printf "\n[backup] No backup files found. Run an initial backup now? [Y/n] "
+        read -r answer
+        [[ "$answer" =~ ^[Yy]?$ ]] && run_backup=1
+      fi
+
+      if [ "$run_backup" = "1" ]; then
+        dinfo "Running initial backup..."
+        local timestamp
+        timestamp=$(date +%Y%m%d-%H%M%S)
+        local db_backup="${backup_dir}/portfolio-${timestamp}.sql.gz"
+        if docker compose -f "$COMPOSE_FILE" exec -T postgres \
+            pg_dump -U "${DB_USER:-postgres}" "${DB_NAME:-portfolio}" \
+            2>/dev/null | gzip > "$db_backup" && [ -s "$db_backup" ]; then
+          dstatus backup-files status=ok dir="$backup_dir"
+          dok "Initial backup created: $(basename "$db_backup") ($(du -sh "$db_backup" | cut -f1))"
+        else
+          rm -f "$db_backup"
+          dstatus backup-files status=warn dir="$backup_dir"
+          dwarn "Initial backup failed — check containers are healthy and DB credentials are correct"
+          ok=0
+        fi
+      else
+        dstatus backup-files status=warn dir="$backup_dir"
+        dwarn "No backup files found in ${backup_dir} — backups may never have run (#164)"
+        ok=0
+      fi
     fi
   fi
 

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1838,7 +1838,16 @@ check_backup_health() {
 
   # ── Check 2: backup directory exists (create if missing) (#352) ─────────
   local cron_line="0 2 * * * \${HOME}/MyPortfolioSite/scripts/backup/db-backup.sh >> \${HOME}/backup.log 2>&1"
-  if [ ! -d "$backup_dir" ]; then
+
+  # Sanity check: BACKUP_DIR must be under the current user's home. A path
+  # like /home/ak/backups synced from a template with a hardcoded username
+  # will fail mkdir for any other SSH user — catch it early with a clear fix.
+  if [[ "$backup_dir" == /home/* ]] && [[ "$backup_dir" != "$HOME"* ]]; then
+    dstatus backup-files status=warn dir="$backup_dir"
+    dwarn "BACKUP_DIR (${backup_dir}) belongs to a different user (running as: $(whoami))."
+    dwarn "Update BACKUP_DIR in .env — suggested value: ${HOME}/backups"
+    ok=0
+  elif [ ! -d "$backup_dir" ]; then
     local create=0
     if [ "${AUTO_YES:-0}" = "1" ]; then
       create=1
@@ -1858,8 +1867,7 @@ check_backup_health() {
       else
         dstatus backup-files status=warn dir="$backup_dir"
         dwarn "Could not create ${backup_dir} — permission denied."
-        dwarn "BACKUP_DIR in .env may point to another user's home (running as: $(whoami))."
-        dwarn "Set BACKUP_DIR to a path under \$HOME, e.g. ${HOME}/backups"
+        dwarn "Set BACKUP_DIR to a writable path in .env, e.g. ${HOME}/backups"
         ok=0
       fi
     else


### PR DESCRIPTION
## Summary

Expanded from the original scope (just create the missing directory) to a full backup bootstrap on first deploy. Also fixes a template bug that caused both dev and prod to write backups to the same folder.

## Changes

### `scripts/deploy/deploy-lib.sh` — `check_backup_health` expanded

**Check 1 — cron missing:**
- `--auto-yes`: installs `0 2 * * * .../db-backup.sh >> ~/backup.log 2>&1` into crontab automatically
- Interactive: prompts `[Y/n]` before installing
- Reports `status=installed` on success

**Check 2 — directory missing:**
- `--auto-yes`: creates with `mkdir -p`, reports `status=created`
- Interactive: prompts `[Y/n]` before creating
- Early guard: if `BACKUP_DIR` is under `/home/` but not `$HOME`, warns immediately with the correct value rather than hitting a permission error (catches stale hardcoded usernames synced from template)

**Check 3 — no backup files found:**
- `--auto-yes`: runs an immediate `pg_dump` via the live containers using already-loaded `COMPOSE_FILE`/`DB_USER`/`DB_NAME` env vars; reports file size on success
- Interactive: prompts `[Y/n]` before running
- Cleans up the empty output file and warns if the dump fails

**Optional new env keys (envsync fix):**
- `envsync` was blocking deploys on keys with empty template values (`KEY=`), treating them the same as real placeholder values (`change-me`). Fixed to only flag keys whose template value matches a `PLACEHOLDER_PATTERNS` entry. Empty-value keys (e.g. `RCLONE_REMOTE=`, `POSTGRES_VOLUME_NAME=`) are now logged at info level and do not halt the deploy.

### `.env.dev-server.example` / `.env.example` — separate backup paths
- Dev: `BACKUP_DIR=~/backups/dev`
- Prod: `BACKUP_DIR=~/backups/prod`
- Previously both pointed to `~/backups`, risking dev and prod backups mixing

### `scripts/backup/db-backup.sh`
- `BACKUP_DIR` now respects an exported env var, falling back to `~/backups/prod` — allows the cron job to use the value from `.env` rather than a hardcoded path

## Test plan

```bash
# 1. Optional keys no longer block deploy
# Ensure RCLONE_REMOTE= and POSTGRES_VOLUME_NAME= are absent from .env,
# then run:
bash ~/MyPortfolioSite-dev/scripts/deploy/deploy.sh --env dev --dry-run --auto-yes
# Expected: [deploy:envsync] status=rebuilt with info lines for optional
# keys — NOT status=keys-added with action-required halt

# 2. Auto-yes bootstraps backup from scratch
# Remove backup dir and crontab entry, then deploy:
rm -rf ~/backups/dev
crontab -l | grep -v backup | crontab -
bash ~/MyPortfolioSite-dev/scripts/deploy/deploy.sh --env dev --auto-yes
# Expected:
#   [deploy:backup-schedule] status=installed
#   [deploy:backup-files]    status=created  (dir created)
#   [deploy:backup-files]    status=ok       (initial dump created)

# 3. Wrong-user BACKUP_DIR caught early
# Set BACKUP_DIR=/home/ak/backups in .env, then:
bash ~/MyPortfolioSite-dev/scripts/deploy/deploy.sh --env dev --dry-run --auto-yes
# Expected: warn about wrong user with suggested corrected path, no raw
# mkdir permission error

# 4. Existing backups — no change
bash ~/MyPortfolioSite-dev/scripts/deploy/deploy.sh --env dev --dry-run --auto-yes
# Expected: [deploy:backup-files] status=ok age_days=0
```

## Smoke tests

- [ ] Fresh server: dir created, cron installed, initial backup runs — all green
- [ ] Wrong-user BACKUP_DIR: clear warn with suggested fix, no raw shell error
- [ ] Optional env keys (`RCLONE_REMOTE` etc.): logged at info, deploy continues
- [ ] Existing healthy backup: no change to behaviour

## Documentation

- [x] N/A — behaviour is self-documenting via deploy output; template comments cover the path change

Closes #352