### PR TITLE
fix: discard browser-extension errors in error-logger

### DIFF
--- a/backend/scripts/tests/test-error-logger-browser.js
+++ b/backend/scripts/tests/test-error-logger-browser.js
@@ -12,6 +12,7 @@
  * Contracts verified:
  *   1. Resource-load failures captured (#332) — capture-phase listener
  *   2. Runtime errors logged exactly once (no duplication from capture listener)
+ *   2b. Browser-extension errors filtered out, site errors still reported (#356)
  *   3. Reports buffered in localStorage when backend unreachable (#334)
  *   4. Buffer drained and emptied after backend returns (#334)
  *   5. No browser hang under error storm against failing backend (#331)
@@ -101,6 +102,32 @@ try {
   await sleep(600);
   const rt = captured.filter(r => r.type === 'uncaught-error');
   check('runtime error reported exactly once (no duplication)', rt.length === 1);
+
+  // ── Test 2b: browser-extension errors are filtered out ─────────────────────
+  // Extension content scripts run in the page context; their uncaught errors
+  // bubble to our handler with a chrome-/moz-/safari-extension:// filename.
+  // These must be dropped before reaching /debug/errors (#356). We dispatch a
+  // synthetic ErrorEvent (real extension throws can't be staged in Puppeteer),
+  // plus a control site error to prove genuine errors still get through.
+  console.log('\n📍 Test 2b — browser-extension errors filtered (#356)');
+  captured.length = 0;
+  await page.evaluate(() => {
+    window.dispatchEvent(new ErrorEvent('error', {
+      message: "Couldn't load fs",
+      filename: 'chrome-extension://abcdefghijklmnop/content.js',
+      lineno: 1, colno: 1,
+    }));
+    window.dispatchEvent(new ErrorEvent('error', {
+      message: 'genuine-site-error-356',
+      filename: window.location.href,
+      lineno: 2, colno: 3,
+    }));
+  });
+  await sleep(600);
+  const extReport  = captured.find(r => String(r.filename || '').startsWith('chrome-extension://'));
+  const siteReport = captured.find(r => String(r.message || '').includes('genuine-site-error-356'));
+  check('extension-origin error NOT reported', !extReport);
+  check('genuine site error still reported', !!siteReport);
 
   // ── Test 3: buffered when backend down ─────────────────────────────────────
   console.log('\n📍 Test 3 — reports buffered when backend unreachable (#334)');

--- a/resources/js/error-logger.js
+++ b/resources/js/error-logger.js
@@ -58,6 +58,18 @@ function withCorrelation(payload) {
   return { ...payload, sessionId: SESSION_ID, requestId: getRecentRequestId() };
 }
 
+// ── Extension-noise filter (#356) ──────────────────────────────────────────
+// Browser extension content scripts run in the page's window context, so their
+// uncaught errors (e.g. require('fs')/require('zlib') in Node-targeting
+// extensions) bubble to our handlers. They are not site errors — discard them
+// before they reach the dedup/send pipeline so they never pollute /debug/errors
+// or contribute to alert thresholds (#333).
+const EXTENSION_URL = /^(chrome|moz|safari)-extension:\/\//;
+
+function isExtensionUrl(url) {
+  return typeof url === 'string' && EXTENSION_URL.test(url);
+}
+
 // ── Dedup / buffer / send ──────────────────────────────────────────────────
 // Suppress duplicate reports within a page view.
 const seenErrors = new Set();
@@ -150,6 +162,8 @@ function dedupAndLog(key, payload) {
 
 // Uncaught runtime errors (bubble phase). event.target is window here.
 window.addEventListener('error', (event) => {
+  // Skip errors thrown by browser extension content scripts (#356).
+  if (isExtensionUrl(event.filename)) return;
   const key = `${event.filename}:${event.lineno}:${event.message}`;
   dedupAndLog(key, withCorrelation({
     type: 'uncaught-error',
@@ -171,7 +185,8 @@ window.addEventListener('error', (event) => {
   const target = event.target;
   if (!target || !(target instanceof HTMLElement)) return; // runtime errors handled above
   const resourceUrl = target.src || target.href;
-  if (!resourceUrl) return;
+  // Skip missing URLs and extension-injected resources (#356).
+  if (!resourceUrl || isExtensionUrl(resourceUrl)) return;
   const tag = target.tagName.toLowerCase();
   dedupAndLog(`resource:${tag}:${resourceUrl}`, withCorrelation({
     type: 'resource-error',


### PR DESCRIPTION
## Summary

Browser extension content scripts run in the page's `window` context, so their uncaught errors (e.g. `require('fs')`/`require('zlib')` thrown by Node-targeting extensions) bubble to our global error handlers and land in `/debug/errors` on every page view. These are not site errors — they're noise that would also make the #333 threshold alerting fire on the wrong signal.

This adds an extension-scheme guard at the source, discarding extension-origin reports before they enter the dedup/send pipeline, plus a Puppeteer contract test that proves it.

## Changes

`resources/js/error-logger.js`:
- New `EXTENSION_URL` regex (`chrome-/moz-/safari-extension://`) + `isExtensionUrl()` helper
- Uncaught-error handler: skip when `event.filename` is an extension URL
- Resource-load capture handler: skip when `resourceUrl` is an extension URL (folded into the existing falsy-URL guard)

`backend/scripts/tests/test-error-logger-browser.js` (post-deploy Puppeteer suite):
- New **Test 2b**: dispatches a synthetic `chrome-extension://` `ErrorEvent` and asserts it is NOT forwarded to `/debug/errors`, plus a control site error that must still be reported

## Test plan

```bash
# Post-deploy browser suite (runs automatically in deploy.sh, also runnable directly):
docker compose exec backend npm run test:error-logger:browser -- https://nginx:3001
# Expected: status=OK passed=10 failed=0, including:
#   📍 Test 2b — browser-extension errors filtered (#356)
#     ✅ extension-origin error NOT reported
#     ✅ genuine site error still reported

# Backend unit suite — no regression:
docker compose exec backend npm test
# Expected: 9 test files, 87 tests, all passing
```

**Regression-test integrity:** verified locally that Test 2b *fails* when the `#356` guard is removed and *passes* when restored — it exercises the real behaviour, not a tautology.

## Documentation checklist

- [x] Test contract list in the suite's header comment updated to include 2b
- [x] N/A — no operator/dev workflow, route, env var, or script-name changes

Closes #356

---

**Suggested squash commit message:**
```
fix: discard browser-extension errors in error-logger

Extension content scripts run in the page's window context, so their
uncaught errors (require('fs')/require('zlib') from Node-targeting
extensions) bubbled to our handlers and polluted /debug/errors. Add an
EXTENSION_URL guard (chrome-/moz-/safari-extension://) on both the
uncaught-error handler (event.filename) and the resource-load capture
handler (resourceUrl), dropping extension-origin reports before dedup/
send. Adds a Puppeteer contract (Test 2b) verifying extension errors are
filtered while genuine site errors still report.

Closes #356

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```