### PR TITLE
feat: redirect dev hostname on prod 443 to dev port 3001

### DIFF
--- a/docs/PROD_ENVIRONMENT.md
+++ b/docs/PROD_ENVIRONMENT.md
@@ -27,6 +27,16 @@ docker compose -f docker-compose.prod.yml <command>
 
 **SSL:** Let's Encrypt certs managed by certbot on the host; `/etc/letsencrypt` is bind-mounted into the nginx container read-only.
 
+**Dev-hostname redirect (#358):** the prod nginx template includes an extra
+`server` block for `dev.<domain>` on port 443 that issues a `301` to
+`https://dev.<domain>:3001`. The dev server only listens on `3001`; visiting
+the dev hostname without the port otherwise lands on prod nginx and silently
+runs prod code, which has repeatedly caused confusing test results. The block
+reuses the prod cert, so browsers show a one-time hostname-mismatch warning
+before the redirect fires. This block lives **only** in
+`nginx-portfolio.conf.template` — adding it to the dev/local templates (which
+already serve the dev hostname on `3001`) would create a redirect loop.
+
 ---
 
 ## Prod env vars and key files

--- a/scripts/config/nginx-portfolio.conf.template
+++ b/scripts/config/nginx-portfolio.conf.template
@@ -66,3 +66,26 @@ server {
         try_files $uri $uri/ $uri.html =404;
     }
 }
+
+# Redirect accidental prod-port hits on the dev hostname to the correct port.
+# Visiting https://dev.${DOMAIN} (omitting :3001) otherwise lands on prod nginx
+# and silently runs prod code — the cause of repeated test confusion (#358).
+#
+# PROD-ONLY: this block must never be added to nginx-dev-server.conf.template
+# or nginx-local.conf.template. The dev nginx already listens on 3001 and
+# serves dev.${DOMAIN} there; adding this redirect to it would loop forever.
+#
+# The prod cert is for ${DOMAIN}/www.${DOMAIN}, so browsers show a one-time
+# hostname-mismatch warning on the TLS handshake; the 301 fires before any
+# content is served, so the redirect still works once accepted.
+server {
+    listen 443 ssl;
+    server_name dev.${DOMAIN};
+
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://dev.${DOMAIN}:3001$request_uri;
+}


### PR DESCRIPTION
## Summary

Visiting `https://dev.andykeys.me` without `:3001` lands on the **prod** nginx and silently runs prod code. This has repeatedly caused confusing test sessions — wrong backend, CORS failures, results that look broken but are actually hitting prod.

This adds a prod-only `server` block for `dev.${DOMAIN}` on port 443 that `301`-redirects to `https://dev.${DOMAIN}:3001`, so accidental port-less hits land on the right server.

## ⚠️ Testability note

**The redirect itself cannot be verified on the dev server.** Prod nginx is the only process that owns port 443 on the shared host, so the new block only takes effect once this reaches **prod via a `dev → main` release**. The dev nginx never receives port-443 traffic, so there is nothing to curl against on dev. Behavioural verification is therefore **deferred to the post-release smoke test** (see below).

What *is* checkable before prod: config validity. The deploy's `nginx -t` step parses the rendered prod template, and the block was rendered + structurally reviewed locally (mirrors the existing HTTPS block's SSL setup exactly).

## Changes

`scripts/config/nginx-portfolio.conf.template`:
- New `server { listen 443 ssl; server_name dev.${DOMAIN}; ... return 301 https://dev.${DOMAIN}:3001$request_uri; }` block
- Reuses the prod Let's Encrypt cert (same paths as the main HTTPS block)

`docs/PROD_ENVIRONMENT.md`:
- Documents the redirect block, why it exists, the one-time cert-mismatch warning, and the prod-only constraint

## Design notes

- **Routing:** nginx selects the server block by SNI `server_name`, so `andykeys.me` still hits the main block and `dev.andykeys.me` hits the redirect block. No `default_server` change — unknown hostnames behave exactly as before.
- **Cert mismatch:** the prod cert covers `andykeys.me`/`www.andykeys.me`, not `dev.andykeys.me`, so browsers show a one-time TLS hostname-mismatch warning. The `301` fires before any content is served, so it still works once accepted. (Acceptable — the alternative is silently running prod code.)
- **Scope constraint:** the block exists **only** in `nginx-portfolio.conf.template`. Adding it to `nginx-dev-server.conf.template` or `nginx-local.conf.template` — which already serve the dev hostname on `3001` — would create a redirect loop. Confirmed both still have zero dev-redirect blocks.

## Test plan

### Pre-merge / pre-prod (what can be checked now)
```bash
# Config validity — the prod deploy runs `nginx -t` automatically. To verify
# the rendered prod template parses (run on the prod server after this lands
# on main, or any host with the nginx image):
docker compose -f ~/MyPortfolioSite/docker-compose.prod.yml exec nginx nginx -t
# Expected: "syntax is ok" / "test is successful"
```

### Post-release (the redirect behaviour — ONLY verifiable once on prod/main)
```bash
# 1. Redirect fires (from any machine that resolves dev.andykeys.me):
curl -sk -I https://dev.andykeys.me/some/path
# Expected: HTTP/1.1 301 ... ; Location: https://dev.andykeys.me:3001/some/path

# 2. Dev server unchanged — still serves on 3001:
curl -sk -I https://dev.andykeys.me:3001/api/health
# Expected: 200 (X-Request-Id header present)

# 3. Prod unaffected:
curl -sk -I https://andykeys.me/
# Expected: 200, prod content
```

## Documentation checklist

- [x] `docs/PROD_ENVIRONMENT.md` updated with the redirect block, rationale, and prod-only constraint
- [x] Scope constraint verified — dev/local templates contain no dev-redirect block (would loop)
- [x] Testability limitation documented — redirect behaviour is verifiable only post-release to prod
- [x] N/A — no new env vars (uses existing `${DOMAIN}`); dev port `3001` is the established dev constant

Closes #358

---

**Suggested squash commit message:**
```
feat: redirect dev hostname on prod 443 to dev port 3001

Visiting https://dev.andykeys.me without :3001 lands on prod nginx and
silently runs prod code — the cause of repeated test confusion. Add a
prod-only server block for dev.${DOMAIN}:443 that 301-redirects to
:3001, reusing the prod cert (one-time hostname-mismatch warning; the
redirect fires before content). Lives only in the prod template —
adding it to dev/local templates would loop. Documented in
PROD_ENVIRONMENT.md. Note: redirect behaviour is verifiable only after
release to prod, since prod nginx owns 443.

Closes #358

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```