### PR TITLE
fix: add startup env validation and CORS smoke test (#357)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -3,11 +3,11 @@ import { createApp } from './app.js';
 import { logger } from './utils/logger.js';
 import { pool } from './db/pool.js';
 import { isOAuth2Configured, getGraphAccessToken } from './utils/email.js';
+import { validateEnvOrExit } from './utils/validateEnv.js';
 
-if (!process.env.JWT_SECRET) {
-  logger.fatal('[startup] JWT_SECRET environment variable is not set — refusing to start');
-  process.exit(1);
-}
+// Fail fast if any required env var is missing/empty — catches vars defined in
+// .env but not bridged into the container's compose `environment` block (#357).
+validateEnvOrExit(logger);
 
 const app  = createApp();
 const PORT = process.env.PORT || 3001;

--- a/backend/tests/utils/validateEnv.test.js
+++ b/backend/tests/utils/validateEnv.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { findMissingEnv, validateEnvOrExit, REQUIRED_ENV } from '../../utils/validateEnv.js';
+
+// A fully-populated env to start from, so each test can knock out one var.
+function fullEnv() {
+  return Object.fromEntries(REQUIRED_ENV.map((k) => [k, 'value']));
+}
+
+describe('findMissingEnv', () => {
+  it('returns [] when every required var is present', () => {
+    expect(findMissingEnv(fullEnv())).toEqual([]);
+  });
+
+  it('flags an undefined var', () => {
+    const env = fullEnv();
+    delete env.SITE_HOST;
+    expect(findMissingEnv(env)).toEqual(['SITE_HOST']);
+  });
+
+  it('flags an empty-string var (the compose ${SITE_HOST:-} case)', () => {
+    const env = fullEnv();
+    env.SITE_HOST = '';
+    expect(findMissingEnv(env)).toEqual(['SITE_HOST']);
+  });
+
+  it('flags a whitespace-only var', () => {
+    const env = fullEnv();
+    env.JWT_SECRET = '   ';
+    expect(findMissingEnv(env)).toEqual(['JWT_SECRET']);
+  });
+
+  it('reports multiple missing vars', () => {
+    const env = fullEnv();
+    delete env.DB_PASSWORD;
+    delete env.ADMIN_EMAIL;
+    expect(findMissingEnv(env).sort()).toEqual(['ADMIN_EMAIL', 'DB_PASSWORD']);
+  });
+});
+
+describe('validateEnvOrExit', () => {
+  const fakeLogger = () => ({ fatal: vi.fn() });
+
+  it('does not exit when all vars are present', () => {
+    const logger = fakeLogger();
+    const exit = vi.fn();
+    validateEnvOrExit(logger, fullEnv(), exit);
+    expect(exit).not.toHaveBeenCalled();
+    expect(logger.fatal).not.toHaveBeenCalled();
+  });
+
+  it('logs each missing var and exits(1)', () => {
+    const logger = fakeLogger();
+    const exit = vi.fn();
+    const env = fullEnv();
+    delete env.SITE_HOST;
+    validateEnvOrExit(logger, env, exit);
+    expect(exit).toHaveBeenCalledWith(1);
+    // one per-var line + one summary line
+    expect(logger.fatal).toHaveBeenCalledWith(expect.stringContaining('SITE_HOST'));
+  });
+});

--- a/backend/utils/validateEnv.js
+++ b/backend/utils/validateEnv.js
@@ -1,0 +1,62 @@
+/**
+ * Startup environment validation (#357).
+ *
+ * The original incident: SITE_HOST was present in .env and validated host-side
+ * by validate_env() in deploy-lib.sh, but missing from the docker-compose.yml
+ * `environment` block — so it was undefined inside the container and the CORS
+ * check silently failed. Nothing in the pipeline caught the gap between
+ * "defined on host" and "actually bridged into the container".
+ *
+ * This closes that gap from the container's side: on startup the backend
+ * asserts every var it actually reads is present and non-empty, and fails loud
+ * (exit 1) rather than booting with broken config and serving traffic.
+ */
+
+// Vars the app genuinely reads at runtime. Keep in sync with usage in
+// app.js (CORS/FRONTEND_URL/SITE_HOST), db/pool.js (DB_*), auth.js
+// (JWT_SECRET, WEBAUTHN_*, ADMIN_EMAIL), and server.js (PORT).
+export const REQUIRED_ENV = [
+  'PORT',
+  'DB_HOST',
+  'DB_PORT',
+  'DB_NAME',
+  'DB_USER',
+  'DB_PASSWORD',
+  'JWT_SECRET',
+  'WEBAUTHN_RP_ID',
+  'WEBAUTHN_ORIGIN',
+  'FRONTEND_URL',
+  'SITE_HOST',
+  'ADMIN_EMAIL',
+];
+
+/**
+ * Return the list of required vars that are missing or empty in `env`.
+ * A var set to '' (e.g. compose `${SITE_HOST:-}` with nothing in .env) counts
+ * as missing — an empty value is exactly the silent-failure case we're guarding.
+ */
+export function findMissingEnv(env = process.env, required = REQUIRED_ENV) {
+  return required.filter((key) => {
+    const val = env[key];
+    return val === undefined || val === null || String(val).trim() === '';
+  });
+}
+
+/**
+ * Validate required env at startup. On any missing var, log each one via the
+ * provided logger and exit(1) so the deploy fails fast before serving traffic.
+ * Pure-ish: logger and exit are injected so it can be unit-tested.
+ */
+export function validateEnvOrExit(logger, env = process.env, exit = process.exit) {
+  const missing = findMissingEnv(env);
+  if (missing.length === 0) return;
+
+  for (const key of missing) {
+    logger.fatal(`[startup] Required env var ${key} is missing or empty`);
+  }
+  logger.fatal(
+    `[startup] ${missing.length} required env var(s) missing: ${missing.join(', ')} — refusing to start. ` +
+    'Check the service `environment:` block in docker-compose.yml bridges them from .env.',
+  );
+  exit(1);
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,8 +34,9 @@ This approach catches integration issues that unit tests cannot (database state,
 
 Dev and prod deploy scripts now run automated checks as part of every deployment to the server:
 
+- **Backend startup env validation** (#357) — on boot the backend asserts every required env var (`PORT`, `DB_*`, `JWT_SECRET`, `WEBAUTHN_*`, `FRONTEND_URL`, `SITE_HOST`, `ADMIN_EMAIL`) is present and non-empty via `validateEnvOrExit()` in `backend/utils/validateEnv.js`. A var defined in `.env` but not bridged into the compose `environment:` block resolves to empty in the container; the backend then logs each missing var and exits 1, so the deploy fails fast (and rolls back) instead of serving traffic with broken config. This closes the gap that let `SITE_HOST` reach the container undefined.
 - **Backend Vitest suite** runs inside the already-deployed container (`backend` on both dev and prod). If `npm test` fails in the container, the deploy script rolls back to a known-good state and marks the deploy as failed.
-- **HTTP regression smoke tests** run via `scripts/tests/test-regression.sh` against the live site (dev: `https://<SITE_HOST>:3001`, prod: `https://<SITE_HOST>`). These tests hit core public and auth-protected endpoints and will also fail the deploy if they do not pass.
+- **HTTP regression smoke tests** run via `scripts/tests/test-regression.sh` against the live site (dev: `https://<SITE_HOST>:3001`, prod: `https://<SITE_HOST>`). These tests hit core public and auth-protected endpoints and will also fail the deploy if they do not pass. This includes a **CORS origin check** (#357): a `POST /api/debug/errors` with `Origin: https://<SITE_HOST>` (port omitted, as browsers send it) must not be CORS-rejected — catching the case where `SITE_HOST` is missing/wrong in the container and every site-host origin returns 500.
 
 You can skip the regression smoke tests (for example, during quick iteration) by passing the `-SkipRegression` boolean parameter to the PowerShell wrappers (`$true`/`$false`, defaults to `$false`):
 

--- a/scripts/tests/test-regression.sh
+++ b/scripts/tests/test-regression.sh
@@ -208,6 +208,20 @@ check "POST /api/stats/visit?page=unknown returns 400" \
 check "Unknown route returns 404" \
   GET "$BASE_URL/api/does-not-exist" 404
 
+# CORS: a browser at the canonical site host omits the non-standard port from
+# the Origin header (e.g. https://dev.andykeys.me, not :3001). The backend must
+# allow it via its SITE_HOST check. This is the exact failure from #357 —
+# SITE_HOST was undefined in the container and every such origin was rejected
+# with a 500. Derive the host from BASE_URL and assert the POST is NOT rejected.
+CORS_HOST="${BASE_URL#*://}"   # strip scheme
+CORS_HOST="${CORS_HOST%%/*}"   # strip any path
+CORS_HOST="${CORS_HOST%%:*}"   # strip port → bare hostname
+check "POST /api/debug/errors with site-host Origin is not CORS-rejected" \
+  POST "$BASE_URL/api/debug/errors" 200 "received" \
+  -H "Origin: https://${CORS_HOST}" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"smoke-test","message":"cors check"}'
+
 say ""
 
 # ── Auth gating (protected routes must reject anonymous requests) ─────────────────


### PR DESCRIPTION
## Summary

`SITE_HOST` was present in `.env` and validated host-side by `validate_env()`, but missing from the `environment:` block in `docker-compose.yml` — so `process.env.SITE_HOST` was `undefined` inside the container and the CORS check silently rejected every non-localhost origin with a 500. Nothing in the deploy pipeline caught the gap between *defined on host* and *bridged into the container*.

This closes that class of bug with two independent layers.

## Changes

### 1. Backend startup validation — `backend/utils/validateEnv.js` (new)
- `findMissingEnv(env)` returns required vars that are missing **or empty** (an empty value is exactly the `${SITE_HOST:-}` compose case).
- `validateEnvOrExit(logger)` logs each missing var and `process.exit(1)` — so the deploy fails fast and rolls back rather than serving broken config.
- Wired into `server.js`, replacing the narrower inline `JWT_SECRET`-only check.
- Required set: `PORT, DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD, JWT_SECRET, WEBAUTHN_RP_ID, WEBAUTHN_ORIGIN, FRONTEND_URL, SITE_HOST, ADMIN_EMAIL` — all confirmed present in the compose `environment:` block, so the validator itself can't break a correct deploy.

### 2. CORS smoke test — `scripts/tests/test-regression.sh`
- New no-auth check: `POST /api/debug/errors` with `Origin: https://<site-host>` (port omitted, as browsers send it). Asserts `200 received` — a CORS rejection returns 500. The host is derived from `BASE_URL`, which the deploy already sets to the canonical `SITE_HOST`.

### 3. Docs — `docs/TESTING.md`
- Documents both checks under the "Automatic tests during deploy" section.

## Verification (done locally)

Ran the real backend with env set, confirming behaviour matches the test assertions:

| Scenario | Result |
|----------|--------|
| `Origin: https://dev.example.com` (matches `SITE_HOST`) | **200** ✅ |
| `Origin: https://evil.example.org` (disallowed) | **500** ✅ |
| `SITE_HOST=` (empty — the #357 case) | server **exits 1** with `FATAL [startup] Required env var SITE_HOST is missing or empty` ✅ |
| all vars present | server boots normally ✅ |

```bash
docker compose exec backend npm test
# Expected: 10 test files, 94 tests, all passing (includes 7 new validateEnv unit tests)
```

## Scope / honesty note

This fully prevents recurrence of the **host-defined-but-not-container-bridged** bug (two layers catch it). It does **not** auto-detect a brand-new `process.env.X` that's never wired up anywhere — `REQUIRED_ENV` is a hand-maintained list, and validation checks presence/non-empty, not value correctness (the CORS test covers value-correctness for `SITE_HOST` specifically). A fully-dynamic drift check (grep `process.env` usage vs `REQUIRED_ENV` vs compose block in CI) would be a separate, larger follow-up — happy to raise it if wanted.

## Documentation checklist

- [x] `docs/TESTING.md` updated with both the startup validation and CORS smoke-test checks
- [x] Unit tests added for `findMissingEnv` / `validateEnvOrExit`
- [x] Required-var list cross-checked against `docker-compose.yml` `environment:` block (no deploy-breaking entries)
- [x] N/A — no new env vars introduced; this validates existing ones

Closes #357

---

**Suggested squash commit message:**
```
fix: add startup env validation and CORS smoke test (#357)

SITE_HOST was in .env but missing from the compose environment block, so
it was undefined in the container and CORS silently 500'd every site-host
origin. Add validateEnvOrExit() (utils/validateEnv.js) asserting all
required vars are present + non-empty — empty counts as missing, backend
exits 1 so the deploy fails fast and rolls back. Add a regression CORS
check POSTing with Origin: https://<site-host> and asserting it isn't
rejected. Unit tests + TESTING.md included.

Closes #357

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FW7jvozMeS2YouBJmkyQM8)_