### PR TITLE
fix: normalise relative media URLs in travel card builders (#266 #267)

### DIFF
--- a/resources/js/utils/dom.js
+++ b/resources/js/utils/dom.js
@@ -85,11 +85,14 @@ export function buildPostCard(type, data) {
     tCard.attr('data-memory-id', data.id);
 
     var media = $('<div class="media"></div>');
-    if (data.mediaUrl) {
+    // Same root-relative guard as buildPublicTravelCard (#266).
+    var safeMediaUrl = (data.mediaUrl && !data.mediaUrl.startsWith('/') && !data.mediaUrl.startsWith('http'))
+        ? '/' + data.mediaUrl : data.mediaUrl;
+    if (safeMediaUrl) {
         if (data.mediaType && data.mediaType.indexOf('video') === 0) {
-            $('<video controls></video>').attr('src', data.mediaUrl).appendTo(media);
+            $('<video controls></video>').attr('src', safeMediaUrl).appendTo(media);
         } else {
-            var img = $('<img alt="Travel snapshot">').attr('src', data.mediaUrl);
+            var img = $('<img alt="Travel snapshot">').attr('src', safeMediaUrl);
             img.on('error', function () { $(this).attr('src', placeholder); });
             media.append(img);
         }
@@ -131,6 +134,12 @@ export function buildPublicTravelCard(travel, formatVisitDateFn) {
     var extraCount = allMedia ? allMedia.length - 1 : 0;
 
     var placeholder = '/resources/img/placeholder-transparent.png';
+    // Ensure media URLs from the API are root-relative. A bare relative path
+    // (e.g. "resources/img/...") would be resolved relative to the current page
+    // path ("/travel/") causing a 404 before the error-fallback fires (#266).
+    if (mediaUrl && !mediaUrl.startsWith('/') && !mediaUrl.startsWith('http')) {
+        mediaUrl = '/' + mediaUrl;
+    }
     if (mediaUrl) {
         var mediaWrap = $('<div class="media-thumb-wrap"></div>');
         if (mediaType && mediaType.indexOf('video') === 0) {


### PR DESCRIPTION
## Summary

Fixes the 404 for `/travel/resources/img/placeholder-transparent.png` that was being captured by error-logger and reported to `/api/debug/errors` on every travel page load.

## Root cause

A travel entry in the DB has a `media_url` stored as a bare relative path (e.g. `resources/img/placeholder-transparent.png` — no leading `/`). When `buildPublicTravelCard` sets ``&lt;img src="resources/img/..."&gt;`` on the `/travel/` page, the browser resolves it relative to the current path → requests `/travel/resources/img/placeholder-transparent.png` → 404. The error-fallback then correctly loads the absolute placeholder, but the 404 is already captured and POSTed by error-logger.

`buildPostCard` (admin travel cards) had the same latent bug.

## Changes

**`resources/js/utils/dom.js`**
- `buildPublicTravelCard`: normalise `mediaUrl` — if it doesn't start with `/` or `http`, prepend `/` so it always resolves from the origin root regardless of which page renders the card.
- `buildPostCard` (travel): same guard applied via `safeMediaUrl`.

Both functions already had an `onerror` fallback to the placeholder; this fix prevents the initial bad request from firing at all.

## Test plan

```bash
# 1. Deploy to dev and open /travel/ — confirm no 404 in DevTools Network tab
#    for placeholder-transparent.png

# 2. Confirm no new POST to /api/debug/errors on page load
#    (check DevTools Network tab — only the stats POST should appear)

# 3. If a travel entry with no media exists, confirm the placeholder
#    image loads correctly (200) at /resources/img/placeholder-transparent.png

# 4. Regression: existing travel entries with valid /uploads/... URLs
#    still load their images correctly
```

## Documentation checklist

- [x] N/A — frontend-only defensive fix, no API or operator behaviour change

Closes #266
Closes #267

---

**Suggested squash commit message:**
```
fix: normalise relative media URLs in travel card builders (#266 #267)

A travel entry with a bare relative media_url was resolved relative to
/travel/, causing a 404 for /travel/resources/img/... before the error
fallback fired — error-logger captured and reported each one. Prepend /
to any media URL that doesn't already start with / or http in both
buildPublicTravelCard and buildPostCard.

Closes #266 #267

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FW7jvozMeS2YouBJmkyQM8)_