### PR TITLE
Fix rate-limit reset and JWT generation in regression script (#387)

### DIFF
--- a/scripts/tests/test-regression.sh
+++ b/scripts/tests/test-regression.sh
@@ -74,8 +74,8 @@ fi
 # ── JWT auto-generation ──────────────────────────────────────────────────────────
 
 if [ -z "$TOKEN" ] && [ -n "$COMPOSE_FILE" ]; then
-  TOKEN=$(docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" node -e "
-    const jwt = require('jsonwebtoken');
+  TOKEN=$(docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" node --input-type=module -e "
+    import jwt from 'jsonwebtoken';
     if (!process.env.JWT_SECRET) { process.stderr.write('NO_SECRET\n'); process.exit(1); }
     console.log(jwt.sign({ userId: 'regression-test' }, process.env.JWT_SECRET, { expiresIn: '1h' }));
   " 2>/dev/null | grep '^eyJ' | tail -1 || true)
@@ -99,7 +99,7 @@ TMPERR=$(mktemp)
 reset_rate_limits() {
   [ "$RESET_RL" = "1" ] || return 0
   [ -n "$COMPOSE_FILE" ] || return 0
-  if docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" node -e "
+  if docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" node --input-type=module -e "
     import('./db/pool.js')
       .then(async ({ pool }) => { await pool.query('DELETE FROM rate_limits'); await pool.end(); })
       .then(() => process.exit(0))


### PR DESCRIPTION
## Summary

Both `node -e` inline scripts in `test-regression.sh` were missing `--input-type=module`. The backend has `"type": "module"` in `package.json`, so inline scripts without this flag run as CommonJS and silently fail when they use `import()` or ES module `import` syntax. Output was suppressed by `>/dev/null 2>&1`, so the failure was invisible.

**Effect:** Rate-limit counters were never cleared after the smoke suite, leaving the admin IP locked out of `/auth/email/send` (and other rate-limited routes) for the rest of the hour after every dev deploy.

## Root cause

```bash
# Before — runs as CJS, import() fails silently
node -e "import('./db/pool.js').then(...)"

# After — explicitly ESM
node --input-type=module -e "import('./db/pool.js').then(...)"
```

Same issue affected the JWT generation script which used `require('jsonwebtoken')` — switched to `import jwt from 'jsonwebtoken'`.

## Changes

- `scripts/tests/test-regression.sh`: add `--input-type=module` to both `node -e` calls; convert JWT generation from `require()` to ESM `import`

## Test plan

```bash
# 1. On the dev server, run a deploy and check rate_limits is cleared afterwards
docker compose exec postgres psql -U $(grep ^DB_USER .env | cut -d= -f2) \
  -d $(grep ^DB_NAME .env | cut -d= -f2) \
  -c "SELECT ip, count FROM rate_limits;"
# Expected: 0 rows (table cleared by EXIT trap after regression suite)
```

```bash
# 2. Confirm magic link works immediately after deploy without manual DB clear
# Visit https://dev.andykeys.me:3001/login/ and request a magic link
# Expected: email received, no 429
```

```bash
# 3. Confirm regression suite still passes (auth tests now actually run)
bash scripts/tests/test-regression.sh \
  --base-url https://dev.andykeys.me:3001 \
  --resolve dev.andykeys.me:3001:$(hostname -I | awk '{print $1}') \
  --compose-file docker-compose.yml \
  --service backend \
  --insecure \
  --reset-rate-limits
# Expected: all checks pass, "Rate-limit counters reset (dev)" shown twice
```

## Documentation

- N/A: script-internal fix, no operator workflow change

Fixes #387.

https://claude.ai/code/session_01FW7jvozMeS2YouBJmkyQM8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FW7jvozMeS2YouBJmkyQM8)_