### PR TITLE
fix: cache-bust JS after deploy; protect dev certs and backup dir (#391, #346)

### DIFF
--- a/.env.dev-server.example
+++ b/.env.dev-server.example
@@ -39,7 +39,7 @@ UPLOADS_VOLUME_NAME=
 # ── Deploy ───────────────────────────────────────────────────────────────────
 CERT_MODE=self-signed
 ROLLBACK_BRANCH=dev
-BACKUP_DIR=~/backups/dev
+BACKUP_DIR=~/backups/dev       # ~/... is expanded to $HOME by deploy-lib.sh; absolute paths also work
 
 # ── Database ─────────────────────────────────────────────────────────────────
 DB_NAME=portfolio_dev

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __MACOSX/
 uploads/*
 !uploads/.gitkeep
 test-results/
+backend/coverage/
+scripts/config/certs/
+.env.bak-*
+/~/

--- a/docs/UNTRACKED_FILES.md
+++ b/docs/UNTRACKED_FILES.md
@@ -159,17 +159,20 @@ docker compose -f docker-compose.dev-server.yml up -d --build
 - `uploads/` (user data)
 
 **Always use .gitignore:**
-These are already in `.gitignore`:
+These are in `.gitignore`:
 ```
 .env
-.env.local
 scripts/config/certs/
 uploads/
 node_modules/
 .DS_Store
+.env.bak-*          # deploy script .env backups
+backend/coverage/   # vitest coverage output
 ```
 
 Verify with: `git check-ignore .env`
+
+**Note on `BACKUP_DIR=~/backups/dev` in `.env`:** The deploy script reads `.env` verbatim (not via `source`), so `~` is expanded to `$HOME` by deploy-lib.sh itself. If a `~/` directory ever appears inside the repo root, it means a deploy ran before this expansion fix was in place — move any backups to `$HOME/backups/dev/` and delete the directory.
 
 ## Reference: How Variables Flow
 

--- a/scripts/config/nginx-dev-server.conf.template
+++ b/scripts/config/nginx-dev-server.conf.template
@@ -59,6 +59,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # JS modules: revalidate on every request to prevent stale-module bugs after deploy
+    location ~* \.js$ {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+
     # Static files
     location / {
         try_files $uri $uri/ $uri.html =404;

--- a/scripts/config/nginx-local.conf.template
+++ b/scripts/config/nginx-local.conf.template
@@ -41,6 +41,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # JS modules: revalidate on every request to prevent stale-module bugs after deploy
+    location ~* \.js$ {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+
     # Static files
     location / {
         try_files $uri $uri/ $uri.html =404;

--- a/scripts/config/nginx-portfolio.conf.template
+++ b/scripts/config/nginx-portfolio.conf.template
@@ -61,6 +61,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # JS modules: revalidate on every request to prevent stale-module bugs after deploy
+    location ~* \.js$ {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+
     # Static files
     location / {
         try_files $uri $uri/ $uri.html =404;

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -387,6 +387,10 @@ load_env() {
       if [[ "$value" =~ ^\"(.*)\"$ ]] || [[ "$value" =~ ^\'(.*)\'$ ]]; then
         value="${BASH_REMATCH[1]}"
       fi
+      # Expand a leading ~/ to $HOME/ for path variables. Pure substitution —
+      # does not execute bash code, so complex passwords with ~ in other positions
+      # are unaffected.
+      [[ "$value" == "~/"* ]] && value="$HOME/${value:2}"
       export "$key=$value"
     fi
   done < "$ENV_FILE"


### PR DESCRIPTION
## Summary

Fixes two deploy-hygiene bugs: stale JS modules served after deploys (#391), and dev certs being regenerated on every branch-switching deploy (#346). Also fixes a BACKUP_DIR tilde-expansion bug that was creating a literal `~/` directory inside the repo root, and hardens the `.gitignore` against future untracked-file surprises.

Closes #391, Closes #346

## Changes

- **`scripts/config/nginx-*.conf.template` (all 3)** — Add `location ~* \.js$` block with `Cache-Control: no-cache` before the generic `location /`. Forces browsers to revalidate JS on every load; unchanged files return 304 (cheap). Eliminates the stale-module class of bugs.
- **`.gitignore`** — Add `scripts/config/certs/` (dev cert files), `backend/coverage/` (vitest output), `.env.bak-*` (deploy script .env backups), `/~/` (safety net for tilde-expansion bug described below).
- **`scripts/deploy/deploy-lib.sh` (`load_env`)** — Expand a leading `~/` to `$HOME/` after reading values verbatim from `.env`. `load_env` intentionally avoids `source` to handle complex passwords safely; this adds only pure string substitution for path variables, so passwords with `~` in other positions are unaffected.
- **`.env.dev-server.example`** — Add inline comment noting that `~/…` is expanded by deploy-lib.sh.
- **`docs/UNTRACKED_FILES.md`** — Correct the stale claim that `scripts/config/certs/` was already gitignored, document the new entries, and add a note about the tilde-expansion issue.

## Test Plan

### Happy path

1. Deploy to dev server via `.\scripts\deploy\dev-deploy.ps1`
2. Load https://dev.andykeys.me:3001/blog/ in a browser with DevTools → Network tab open
3. Confirm JS files (`blog.js`, `nav.js`, etc.) show `Cache-Control: no-cache` in response headers
4. Hard-reload — confirm subsequent requests return HTTP 304 for JS files (not 200 with stale content)
5. Run the deploy a **second time** on the same branch; confirm the cert-check step logs `SSL certificates present and cover dev.andykeys.me — skipping regeneration` instead of the `Dev certificates missing` warning

### Edge cases

- [x] First deploy on a fresh clone — certs don't exist yet, so generation still runs once (expected)
- [x] Deploy after a branch switch — `git clean -fd` runs, but cert files are now gitignored so they survive
- [x] `BACKUP_DIR=~/backups/dev` — with the `load_env` fix, the backup dir resolves to `$HOME/backups/dev`, not a `~/` directory inside the repo

### Regression checks

- [ ] Blog page loads without JS errors
- [ ] Travel page loads without JS errors (map, lightbox)
- [ ] Admin panel loads and CRUD operations work (posts, travel)
- [ ] Uploads location (`/uploads/`) still serves with `public, immutable` (the new JS location block must not interfere)

### Setup required before testing

- None — changes take effect on next deploy

## Smoke Test

- [x] N/A — no backend route changes in this PR (nginx config + deploy script + gitignore only)

## Documentation

- [x] `docs/CHANGELOG.md` — N/A (entry added at release time)
- [x] Behaviour docs — N/A
- [x] Ops docs — `docs/UNTRACKED_FILES.md` updated
- [x] CSP allowlist — N/A (no external resources added)

## Risk / Impact

- **#391 (JS caching):** Low risk. `no-cache` only triggers revalidation; 304 responses are cheap. The `~* \.js$` location is added *before* the fallback `location /`, so nginx routing precedence is unchanged. The `uploads/` location (which uses `immutable`) is a separate exact-prefix match and is unaffected.
- **#346 (certs gitignore):** Zero risk. Adding to `.gitignore` is purely additive; it only prevents files from being tracked. Existing certs on disk persist; git history is unchanged.
- **BACKUP_DIR tilde expansion:** Low risk. The `load_env` change is a pure string prefix substitution applied only to values starting with `~/`. Values that don't start with `~/` (all other vars including passwords) are completely unaffected.

## Squash Commit Message

```text
fix: cache-bust JS after deploy; protect dev certs

Three deploy-hygiene fixes: (1) add Cache-Control: no-cache
for *.js in all nginx templates so browsers revalidate JS
after each deploy, eliminating stale-module bugs like #391;
(2) gitignore scripts/config/certs/ so git clean -fd during
branch switches no longer deletes dev certs, fixing repeated
regeneration (#346); (3) expand leading ~/ to $HOME/ in
load_env so BACKUP_DIR=~/backups/dev resolves correctly
instead of creating a literal ~/backups/ inside the repo.
Also adds backend/coverage/ and .env.bak-* to gitignore.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

**Why `no-cache` and not `must-revalidate`?** `no-cache` means "always revalidate before serving from cache" — the browser still caches and sends conditional requests (If-None-Match / ETag). `must-revalidate` only enforces revalidation after the `max-age` expires; without an explicit `max-age`, browsers apply a heuristic TTL (often hours). `no-cache` is the right choice here.

**Cert commit on `release/2026-05-27-clean`:** During this investigation, `dev-server.key` was found committed on the `origin/release/2026-05-27-clean` branch (commit `2392288`). That branch was a draft release superseded by `release/2026-05-27-v2`; the key is NOT in `main` or `dev` ancestry. Recommend deleting `release/2026-05-27-clean` from GitHub to remove the reference and rotate the dev cert (generate fresh via `bash scripts/setup/generate-dev-certs.sh`).