### PR TITLE
feat: puppeteer JS runtime check for all public pages (#390)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "test:error-logger:browser": "node ./scripts/tests/test-error-logger-browser.js",
     "test:csp-violations": "node ./scripts/tests/test-csp-violations.js",
     "test:admin-e2e": "node ./scripts/tests/test-admin-e2e.js",
-    "test:admin-e2e-csp": "node ./scripts/tests/test-admin-e2e-csp.js"
+    "test:admin-e2e-csp": "node ./scripts/tests/test-admin-e2e-csp.js",
+    "test:public-pages": "node ./scripts/tests/test-public-pages.js"
   },
   "dependencies": {
     "@simplewebauthn/server": "^7.4.0",

--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -152,10 +152,14 @@ try {
     req.continue();
   });
 
-  // Collect console errors from the page for smoke checks.
+  // Collect console errors and unhandled JS exceptions for smoke checks (#397).
   const consoleErrors = [];
+  const pageErrors = [];
   page.on('console', msg => {
     if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', err => {
+    if (!err.message.includes('-extension://')) pageErrors.push(err.message);
   });
 
   // Auto-accept all confirm() dialogs (delete confirmations, etc.).
@@ -184,6 +188,10 @@ try {
   // Filter known noise (zlib warning from exifr is cosmetic and not a code error)
   const realErrors = consoleErrors.filter(e => !e.includes('zlib'));
   smoke('No JS console errors on page load', realErrors.length === 0, realErrors.join('; '));
+
+  // S2b: no unhandled JS exceptions on load (#397)
+  smoke('No unhandled JS exceptions on page load', pageErrors.length === 0, pageErrors.join('; '));
+  const pageErrorsAtLoad = pageErrors.length; // snapshot — S-final only reports new errors from interactions
 
   // S3–S8: each section present in DOM
   const sections = [
@@ -329,6 +337,15 @@ try {
   } catch (e) {
     interact('Deploy fetch — output appeared', false, e.message);
   }
+
+  // S-final: no unhandled JS exceptions fired during interactions (#397)
+  // Uses pageErrorsAtLoad snapshot so errors already reported in S2b aren't double-counted.
+  const interactionPageErrors = pageErrors.slice(pageErrorsAtLoad);
+  smoke(
+    'No unhandled JS exceptions during interactions',
+    interactionPageErrors.length === 0,
+    interactionPageErrors.join('; '),
+  );
 
 } catch (err) {
   console.error('\n💥 Test runner crashed:', err.message);

--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -352,41 +352,44 @@ try {
   failures.push('runner crash: ' + err.message);
 } finally {
   // ── Cleanup: delete any [E2E] test data the tests didn't clean up ─────────
-  // Uses the API directly with the test token — no browser page needed.
-  // Best-effort: failures here don't affect the test result.
-  try {
-    const headers = { Authorization: `Bearer ${testToken}`, 'Content-Type': 'application/json' };
-    const https = await import('https');
-    const agent = new https.Agent({ rejectUnauthorized: false });
-
-    const checkAndDelete = async (listUrl, deleteBase) => {
-      try {
-        const { default: fetch } = await import('node-fetch').catch(() => ({ default: null }));
-        if (!fetch) return; // node-fetch not available — skip best-effort cleanup
-        const r = await fetch(listUrl, { headers, agent });
-        if (!r.ok) return;
-        const items = await r.json();
-        for (const item of items) {
-          if (item.title?.startsWith(TEST_PREFIX)) {
-            await fetch(`${deleteBase}/${item.id}`, { method: 'DELETE', headers, agent });
-            console.log(`  cleaned up: ${item.title}`);
-          }
-        }
-      } catch { /* best effort */ }
-    };
-
-    await checkAndDelete(`${baseUrl}/api/posts/all`, `${baseUrl}/api/posts`);
-    await checkAndDelete(`${baseUrl}/api/travel/all`, `${baseUrl}/api/travel`);
-  } catch { /* best effort */ }
-
+  // Uses the browser page (still open) to make authenticated API calls so the
+  // browser's --ignore-certificate-errors covers the self-signed dev cert —
+  // no rejectUnauthorized bypass in Node code. Best-effort: failures here
+  // don't affect the test result.
   if (browser) {
     try {
+      const cleanupPage = await browser.newPage();
+      const authHeaders = { Authorization: `Bearer ${testToken}`, 'Content-Type': 'application/json' };
+
+      const checkAndDelete = async (listUrl, deleteBase) => {
+        try {
+          const items = await cleanupPage.evaluate(async (url, headers) => {
+            try {
+              const r = await fetch(url, { headers });
+              return r.ok ? r.json() : [];
+            } catch { return []; }
+          }, listUrl, authHeaders);
+          for (const item of (items || [])) {
+            if (item.title?.startsWith(TEST_PREFIX)) {
+              await cleanupPage.evaluate(async (url, headers) => {
+                try { await fetch(url, { method: 'DELETE', headers }); } catch {}
+              }, `${deleteBase}/${item.id}`, authHeaders);
+              console.log(`  cleaned up: ${item.title}`);
+            }
+          }
+        } catch { /* best effort */ }
+      };
+
+      await checkAndDelete(`${baseUrl}/api/posts/all`, `${baseUrl}/api/posts`);
+      await checkAndDelete(`${baseUrl}/api/travel/all`, `${baseUrl}/api/travel`);
+
       const pages = await browser.pages();
       for (const p of pages) {
         await p.evaluate(() => {
           try { localStorage.removeItem('adminToken'); } catch {}
         }).catch(() => {});
       }
+      await cleanupPage.close();
     } catch {}
     await browser.close();
   }

--- a/backend/scripts/tests/test-public-pages.js
+++ b/backend/scripts/tests/test-public-pages.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Load each public page in a real browser and fail if any unhandled JS
+ * exceptions occur. Catches the class of errors (null dereferences, failed
+ * imports) that curl-based smoke tests cannot see.
+ *
+ * Discovered during #389 (jQuery removal): blog and travel pages had JS errors
+ * that the HTTP smoke suite did not flag. Only visible once a browser ran the
+ * page JS.
+ *
+ * Usage: node test-public-pages.js <base-url>
+ * Example: node test-public-pages.js https://nginx:3001
+ *
+ * Exits 0 if all pages load without unhandled JS errors.
+ * Exits 1 if any page throws an unhandled exception.
+ *
+ * IMPORTANT: intercepts POST /api/debug/errors so headless-Chromium internal
+ * noise ("Couldn't load fs/zlib" etc.) does not write to the live client_errors
+ * table and trigger false alert emails.
+ */
+
+import puppeteer from 'puppeteer';
+
+const baseUrl = process.argv[2];
+if (!baseUrl) {
+  console.error('Usage: node test-public-pages.js <base-url>');
+  process.exit(1);
+}
+
+const PAGES = ['/', '/blog/', '/travel/', '/login/'];
+
+let browser;
+const results = { passed: [], failed: [] };
+
+async function testPage(page, path) {
+  const url = `${baseUrl}${path}`;
+  const pageErrors = [];
+
+  await page.setRequestInterception(true);
+  page.on('request', (req) => {
+    if (req.method() === 'POST' && req.url().includes('/api/debug/errors')) {
+      req.respond({ status: 200, contentType: 'application/json', body: '{"received":true}' });
+      return;
+    }
+    req.continue();
+  });
+
+  page.on('pageerror', (err) => {
+    if (!err.message.includes('-extension://')) {
+      pageErrors.push(err.message);
+    }
+  });
+
+  let response;
+  try {
+    response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
+  } catch (err) {
+    results.failed.push(`${path} — navigation failed: ${err.message}`);
+    console.log(`  ❌ ${path} — navigation failed: ${err.message}`);
+    return;
+  }
+
+  const status = response ? response.status() : 0;
+  // 401 is expected for pages that redirect unauthenticated users — still load the page JS
+  if (!response || (status >= 400 && status !== 401)) {
+    results.failed.push(`${path} — HTTP ${status}`);
+    console.log(`  ❌ ${path} — HTTP ${status}`);
+    return;
+  }
+
+  // Allow deferred module imports and inline scripts to finish executing
+  await new Promise((r) => setTimeout(r, 1500));
+
+  if (pageErrors.length === 0) {
+    results.passed.push(path);
+    console.log(`  ✅ ${path}`);
+  } else {
+    results.failed.push(`${path} — ${pageErrors.length} JS error(s): ${pageErrors[0]}`);
+    console.log(`  ❌ ${path} — ${pageErrors.length} unhandled JS error(s):`);
+    pageErrors.forEach((e) => console.log(`     • ${e}`));
+  }
+}
+
+async function run() {
+  console.log(`\n🧪 Public Pages — JS Runtime Error Check`);
+  console.log(`📍 Base URL: ${baseUrl}\n`);
+
+  try {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--ignore-certificate-errors',
+      ],
+    });
+
+    for (const path of PAGES) {
+      const page = await browser.newPage();
+      await testPage(page, path);
+      await page.close();
+    }
+  } catch (err) {
+    results.failed.push(`Test runner crashed: ${err.message}`);
+    console.error(`\n❌ Test runner crashed: ${err.message}`);
+  } finally {
+    if (browser) await browser.close();
+
+    const total = PAGES.length;
+    console.log(`\n${'='.repeat(50)}`);
+    console.log(`✅ Passed: ${results.passed.length} / ${total}`);
+    if (results.failed.length) {
+      console.log(`❌ Failed: ${results.failed.length}`);
+      results.failed.forEach((r) => console.log(`   • ${r}`));
+    }
+    console.log(`${'='.repeat(50)}`);
+    const status = results.failed.length > 0 ? 'FAIL' : 'OK';
+    console.log(
+      `[public-pages] status=${status} passed=${results.passed.length} ` +
+        `failed=${results.failed.length} total=${total}\n`,
+    );
+    process.exit(results.failed.length > 0 ? 1 : 0);
+  }
+}
+
+run().catch((err) => {
+  console.error('Unhandled error:', err);
+  process.exit(1);
+});

--- a/backend/scripts/tests/test-public-pages.js
+++ b/backend/scripts/tests/test-public-pages.js
@@ -19,7 +19,6 @@
  * table and trigger false alert emails.
  */
 
-import https from 'https';
 import puppeteer from 'puppeteer';
 
 const baseUrl = process.argv[2];
@@ -34,24 +33,25 @@ const STATIC_PAGES = ['/', '/blog/', '/travel/', '/login/', '/setup/'];
 // ── Dynamic slug discovery ────────────────────────────────────────────────────
 
 // Fetch the first item from an API endpoint and return the value of `field`.
-// Uses rejectUnauthorized:false so the self-signed dev cert is accepted.
+// Uses a puppeteer page so the browser's --ignore-certificate-errors flag
+// handles the self-signed dev cert — no Node-level TLS bypass needed.
 // Returns null if the request fails or no item is found.
-function fetchFirstField(apiPath, field) {
-  return new Promise((resolve) => {
-    const url = `${baseUrl}${apiPath}`;
-    const agent = new https.Agent({ rejectUnauthorized: false });
-    https.get(url, { agent, headers: { Accept: 'application/json' } }, (res) => {
-      let data = '';
-      res.on('data', (c) => { data += c; });
-      res.on('end', () => {
-        try {
-          const items = JSON.parse(data);
-          const found = Array.isArray(items) ? items.find((i) => i[field]) : null;
-          resolve(found ? found[field] : null);
-        } catch { resolve(null); }
-      });
-    }).on('error', () => resolve(null));
-  });
+async function fetchFirstField(browser, apiPath, field) {
+  const page = await browser.newPage();
+  try {
+    const items = await page.evaluate(async (url) => {
+      try {
+        const res = await fetch(url);
+        return res.ok ? res.json() : null;
+      } catch { return null; }
+    }, `${baseUrl}${apiPath}`);
+    const found = Array.isArray(items) ? items.find((i) => i[field]) : null;
+    return found ? found[field] : null;
+  } catch {
+    return null;
+  } finally {
+    await page.close();
+  }
 }
 
 // ── Test runner ───────────────────────────────────────────────────────────────
@@ -112,30 +112,6 @@ async function run() {
   console.log(`\n🧪 Public Pages — JS Runtime Error Check`);
   console.log(`📍 Base URL: ${baseUrl}\n`);
 
-  // Discover live content slugs/ids so post pages are exercised too (#397).
-  const [blogSlug, travelId] = await Promise.all([
-    fetchFirstField('/api/posts', 'slug'),
-    fetchFirstField('/api/travel', 'id'),
-  ]);
-
-  const pages = [...STATIC_PAGES];
-
-  if (blogSlug) {
-    pages.push(`/blog/post/?slug=${encodeURIComponent(blogSlug)}`);
-    console.log(`  ℹ️  blog post discovered: /blog/post/?slug=${blogSlug}`);
-  } else {
-    console.log('  ⚠️  no published blog post found — /blog/post/ skipped');
-  }
-
-  if (travelId) {
-    pages.push(`/travel/post/?id=${encodeURIComponent(travelId)}`);
-    console.log(`  ℹ️  travel post discovered: /travel/post/?id=${travelId}`);
-  } else {
-    console.log('  ⚠️  no travel memory found — /travel/post/ skipped');
-  }
-
-  console.log('');
-
   try {
     browser = await puppeteer.launch({
       headless: 'new',
@@ -146,6 +122,32 @@ async function run() {
         '--ignore-certificate-errors',
       ],
     });
+
+    // Discover live content slugs/ids so post pages are exercised too (#397).
+    // Done via a browser page so --ignore-certificate-errors covers the self-signed
+    // dev cert — no rejectUnauthorized bypass in Node code.
+    const [blogSlug, travelId] = await Promise.all([
+      fetchFirstField(browser, '/api/posts', 'slug'),
+      fetchFirstField(browser, '/api/travel', 'id'),
+    ]);
+
+    const pages = [...STATIC_PAGES];
+
+    if (blogSlug) {
+      pages.push(`/blog/post/?slug=${encodeURIComponent(blogSlug)}`);
+      console.log(`  ℹ️  blog post discovered: /blog/post/?slug=${blogSlug}`);
+    } else {
+      console.log('  ⚠️  no published blog post found — /blog/post/ skipped');
+    }
+
+    if (travelId) {
+      pages.push(`/travel/post/?id=${encodeURIComponent(travelId)}`);
+      console.log(`  ℹ️  travel post discovered: /travel/post/?id=${travelId}`);
+    } else {
+      console.log('  ⚠️  no travel memory found — /travel/post/ skipped');
+    }
+
+    console.log('');
 
     for (const path of pages) {
       const page = await browser.newPage();
@@ -158,7 +160,7 @@ async function run() {
   } finally {
     if (browser) await browser.close();
 
-    const total = pages.length;
+    const total = results.passed.length + results.failed.length;
     console.log(`\n${'='.repeat(50)}`);
     console.log(`✅ Passed: ${results.passed.length} / ${total}`);
     if (results.failed.length) {

--- a/backend/scripts/tests/test-public-pages.js
+++ b/backend/scripts/tests/test-public-pages.js
@@ -19,6 +19,7 @@
  * table and trigger false alert emails.
  */
 
+import https from 'https';
 import puppeteer from 'puppeteer';
 
 const baseUrl = process.argv[2];
@@ -27,7 +28,33 @@ if (!baseUrl) {
   process.exit(1);
 }
 
-const PAGES = ['/', '/blog/', '/travel/', '/login/'];
+// Static pages always included — individual content pages added dynamically below.
+const STATIC_PAGES = ['/', '/blog/', '/travel/', '/login/', '/setup/'];
+
+// ── Dynamic slug discovery ────────────────────────────────────────────────────
+
+// Fetch the first item from an API endpoint and return the value of `field`.
+// Uses rejectUnauthorized:false so the self-signed dev cert is accepted.
+// Returns null if the request fails or no item is found.
+function fetchFirstField(apiPath, field) {
+  return new Promise((resolve) => {
+    const url = `${baseUrl}${apiPath}`;
+    const agent = new https.Agent({ rejectUnauthorized: false });
+    https.get(url, { agent, headers: { Accept: 'application/json' } }, (res) => {
+      let data = '';
+      res.on('data', (c) => { data += c; });
+      res.on('end', () => {
+        try {
+          const items = JSON.parse(data);
+          const found = Array.isArray(items) ? items.find((i) => i[field]) : null;
+          resolve(found ? found[field] : null);
+        } catch { resolve(null); }
+      });
+    }).on('error', () => resolve(null));
+  });
+}
+
+// ── Test runner ───────────────────────────────────────────────────────────────
 
 let browser;
 const results = { passed: [], failed: [] };
@@ -85,6 +112,30 @@ async function run() {
   console.log(`\n🧪 Public Pages — JS Runtime Error Check`);
   console.log(`📍 Base URL: ${baseUrl}\n`);
 
+  // Discover live content slugs/ids so post pages are exercised too (#397).
+  const [blogSlug, travelId] = await Promise.all([
+    fetchFirstField('/api/posts', 'slug'),
+    fetchFirstField('/api/travel', 'id'),
+  ]);
+
+  const pages = [...STATIC_PAGES];
+
+  if (blogSlug) {
+    pages.push(`/blog/post/?slug=${encodeURIComponent(blogSlug)}`);
+    console.log(`  ℹ️  blog post discovered: /blog/post/?slug=${blogSlug}`);
+  } else {
+    console.log('  ⚠️  no published blog post found — /blog/post/ skipped');
+  }
+
+  if (travelId) {
+    pages.push(`/travel/post/?id=${encodeURIComponent(travelId)}`);
+    console.log(`  ℹ️  travel post discovered: /travel/post/?id=${travelId}`);
+  } else {
+    console.log('  ⚠️  no travel memory found — /travel/post/ skipped');
+  }
+
+  console.log('');
+
   try {
     browser = await puppeteer.launch({
       headless: 'new',
@@ -96,7 +147,7 @@ async function run() {
       ],
     });
 
-    for (const path of PAGES) {
+    for (const path of pages) {
       const page = await browser.newPage();
       await testPage(page, path);
       await page.close();
@@ -107,7 +158,7 @@ async function run() {
   } finally {
     if (browser) await browser.close();
 
-    const total = PAGES.length;
+    const total = pages.length;
     console.log(`\n${'='.repeat(50)}`);
     console.log(`✅ Passed: ${results.passed.length} / ${total}`);
     if (results.failed.length) {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -103,8 +103,9 @@ Puppeteer scripts run automatically inside the backend container after every dev
 | `test-csp-violations.js` | `test:csp-violations` | No first-party CSP violations on any page — catches missing allowlist entries (#341) |
 | `test-admin-e2e-csp.js` | `test:admin-e2e-csp` | Authenticated admin interactions (Nominatim geocoding etc.) produce no CSP violations (#342) |
 | `test-admin-e2e.js` | `test:admin-e2e` | Full admin CRUD E2E — blog create/delete, travel create/delete, deploy panel smoke (#175) |
+| `test-public-pages.js` | `test:public-pages` | All public pages load without unhandled JS exceptions (`/`, `/blog/`, `/travel/`, `/login/`) — catches null dereferences and import failures invisible to curl-based checks (#390) |
 
-> **Important:** every script that loads live pages (`test-error-logger-all-pages.js`, `test-csp-violations.js`, `test-admin-e2e-csp.js`, `test-admin-e2e.js`) intercepts and mocks `POST /api/debug/errors` responses. Headless Chromium generates internal noise errors (e.g. "Couldn't load fs/zlib") that `error-logger.js` would otherwise capture and POST as real entries, polluting the `client_errors` table and triggering false alert emails. Any new Puppeteer script that loads pages must do the same — add `page.setRequestInterception(true)` and mock the endpoint before calling `page.goto()`.
+> **Important:** every script that loads live pages (`test-error-logger-all-pages.js`, `test-csp-violations.js`, `test-admin-e2e-csp.js`, `test-admin-e2e.js`, `test-public-pages.js`) intercepts and mocks `POST /api/debug/errors` responses. Headless Chromium generates internal noise errors (e.g. "Couldn't load fs/zlib") that `error-logger.js` would otherwise capture and POST as real entries, polluting the `client_errors` table and triggering false alert emails. Any new Puppeteer script that loads pages must do the same — add `page.setRequestInterception(true)` and mock the endpoint before calling `page.goto()`.
 
 ### Contract test (`test-error-logger-browser.js`)
 
@@ -472,7 +473,7 @@ Mounts each router against the full Express app via Supertest with the `pg` pool
 | Email delivery (nodemailer) | Requires real SMTP credentials; nodemailer is mocked — the send path is covered by the contact route tests |
 | Contact form in local dev | When `SMTP_HOST`/`SMTP_USER`/`SMTP_PASS` are not set, the route logs the submission to the backend console and returns `{ success: true }` — no email is sent. This is the expected behaviour in the Docker dev environment; the form UI will appear to succeed. Check the backend container logs (`docker compose logs backend`) to see the submitted values. |
 | Database queries | Integration tests mock the pg pool; real DB behaviour is covered by manual smoke testing against the dev Docker DB |
-| Frontend JavaScript | Out of scope for the backend suite; covered by manual browser testing |
+| Frontend JavaScript (unit/integration) | Out of scope for the backend suite; JS runtime errors on public pages are caught by `test-public-pages.js` (puppeteer, runs every deploy) |
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -102,8 +102,8 @@ Puppeteer scripts run automatically inside the backend container after every dev
 | `test-error-logger-browser.js` | `test:error-logger:browser` | Behavioural **contracts** (see below) via request interception |
 | `test-csp-violations.js` | `test:csp-violations` | No first-party CSP violations on any page — catches missing allowlist entries (#341) |
 | `test-admin-e2e-csp.js` | `test:admin-e2e-csp` | Authenticated admin interactions (Nominatim geocoding etc.) produce no CSP violations (#342) |
-| `test-admin-e2e.js` | `test:admin-e2e` | Full admin CRUD E2E — blog create/delete, travel create/delete, deploy panel smoke (#175) |
-| `test-public-pages.js` | `test:public-pages` | All public pages load without unhandled JS exceptions (`/`, `/blog/`, `/travel/`, `/login/`) — catches null dereferences and import failures invisible to curl-based checks (#390) |
+| `test-admin-e2e.js` | `test:admin-e2e` | Full admin CRUD E2E — blog create/delete, travel create/delete, deploy panel smoke (#175); also checks for unhandled JS exceptions on load and during interactions (#397) |
+| `test-public-pages.js` | `test:public-pages` | All public pages load without unhandled JS exceptions (`/`, `/blog/`, `/travel/`, `/login/`, `/setup/`, plus dynamically discovered blog post and travel post pages) — catches null dereferences and import failures invisible to curl-based checks (#390, #397) |
 
 > **Important:** every script that loads live pages (`test-error-logger-all-pages.js`, `test-csp-violations.js`, `test-admin-e2e-csp.js`, `test-admin-e2e.js`, `test-public-pages.js`) intercepts and mocks `POST /api/debug/errors` responses. Headless Chromium generates internal noise errors (e.g. "Couldn't load fs/zlib") that `error-logger.js` would otherwise capture and POST as real entries, polluting the `client_errors` table and triggering false alert emails. Any new Puppeteer script that loads pages must do the same — add `page.setRequestInterception(true)` and mock the endpoint before calling `page.goto()`.
 

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1506,6 +1506,41 @@ test_error_logger_contracts() {
   fi
 }
 
+# ── Public Page JS Runtime Error Check (#390) ────────────────────────────────
+
+# Load every public page in a real browser and fail if any unhandled JS
+# exception fires (null dereferences, failed imports, etc.). Catches the class
+# of errors invisible to curl-based smoke tests — first caught during #389
+# (jQuery removal), where page JS errors weren't surfaced until a browser ran.
+# Warn-only — surfaces loudly but does not roll back the deploy.
+check_public_page_js() {
+  dsection "Frontend tests — public pages JS runtime errors (#390)"
+
+  local base_url="${NGINX_URL:-}"
+  if [ -z "$base_url" ]; then
+    dwarn "NGINX_URL not set — skipping public page JS runtime check"
+    dstatus public-pages suite=frontend status=skipped reason=no-nginx-url
+    return
+  fi
+
+  dinfo "Loading public pages in headless browser to check for unhandled JS errors..."
+
+  local test_output rc
+  if test_output=$(docker compose -f "$COMPOSE_FILE" exec -T "$BACKEND_SERVICE" \
+      npm run test:public-pages -- "$base_url" 2>&1); then rc=0; else rc=$?; fi
+  local sline; sline=$(printf '%s\n' "$test_output" | grep -E '^\[public-pages\]' | tail -1 || true)
+  local passed failed total
+  passed=$(_kv_num "$sline" passed); failed=$(_kv_num "$sline" failed); total=$(_kv_num "$sline" total)
+  if [ "$rc" -eq 0 ]; then
+    dstatus public-pages suite=frontend status=ok tests="${total:-0}" passed="${passed:-0}" failed="${failed:-0}"
+    dok "Public pages JS check passed — ${passed:-0}/${total:-0} ✓"
+  else
+    dstatus public-pages suite=frontend status=failed tests="${total:-0}" passed="${passed:-0}" failed="${failed:-0}"
+    printf '%s\n' "$test_output" | tee -a "$LOG_FILE"
+    dwarn "JS runtime errors detected on public pages — see output above"
+  fi
+}
+
 # ── CSP Browser Violation Detection (#341) ────────────────────────────────────
 
 # Load every served page in a real browser and listen for securitypolicyviolation

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -124,6 +124,7 @@ case "$DEPLOY_ENV" in
     RUN_DEV_CERTS=1      # dev uses self-signed certs (no certbot); must be generated before nginx starts
     RUN_VITEST=1         # unified image includes devDependencies; run tests against the live container post-deploy
     RUN_ERROR_LOGGER=1   # unified image includes Chromium/puppeteer; run error-logger checks post-deploy
+    RUN_PUBLIC_PAGES=1   # puppeteer check for unhandled JS errors on all public pages (#390)
     RUN_ADMIN_E2E=1      # smoke + interaction tests for admin panel — hard fail (admin is required for content management)
     RUN_DDNS_CHECK=0     # no public DNS in dev; site is LAN-only
     RUN_BACKUP_CHECK=1   # warn if local backups are absent or stale
@@ -143,6 +144,7 @@ case "$DEPLOY_ENV" in
     RUN_DEV_CERTS=0      # prod uses Let's Encrypt certs managed by certbot, not self-signed
     RUN_VITEST=1         # unified image includes devDependencies; run tests post-deploy on prod too
     RUN_ERROR_LOGGER=1   # unified image includes Chromium/puppeteer; run error-logger on prod too
+    RUN_PUBLIC_PAGES=1   # puppeteer check for unhandled JS errors on all public pages (#390)
     RUN_ADMIN_E2E=1      # smoke + interaction tests for admin panel — hard fail (admin is required for content management)
     RUN_DDNS_CHECK=1     # prod is public; verify DNS points to this server before deploying
     RUN_BACKUP_CHECK=1   # warn if local backups are absent or stale
@@ -387,6 +389,7 @@ if [ "$DRY_RUN" = "1" ]; then
   dinfo "  health URL:   $HEALTH_URL"
   [ "$RUN_VITEST"        = "1" ] && dinfo "  vitest:        would run after health check"
   [ "$RUN_ERROR_LOGGER"  = "1" ] && dinfo "  error-logger:  would run after vitest (incl. CSP violation scan)"
+  [ "$RUN_PUBLIC_PAGES"  = "1" ] && dinfo "  public-pages:  would check all public pages for JS runtime errors"
   [ "$SKIP_REGRESSION"   = "0" ] && dinfo "  regression:    would run smoke tests"
   [ "$RUN_BACKUP_CHECK"  = "1" ] && dinfo "  backup check:  would warn if backups absent/stale"
   dinfo ""
@@ -418,6 +421,7 @@ check_outlook_token "$BACKEND_SERVICE"
 
 [ "$RUN_ERROR_LOGGER" = "1" ] && test_error_logger_all_pages
 [ "$RUN_ERROR_LOGGER" = "1" ] && test_error_logger_contracts
+[ "$RUN_PUBLIC_PAGES" = "1" ] && check_public_page_js
 [ "$RUN_ERROR_LOGGER" = "1" ] && check_csp_violations
 [ "$RUN_ERROR_LOGGER" = "1" ] && check_admin_e2e_csp
 [ "$RUN_ADMIN_E2E"    = "1" ] && check_admin_e2e


### PR DESCRIPTION
## Summary

- Adds `test-public-pages.js` — a puppeteer script that loads every public page in headless Chromium and fails if any unhandled JS exception fires
- Dynamically discovers a live blog post and travel post page before each run and includes them in the check; skips gracefully if the environment has no content
- Covers `/`, `/blog/`, `/travel/`, `/login/`, `/setup/`, plus discovered blog/travel post pages
- Wires it into the deploy pipeline via `RUN_PUBLIC_PAGES=1` (both dev and prod) as `check_public_page_js()` in `deploy-lib.sh`, running after the error-logger suite, warn-only
- Adds `pageerror` tracking to `test-admin-e2e.js` (load and interactions), reported as smoke checks
- Removes `rejectUnauthorized: false` from both scripts — API calls use a browser page instead, so `--ignore-certificate-errors` handles the self-signed dev cert with no Node-level TLS bypass
- Updates `docs/TESTING.md` to document the new and extended coverage

## Problem solved

After the jQuery removal (#389), blog and travel pages had JS runtime errors (null dereferences) that the HTTP smoke suite did not catch — only visible once a real browser executed the page JS. This adds a systematic browser-level gate for exactly this class of error.

## Changes

- `backend/scripts/tests/test-public-pages.js` — new puppeteer script; intercepts `POST /api/debug/errors`; uses a browser page to query `/api/posts` and `/api/travel` for live content slugs/ids; emits `[public-pages] status=OK passed=N failed=N total=N`
- `backend/package.json` — adds `test:public-pages` npm script
- `scripts/deploy/deploy-lib.sh` — adds `check_public_page_js()` (warn-only)
- `scripts/deploy/deploy.sh` — adds `RUN_PUBLIC_PAGES=1` for both envs; dry-run hint; call in test sequence
- `backend/scripts/tests/test-admin-e2e.js` — adds `page.on('pageerror')` listener; adds smoke checks S2b (no exceptions on load) and S-final (no exceptions during interactions); cleanup block rewritten to use browser-page fetch instead of `node-fetch` + `rejectUnauthorized: false`
- `docs/TESTING.md` — updated browser tests table, mock requirement note, "What Is Not Tested"

## Test plan

```bash
# Verify test-public-pages.js runs and discovers content pages
# (expects: /setup/ in list, blog/travel post discovered if content exists, all ✅)
docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml exec backend \
  npm run test:public-pages -- https://nginx:3001
# Expected: [public-pages] status=OK — 5 static pages + up to 2 content pages
```

```bash
# Verify admin-e2e includes the new pageerror smoke checks
docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml exec backend \
  npm run test:admin-e2e -- https://nginx:3001
# Expected: "No unhandled JS exceptions on page load" and
#           "No unhandled JS exceptions during interactions" both ✅ in output
```

```bash
# Full dev deploy dry-run — confirm public-pages appears in plan
bash ~/MyPortfolioSite-dev/scripts/deploy/deploy.sh --env dev --dry-run
# Expected: "public-pages: would check all public pages for JS runtime errors"
```

```bash
# Full dev deploy — confirm both suites pass in the deploy report
bash ~/MyPortfolioSite-dev/scripts/deploy/deploy.sh --env dev
# Expected: "[public-pages] status=OK" and "[admin-e2e] status=OK" in report
```

### Smoke test

- Browse to `dev.andykeys.me:3001`, `/blog/`, `/travel/`, `/login/`, `/setup/`, a blog post, a travel post — no console errors in DevTools

## Documentation

- [x] `docs/TESTING.md` updated — browser tests table, mock requirement note, "What Is Not Tested"

Closes #390
Closes #397

---

## Squash commit message

```
feat: puppeteer JS runtime checks — public pages, content posts, admin interactions (#390 #397)

Add test-public-pages.js: loads /, /blog/, /travel/, /login/, /setup/ and
dynamically discovered blog/travel post pages on every deploy, failing on any
unhandled JS exception. Extend test-admin-e2e.js with pageerror tracking on
load and during CRUD interactions. All API calls use browser-page fetch so
--ignore-certificate-errors covers the self-signed dev cert with no Node-level
rejectUnauthorized bypass. Warn-only for public pages; admin-e2e hard-fail
policy unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)