### PR TITLE
feat: admin sub-pages with responsive subnav (#378)

### DIFF
--- a/admin/deploy.html
+++ b/admin/deploy.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Deploy | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card" id="deploy-section">
+                <h2 class="admin-card-title">Deployment</h2>
+                <div id="deploy-status-row" class="deploy-status-row">
+                    <span class="hint">Loading…</span>
+                </div>
+                <div class="form-actions" style="margin-top:1rem">
+                    <button type="button" id="fetch-btn" class="btn-secondary" disabled>Fetch</button>
+                    <button type="button" id="deploy-btn" class="btn-primary" disabled>Deploy latest</button>
+                    <button type="button" id="rollback-btn" class="btn-secondary" disabled>Rollback…</button>
+                </div>
+                <div id="rollback-picker" class="hidden" style="margin-top:0.75rem">
+                    <label>Roll back to
+                        <select id="rollback-sha-select"></select>
+                    </label>
+                    <div class="form-actions" style="margin-top:0.5rem">
+                        <button type="button" id="rollback-confirm-btn" class="btn-small btn-danger">Confirm rollback</button>
+                        <button type="button" id="rollback-cancel-btn" class="btn-secondary">Cancel</button>
+                    </div>
+                </div>
+                <pre id="deploy-output" class="deploy-output hidden"></pre>
+                <p id="deploy-message" class="admin-message"></p>
+                <div id="deploy-log-section" style="margin-top:1.5rem">
+                    <h3 style="font-size:0.9rem;color:var(--color-text-muted);margin-bottom:0.5rem">Deploy history</h3>
+                    <div id="deploy-log-list"><p class="hint">Loading…</p></div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script type="module" src="/resources/js/admin-deploy-page.js"></script>
+</body>
+</html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -5,22 +5,19 @@
     <script type="module" src="/resources/js/error-logger.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Admin Dashboard | AK Portfolio</title>
+    <title>Admin | AK Portfolio</title>
     <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
     <link rel="stylesheet" href="/resources/css/reset.css" />
     <link rel="stylesheet" href="/resources/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <!-- Leaflet for geocode confirmation map -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </head>
 <body>
     <header>
         <h1>A|K</h1>
         <h2>Andy | Keys</h2>
-        <h2>Admin Dashboard</h2>
+        <h2>Admin</h2>
     </header>
     <nav>
         <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
@@ -37,204 +34,46 @@
     </nav>
 
     <main class="admin-page">
-        <section class="sec-cont admin-panel">
-
-            <!-- ── Travel memories ───────────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2 class="admin-card-title">Travel memories</h2>
-                <form id="travel-form">
-                    <input type="hidden" id="travel-edit-id" value="" />
-                    <label>Title
-                        <input id="travel-title" type="text" placeholder="Trip title" />
-                    </label>
-                    <label>Date of visit
-                        <input id="travel-date" type="date" />
-                    </label>
-                    <label>Location
-                        <div class="location-row">
-                            <input id="travel-location" type="text" placeholder="City, country" />
-                            <button type="button" id="geocode-btn" class="btn-secondary" title="Look up coordinates from location name">Geocode</button>
-                        </div>
-                    </label>
-                    <label>Notes
-                        <textarea id="travel-notes" rows="4" placeholder="Describe the moment…"></textarea>
-                    </label>
-                    <!-- Issue #30: multi-file input with preview list -->
-                    <label>Photos / videos
-                        <div class="file-input-wrap">
-                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photos or videos">Add files…</button>
-                            <span class="file-input-label">No files chosen</span>
-                            <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" multiple />
-                        </div>
-                    </label>
-                    <div id="travel-media-list" class="media-list hidden"></div>
-                    <!-- Issue #39: custom coordinate steppers replacing native spinners -->
-                    <div class="coord-row">
-                        <label>Latitude
-                            <div class="coord-stepper">
-                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="-1" aria-label="Decrease latitude">−</button>
-                                <input id="travel-lat" type="number" step="0.000001" placeholder="e.g. 51.5074" />
-                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="1" aria-label="Increase latitude">+</button>
-                            </div>
-                        </label>
-                        <label>Longitude
-                            <div class="coord-stepper">
-                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="-1" aria-label="Decrease longitude">−</button>
-                                <input id="travel-lng" type="number" step="0.000001" placeholder="e.g. -0.1278" />
-                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="1" aria-label="Increase longitude">+</button>
-                            </div>
-                        </label>
-                    </div>
-                    <!-- Geocode confirmation map: hidden until coords are set -->
-                    <div id="geoconfirm-map" class="hidden" style="height:200px;margin-top:0.5rem;border-radius:var(--radius-md);overflow:hidden;"></div>
-                    <div class="form-actions">
-                        <button type="submit" id="travel-save-btn" class="btn-primary">Save draft</button>
-                        <button type="submit" id="travel-publish-btn" class="btn-primary">Publish</button>
-                        <button type="button" id="travel-clear" class="btn-secondary">Clear</button>
-                        <button type="button" id="travel-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
-                    </div>
-                </form>
-                <p id="travel-message" class="admin-message"></p>
-                <div id="travel-preview" class="travel-preview hidden">
-                    <h4>Preview</h4>
-                    <div class="preview-media"></div>
-                    <div class="preview-text"></div>
-                </div>
-                <div class="saved-memories">
-                    <h3 class="saved-list-title">Saved memories</h3>
-                    <div id="saved-memories-list">
-                        <p class="hint">Loading…</p>
-                    </div>
-                </div>
+        <section class="sec-cont">
+            <div class="admin-dashboard-grid">
+                <a href="/admin/posts.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">✏</span>
+                    <span class="admin-dashboard-card-title">Posts</span>
+                    <span class="admin-dashboard-card-desc">Write and manage blog posts</span>
+                </a>
+                <a href="/admin/travel.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">✈</span>
+                    <span class="admin-dashboard-card-title">Travel</span>
+                    <span class="admin-dashboard-card-desc">Log travel memories and photos</span>
+                </a>
+                <a href="/admin/deploy.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">⚡</span>
+                    <span class="admin-dashboard-card-title">Deploy</span>
+                    <span class="admin-dashboard-card-desc">Deploy, rollback, and monitor</span>
+                </a>
+                <a href="/admin/media.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">📁</span>
+                    <span class="admin-dashboard-card-title">Media</span>
+                    <span class="admin-dashboard-card-desc">CV upload and private notes</span>
+                </a>
+                <a href="/admin/stats.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">📊</span>
+                    <span class="admin-dashboard-card-title">Stats</span>
+                    <span class="admin-dashboard-card-desc">Site visit statistics</span>
+                </a>
+                <a href="/admin/settings.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">⚙</span>
+                    <span class="admin-dashboard-card-title">Settings</span>
+                    <span class="admin-dashboard-card-desc">Manage passkeys and account</span>
+                </a>
             </div>
-
-            <!-- ── Blog posts ──────────────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2 class="admin-card-title">Blog posts</h2>
-                <form id="post-form">
-                    <input type="hidden" id="post-edit-id" value="" />
-                    <label>Title
-                        <input id="post-title" type="text" placeholder="Post title" />
-                    </label>
-                    <label>Date
-                        <input id="post-date" type="date" />
-                    </label>
-                    <label>Body (Markdown)
-                        <textarea id="post-body" rows="10" placeholder="Write in Markdown…"></textarea>
-                    </label>
-                    <div class="form-actions">
-                        <button type="submit" id="post-save-btn" class="btn-primary">Save draft</button>
-                        <button type="submit" id="post-publish-btn" class="btn-primary">Publish</button>
-                        <button type="button" id="post-template-btn" class="btn-secondary">Insert template</button>
-                        <button type="button" id="post-clear-btn" class="btn-secondary">Clear</button>
-                        <button type="button" id="post-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
-                    </div>
-                </form>
-                <p id="post-message" class="admin-message"></p>
-                <div class="saved-memories">
-                    <h3 class="saved-list-title">All posts</h3>
-                    <div id="posts-admin-list">
-                        <p class="hint">Loading…</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- ── CV management (#101) ──────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2 class="admin-card-title">CV</h2>
-                <p class="hint" style="margin-bottom:1rem">
-                    Upload a PDF CV to make it available for download on the site.
-                    The file will be scanned for obvious private information before publishing.
-                </p>
-                <div style="margin-bottom:1rem">
-                    <span id="cv-status-badge" class="cv-status-badge not-uploaded">Checking…</span>
-                </div>
-                <div class="file-input-wrap" style="margin-bottom:0.25rem">
-                    <button type="button" id="cv-file-btn" class="btn-secondary" aria-label="Choose CV PDF">Choose PDF…</button>
-                    <span id="cv-file-label" class="file-input-label">No file chosen</span>
-                    <input id="cv-file-input" type="file" accept="application/pdf" class="file-input-hidden" />
-                </div>
-                <!-- Rename notice: shown when selected file is not already named cv.pdf (#110) -->
-                <p id="cv-rename-notice" class="hint" style="display:none;margin-bottom:0.75rem;color:var(--color-text-secondary)">
-                    ℹ Your file will be saved as <strong>cv.pdf</strong>
-                </p>
-                <div class="form-actions">
-                    <button type="button" id="cv-upload-btn" class="btn-primary" disabled>Upload CV</button>
-                    <button type="button" id="cv-delete-btn" class="btn-small btn-danger" disabled>Delete CV</button>
-                </div>
-                <p id="cv-message" class="admin-message"></p>
-            </div>
-
-            <!-- ── Private notes ─────────────────────────────────────────────────── -->
-            <div class="admin-card private-card">
-                <h2 class="admin-card-title">Private coding projects</h2>
-                <label>Private notes
-                    <textarea id="private-notes" rows="6" placeholder="Save private project ideas here…"></textarea>
-                </label>
-                <div class="form-actions">
-                    <button id="save-private" type="button" class="btn-primary">Save notes</button>
-                    <button id="clear-private" type="button" class="btn-secondary">Clear notes</button>
-                </div>
-                <p class="hint" style="margin-top:0.75rem">Notes are saved locally in your browser.</p>
-            </div>
-
-            <!-- ── Site stats ──────────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2>Site visits</h2>
-                <div id="stats-list">
-                    <p class="hint">Loading…</p>
-                </div>
-            </div>
-
-            <!-- ── Deployment (#98 / #117 / #129) ───────────────────────────────── -->
-            <div class="admin-card" id="deploy-section">
-                <h2 class="admin-card-title">Deployment</h2>
-                <div id="deploy-status-row" class="deploy-status-row">
-                    <span class="hint">Loading…</span>
-                </div>
-                <div class="form-actions" style="margin-top:1rem">
-                    <button type="button" id="fetch-btn" class="btn-secondary" disabled>Fetch</button>
-                    <button type="button" id="deploy-btn" class="btn-primary" disabled>Deploy latest</button>
-                    <button type="button" id="rollback-btn" class="btn-secondary" disabled>Rollback…</button>
-                </div>
-                <div id="rollback-picker" class="hidden" style="margin-top:0.75rem">
-                    <label>Roll back to
-                        <select id="rollback-sha-select"></select>
-                    </label>
-                    <div class="form-actions" style="margin-top:0.5rem">
-                        <button type="button" id="rollback-confirm-btn" class="btn-small btn-danger">Confirm rollback</button>
-                        <button type="button" id="rollback-cancel-btn" class="btn-secondary">Cancel</button>
-                    </div>
-                </div>
-                <pre id="deploy-output" class="deploy-output hidden"></pre>
-                <p id="deploy-message" class="admin-message"></p>
-                <div id="deploy-log-section" style="margin-top:1.5rem">
-                    <h3 style="font-size:0.9rem;color:var(--color-text-muted);margin-bottom:0.5rem">Deploy history</h3>
-                    <div id="deploy-log-list"><p class="hint">Loading…</p></div>
-                </div>
-            </div>
-
-            <!-- ── Passkeys ─────────────────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2 class="admin-card-title">Manage passkeys</h2>
-                <p style="color:var(--color-text-secondary);margin-bottom:1rem">Passkeys let you sign in with your device's biometrics or PIN — no password needed.</p>
-                <div id="passkey-list">
-                    <p class="hint">Loading passkeys…</p>
-                </div>
-                <div class="form-actions" style="margin-top:1rem">
-                    <button id="add-passkey-btn" type="button" class="btn-primary">Add passkey</button>
-                </div>
-                <p id="passkey-message" class="admin-message"></p>
-            </div>
-
         </section>
     </main>
 
-    <!-- Issue #33: dev environment indicator -->
     <script src="/resources/js/dev-env.js"></script>
     <script src="/resources/js/darkmode.js"></script>
     <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
     <script type="module" src="/resources/js/admin.js"></script>
-    <script src="/resources/js/admin-init.js"></script>
 </body>
 </html>

--- a/admin/media.html
+++ b/admin/media.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Media | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+
+            <!-- CV management -->
+            <div class="admin-card">
+                <h2 class="admin-card-title">CV</h2>
+                <p class="hint" style="margin-bottom:1rem">
+                    Upload a PDF CV to make it available for download on the site.
+                    The file will be scanned for obvious private information before publishing.
+                </p>
+                <div style="margin-bottom:1rem">
+                    <span id="cv-status-badge" class="cv-status-badge not-uploaded">Checking…</span>
+                </div>
+                <div class="file-input-wrap" style="margin-bottom:0.25rem">
+                    <button type="button" id="cv-file-btn" class="btn-secondary" aria-label="Choose CV PDF">Choose PDF…</button>
+                    <span id="cv-file-label" class="file-input-label">No file chosen</span>
+                    <input id="cv-file-input" type="file" accept="application/pdf" class="file-input-hidden" />
+                </div>
+                <p id="cv-rename-notice" class="hint" style="display:none;margin-bottom:0.75rem;color:var(--color-text-secondary)">
+                    ℹ Your file will be saved as <strong>cv.pdf</strong>
+                </p>
+                <div class="form-actions">
+                    <button type="button" id="cv-upload-btn" class="btn-primary" disabled>Upload CV</button>
+                    <button type="button" id="cv-delete-btn" class="btn-small btn-danger" disabled>Delete CV</button>
+                </div>
+                <p id="cv-message" class="admin-message"></p>
+            </div>
+
+            <!-- Private notes -->
+            <div class="admin-card private-card">
+                <h2 class="admin-card-title">Private coding projects</h2>
+                <label>Private notes
+                    <textarea id="private-notes" rows="6" placeholder="Save private project ideas here…"></textarea>
+                </label>
+                <div class="form-actions">
+                    <button id="save-private" type="button" class="btn-primary">Save notes</button>
+                    <button id="clear-private" type="button" class="btn-secondary">Clear notes</button>
+                </div>
+                <p class="hint" style="margin-top:0.75rem">Notes are saved locally in your browser.</p>
+            </div>
+
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script src="/resources/js/admin-init.js"></script>
+    <script type="module" src="/resources/js/admin-media-page.js"></script>
+</body>
+</html>

--- a/admin/posts.html
+++ b/admin/posts.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Posts | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card">
+                <h2 class="admin-card-title">Blog posts</h2>
+                <form id="post-form">
+                    <input type="hidden" id="post-edit-id" value="" />
+                    <label>Title
+                        <input id="post-title" type="text" placeholder="Post title" />
+                    </label>
+                    <label>Date
+                        <input id="post-date" type="date" />
+                    </label>
+                    <label>Body (Markdown)
+                        <textarea id="post-body" rows="10" placeholder="Write in Markdown…"></textarea>
+                    </label>
+                    <div class="form-actions">
+                        <button type="submit" id="post-save-btn" class="btn-primary">Save draft</button>
+                        <button type="submit" id="post-publish-btn" class="btn-primary">Publish</button>
+                        <button type="button" id="post-template-btn" class="btn-secondary">Insert template</button>
+                        <button type="button" id="post-clear-btn" class="btn-secondary">Clear</button>
+                        <button type="button" id="post-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
+                    </div>
+                </form>
+                <p id="post-message" class="admin-message"></p>
+                <div class="saved-memories">
+                    <h3 class="saved-list-title">All posts</h3>
+                    <div id="posts-admin-list">
+                        <p class="hint">Loading…</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script src="/resources/js/admin-init.js"></script>
+    <script type="module" src="/resources/js/admin-posts-page.js"></script>
+</body>
+</html>

--- a/admin/settings.html
+++ b/admin/settings.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Settings | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card">
+                <h2 class="admin-card-title">Manage passkeys</h2>
+                <p style="color:var(--color-text-secondary);margin-bottom:1rem">Passkeys let you sign in with your device's biometrics or PIN — no password needed.</p>
+                <div id="passkey-list">
+                    <p class="hint">Loading passkeys…</p>
+                </div>
+                <div class="form-actions" style="margin-top:1rem">
+                    <button id="add-passkey-btn" type="button" class="btn-primary">Add passkey</button>
+                </div>
+                <p id="passkey-message" class="admin-message"></p>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script type="module" src="/resources/js/admin-settings-page.js"></script>
+</body>
+</html>

--- a/admin/stats.html
+++ b/admin/stats.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Stats | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card">
+                <h2 class="admin-card-title">Site visits</h2>
+                <div id="stats-list">
+                    <p class="hint">Loading…</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script type="module" src="/resources/js/admin-stats-page.js"></script>
+</body>
+</html>

--- a/admin/travel.html
+++ b/admin/travel.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Travel | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Leaflet for geocode confirmation map -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card">
+                <h2 class="admin-card-title">Travel memories</h2>
+                <form id="travel-form">
+                    <input type="hidden" id="travel-edit-id" value="" />
+                    <label>Title
+                        <input id="travel-title" type="text" placeholder="Trip title" />
+                    </label>
+                    <label>Date of visit
+                        <input id="travel-date" type="date" />
+                    </label>
+                    <label>Location
+                        <div class="location-row">
+                            <input id="travel-location" type="text" placeholder="City, country" />
+                            <button type="button" id="geocode-btn" class="btn-secondary" title="Look up coordinates from location name">Geocode</button>
+                        </div>
+                    </label>
+                    <label>Notes
+                        <textarea id="travel-notes" rows="4" placeholder="Describe the moment…"></textarea>
+                    </label>
+                    <label>Photos / videos
+                        <div class="file-input-wrap">
+                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photos or videos">Add files…</button>
+                            <span class="file-input-label">No files chosen</span>
+                            <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" multiple />
+                        </div>
+                    </label>
+                    <div id="travel-media-list" class="media-list hidden"></div>
+                    <div class="coord-row">
+                        <label>Latitude
+                            <div class="coord-stepper">
+                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="-1" aria-label="Decrease latitude">−</button>
+                                <input id="travel-lat" type="number" step="0.000001" placeholder="e.g. 51.5074" />
+                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="1" aria-label="Increase latitude">+</button>
+                            </div>
+                        </label>
+                        <label>Longitude
+                            <div class="coord-stepper">
+                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="-1" aria-label="Decrease longitude">−</button>
+                                <input id="travel-lng" type="number" step="0.000001" placeholder="e.g. -0.1278" />
+                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="1" aria-label="Increase longitude">+</button>
+                            </div>
+                        </label>
+                    </div>
+                    <div id="geoconfirm-map" class="hidden" style="height:200px;margin-top:0.5rem;border-radius:var(--radius-md);overflow:hidden;"></div>
+                    <div class="form-actions">
+                        <button type="submit" id="travel-save-btn" class="btn-primary">Save draft</button>
+                        <button type="submit" id="travel-publish-btn" class="btn-primary">Publish</button>
+                        <button type="button" id="travel-clear" class="btn-secondary">Clear</button>
+                        <button type="button" id="travel-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
+                    </div>
+                </form>
+                <p id="travel-message" class="admin-message"></p>
+                <div id="travel-preview" class="travel-preview hidden">
+                    <h4>Preview</h4>
+                    <div class="preview-media"></div>
+                    <div class="preview-text"></div>
+                </div>
+                <div class="saved-memories">
+                    <h3 class="saved-list-title">Saved memories</h3>
+                    <div id="saved-memories-list">
+                        <p class="hint">Loading…</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script src="/resources/js/admin-init.js"></script>
+    <script type="module" src="/resources/js/admin-travel-page.js"></script>
+</body>
+</html>

--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -193,30 +193,17 @@ try {
   smoke('No unhandled JS exceptions on page load', pageErrors.length === 0, pageErrors.join('; '));
   const pageErrorsAtLoad = pageErrors.length; // snapshot — S-final only reports new errors from interactions
 
-  // S3–S8: each section present in DOM
-  const sections = [
-    ['Travel form',       '#travel-form'],
-    ['Posts form',        '#post-form'],
-    ['Deploy section',    '#deploy-section'],
-    ['CV section',        '#cv-status-badge'],
-    ['Stats section',     '#stats-list'],
-    ['Notes section',     '#private-notes'],
-    ['Passkeys section',  '#passkey-list'],
-  ];
-  for (const [label, sel] of sections) {
-    const exists = await page.$(sel) !== null;
-    smoke(`${label} present`, exists, `${sel} not found`);
+  // S3: admin sub-nav present and Dashboard is the active item (#378)
+  const subnavExists = await page.$('.admin-subnav') !== null;
+  smoke('Admin sub-nav present', subnavExists, '.admin-subnav not found');
+  if (subnavExists) {
+    const activeLabel = await page.$eval('.admin-subnav-item.active', el => el.textContent.trim()).catch(() => '');
+    smoke('Dashboard active in sub-nav', activeLabel.includes('Dashboard'), `active item: "${activeLabel}"`);
   }
 
-  // S9: deploy status loaded (not crashing — text is not the loading placeholder)
-  try {
-    await waitForText(page, '#deploy-status-row', '?', 5000)
-      .catch(() => {}); // may already have content
-    const statusText = await page.$eval('#deploy-status-row', el => el.textContent.trim());
-    smoke('Deploy status row has content', statusText.length > 0, 'empty status row');
-  } catch (e) {
-    smoke('Deploy status row has content', false, e.message);
-  }
+  // S4: all 6 dashboard navigation cards present (#378)
+  const cardCount = await page.$$eval('.admin-dashboard-card', els => els.length).catch(() => 0);
+  smoke('Dashboard has 6 navigation cards', cardCount === 6, `found ${cardCount}`);
 
   // ── Interaction tests ────────────────────────────────────────────────────
 
@@ -224,6 +211,7 @@ try {
 
   // ── I1: create a blog post ───────────────────────────────────────────────
   console.log('\n📝 I1 — create blog post');
+  await page.goto(`${baseUrl}/admin/posts.html`, { waitUntil: 'networkidle0', timeout: 20000 });
   try {
     await page.waitForSelector('#post-title', { timeout: 5000 });
     await page.$eval('#post-title', el => { el.value = ''; });
@@ -273,6 +261,7 @@ try {
 
   // ── I3: create a travel memory ───────────────────────────────────────────
   console.log('\n🌍 I3 — create travel memory');
+  await page.goto(`${baseUrl}/admin/travel.html`, { waitUntil: 'networkidle0', timeout: 20000 });
   try {
     await page.waitForSelector('#travel-title', { timeout: 5000 });
     await page.$eval('#travel-title', el => { el.value = ''; });
@@ -319,6 +308,7 @@ try {
 
   // ── I5: deploy fetch streams output ──────────────────────────────────────
   console.log('\n📡 I5 — deploy fetch (git fetch origin)');
+  await page.goto(`${baseUrl}/admin/deploy.html`, { waitUntil: 'networkidle0', timeout: 20000 });
   try {
     await page.waitForSelector('#fetch-btn:not([disabled])', { timeout: 8000 });
     await page.click('#fetch-btn');

--- a/backend/scripts/tests/test-public-pages.js
+++ b/backend/scripts/tests/test-public-pages.js
@@ -28,7 +28,12 @@ if (!baseUrl) {
 }
 
 // Static pages always included — individual content pages added dynamically below.
-const STATIC_PAGES = ['/', '/blog/', '/travel/', '/login/', '/setup/'];
+const STATIC_PAGES = [
+    '/', '/blog/', '/travel/', '/login/', '/setup/',
+    // Admin sub-pages (#378) — unauthenticated load still runs all page JS before the auth redirect
+    '/admin/', '/admin/posts.html', '/admin/travel.html', '/admin/deploy.html',
+    '/admin/media.html', '/admin/stats.html', '/admin/settings.html',
+];
 
 // ── Dynamic slug discovery ────────────────────────────────────────────────────
 

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -302,6 +302,97 @@ ul.nav {
     line-height: 1.5em;
 }
 
+/* ── Admin sub-navigation (#378) ────────────────────────────────────────── */
+
+.admin-subnav {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.5rem 1.25rem;
+    background: var(--color-surface-alt);
+    border-bottom: 1px solid var(--color-border);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+
+.admin-subnav::-webkit-scrollbar { display: none; }
+
+.admin-subnav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4rem 0.9rem;
+    border-radius: var(--radius-sm);
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    font-size: 0.85rem;
+    font-weight: 500;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s;
+    border: 1px solid transparent;
+}
+
+.admin-subnav-item:hover {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+}
+
+.admin-subnav-item.active {
+    background: var(--color-accent);
+    color: #fff;
+    border-color: var(--color-accent);
+}
+
+[data-theme="dark"] .admin-subnav-item.active {
+    color: #fff;
+}
+
+@media (max-width: 600px) {
+    .admin-subnav { padding: 0.4rem 0.75rem; }
+    .admin-subnav-item { padding: 0.35rem 0.65rem; font-size: 0.8rem; }
+}
+
+/* ── Admin dashboard (#378) ─────────────────────────────────────────────── */
+
+.admin-dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+    gap: 1rem;
+    padding: 1.5rem 0 0.5rem;
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.admin-dashboard-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1.25rem 1.25rem 1rem;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: var(--color-text);
+    box-shadow: 0 1px 4px var(--color-shadow);
+    transition: box-shadow 0.15s, border-color 0.15s, transform 0.1s;
+}
+
+.admin-dashboard-card:hover {
+    box-shadow: 0 3px 12px var(--color-shadow-hover);
+    border-color: var(--color-accent);
+    transform: translateY(-1px);
+}
+
+.admin-dashboard-card-icon { font-size: 1.4rem; line-height: 1; margin-bottom: 0.15rem; }
+.admin-dashboard-card-title { font-weight: 600; font-size: 0.95rem; }
+.admin-dashboard-card-desc { font-size: 0.8rem; color: var(--color-text-secondary); line-height: 1.4; }
+
+@media (max-width: 480px) {
+    .admin-dashboard-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
 .admin-page {
     padding: 20px 0;
 }

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -306,10 +306,11 @@ ul.nav {
 
 .admin-subnav {
     display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.5rem 1.25rem;
-    background: var(--color-surface-alt);
+    align-items: stretch;
+    justify-content: center;
+    gap: 0;
+    padding: 0 1.25rem;
+    background: var(--color-surface);
     border-bottom: 1px solid var(--color-border);
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
@@ -322,36 +323,30 @@ ul.nav {
     display: flex;
     align-items: center;
     gap: 0.35rem;
-    padding: 0.4rem 0.9rem;
-    border-radius: var(--radius-sm);
+    padding: 0.75rem 0.9rem;
     color: var(--color-text-secondary);
     text-decoration: none;
     font-size: 0.85rem;
     font-weight: 500;
     white-space: nowrap;
-    transition: background 0.15s, color 0.15s;
-    border: 1px solid transparent;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    transition: color 0.15s, border-color 0.15s;
 }
 
 .admin-subnav-item:hover {
-    background: var(--color-surface);
     color: var(--color-text);
-    border-color: var(--color-border);
 }
 
 .admin-subnav-item.active {
-    background: var(--color-accent);
-    color: #fff;
-    border-color: var(--color-accent);
-}
-
-[data-theme="dark"] .admin-subnav-item.active {
-    color: #fff;
+    color: var(--color-accent);
+    border-bottom-color: var(--color-accent);
+    font-weight: 600;
 }
 
 @media (max-width: 600px) {
-    .admin-subnav { padding: 0.4rem 0.75rem; }
-    .admin-subnav-item { padding: 0.35rem 0.65rem; font-size: 0.8rem; }
+    .admin-subnav { padding: 0 0.75rem; justify-content: flex-start; }
+    .admin-subnav-item { padding: 0.65rem 0.65rem; font-size: 0.8rem; }
 }
 
 /* ── Admin dashboard (#378) ─────────────────────────────────────────────── */
@@ -892,14 +887,17 @@ footer a:hover {
 
 /* Skills section */
 .skills-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 2rem;
     max-width: 1100px;
     margin: 0 auto;
 }
 
 .skill-category {
+    flex: 1 1 280px;
+    max-width: 480px;
     background: var(--color-surface);
     padding: 1.75rem;
     border-radius: 10px;

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -203,9 +203,9 @@ strong {
 }
 
 
-/* Nav box — scoped to direct child so admin-subnav <nav> is not affected */
+/* Nav box — exclude admin-subnav so its flex-direction:row is not overridden */
 
-body > nav {
+nav:not(.admin-subnav) {
     display: flex;
     flex-direction: column;
     width: 100%;

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -203,9 +203,9 @@ strong {
 }
 
 
-/* Nav box */
+/* Nav box — scoped to direct child so admin-subnav <nav> is not affected */
 
-nav {
+body > nav {
     display: flex;
     flex-direction: column;
     width: 100%;

--- a/resources/js/admin-deploy-page.js
+++ b/resources/js/admin-deploy-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initDeploy }             from './admin/deploy.js';
+
+requireAuth();
+setLogout();
+initDeploy();

--- a/resources/js/admin-media-page.js
+++ b/resources/js/admin-media-page.js
@@ -1,0 +1,8 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initCv }                 from './admin/cv.js';
+import { initNotes }              from './admin/notes.js';
+
+requireAuth();
+setLogout();
+initCv();
+initNotes();

--- a/resources/js/admin-posts-page.js
+++ b/resources/js/admin-posts-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initPosts }              from './admin/posts.js';
+
+requireAuth();
+setLogout();
+initPosts();

--- a/resources/js/admin-settings-page.js
+++ b/resources/js/admin-settings-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initPasskeys }           from './admin/passkeys.js';
+
+requireAuth();
+setLogout();
+initPasskeys();

--- a/resources/js/admin-stats-page.js
+++ b/resources/js/admin-stats-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initStats }              from './admin/stats.js';
+
+requireAuth();
+setLogout();
+initStats();

--- a/resources/js/admin-subnav.js
+++ b/resources/js/admin-subnav.js
@@ -1,0 +1,47 @@
+// Inject the admin sub-navigation bar and mark the active link (#378).
+// Non-module script — runs synchronously so the nav appears before main content.
+(function () {
+    var NAV_ITEMS = [
+        { href: '/admin/',              label: 'Dashboard', icon: '⊞' },
+        { href: '/admin/posts.html',    label: 'Posts',     icon: '✏' },
+        { href: '/admin/travel.html',   label: 'Travel',    icon: '✈' },
+        { href: '/admin/deploy.html',   label: 'Deploy',    icon: '⚡' },
+        { href: '/admin/media.html',    label: 'Media',     icon: '📁' },
+        { href: '/admin/stats.html',    label: 'Stats',     icon: '📊' },
+        { href: '/admin/settings.html', label: 'Settings',  icon: '⚙' },
+    ];
+
+    var pathname = window.location.pathname;
+
+    var nav = document.createElement('nav');
+    nav.className = 'admin-subnav';
+    nav.setAttribute('aria-label', 'Admin sections');
+
+    NAV_ITEMS.forEach(function (item) {
+        var a = document.createElement('a');
+        a.href = item.href;
+        a.className = 'admin-subnav-item';
+
+        // Match dashboard only on exact path; other items on pathname match.
+        var isActive = item.href === '/admin/'
+            ? (pathname === '/admin/' || pathname === '/admin/index.html')
+            : pathname === item.href;
+
+        if (isActive) {
+            a.classList.add('active');
+            a.setAttribute('aria-current', 'page');
+        }
+
+        a.innerHTML = '<span aria-hidden="true">' + item.icon + '</span>' +
+                      '<span class="admin-subnav-label">' + item.label + '</span>';
+        nav.appendChild(a);
+    });
+
+    // Insert immediately after the main <nav> element.
+    var mainNav = document.querySelector('body > nav');
+    if (mainNav) {
+        mainNav.insertAdjacentElement('afterend', nav);
+    } else {
+        document.body.insertAdjacentElement('afterbegin', nav);
+    }
+}());

--- a/resources/js/admin-travel-page.js
+++ b/resources/js/admin-travel-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initTravel }             from './admin/travel.js';
+
+requireAuth();
+setLogout();
+initTravel();

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -1,19 +1,7 @@
-// ── Admin hub — imports and initialises all admin modules ─────────────────────
+// ── Admin dashboard entry point (#378) ────────────────────────────────────────
+// The dashboard is a static navigation page — no section modules needed here.
+// Each sub-page loads only its own module via admin-*-page.js entry points.
 import { requireAuth, setLogout } from './admin/auth.js';
-import { initTravel }             from './admin/travel.js';
-import { initPosts }              from './admin/posts.js';
-import { initCv }                 from './admin/cv.js';
-import { initDeploy }             from './admin/deploy.js';
-import { initPasskeys }           from './admin/passkeys.js';
-import { initStats }              from './admin/stats.js';
-import { initNotes }              from './admin/notes.js';
 
 requireAuth();
 setLogout();
-initTravel();
-initPosts();
-initCv();
-initDeploy();
-initPasskeys();
-initNotes();
-initStats();


### PR DESCRIPTION
## Summary

Replaces the monolithic `admin/index.html` with a dashboard + six dedicated sub-pages (Option B). A shared responsive sub-nav bar links all sections, and each page loads only its own JS module.

## Changes

**New HTML pages:**
- `admin/index.html` → dashboard with 6 navigation cards (replaces the monolith)
- `admin/posts.html` — blog post CRUD
- `admin/travel.html` — travel memory CRUD (Leaflet only loaded here)
- `admin/deploy.html` — deployment suite
- `admin/media.html` — CV upload + private notes
- `admin/stats.html` — site visit stats
- `admin/settings.html` — passkey management

**New JS entry points** (one per page, imports only what it needs):
`admin-posts-page.js`, `admin-travel-page.js`, `admin-deploy-page.js`, `admin-media-page.js`, `admin-stats-page.js`, `admin-settings-page.js`

**`resources/js/admin-subnav.js`** — non-module script (consistent with `nav.js`, `darkmode.js` pattern) that injects a `<nav class="admin-subnav">` after the main nav and marks the active link from `window.location.pathname`

**`resources/css/styles.css`** — adds `.admin-subnav` (horizontal, scrollable on mobile, dark-mode aware) and `.admin-dashboard-card` grid styles

**`resources/js/admin.js`** — simplified to dashboard entry point: `requireAuth` + `setLogout` only

**`backend/scripts/tests/test-admin-e2e.js`** — smoke checks updated for dashboard structure (subnav present, 6 cards, active item); interaction tests navigate to the relevant sub-page before each CRUD block (localStorage persists across same-origin navigations so the injected JWT remains valid)

**`backend/scripts/tests/test-public-pages.js`** — all 7 admin pages added to the static list for JS runtime error checking on every deploy

No nginx changes needed — existing `try_files $uri $uri/ $uri.html =404` serves `.html` files directly. No CSP changes needed — all new scripts are same-origin `'self'`.

## Test plan

```bash
# Verify the admin E2E suite passes with the new sub-page structure
docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml exec backend \
  npm run test:admin-e2e -- https://nginx:3001
# Expected: [admin-e2e] status=OK — subnav present, 6 cards, all CRUD interactions pass
```

```bash
# Verify the public pages JS check covers all admin sub-pages
docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml exec backend \
  npm run test:public-pages -- https://nginx:3001
# Expected: [public-pages] status=OK — 12 static pages (5 public + 7 admin) + content pages
```

### Manual smoke test

- [ ] Visit `dev.andykeys.me:3001/admin/` — dashboard loads with 6 cards, subnav shows Dashboard as active
- [ ] Click each card — navigates to correct sub-page, subnav updates active item
- [ ] Sub-nav is scrollable horizontally on mobile viewport
- [ ] Dark mode renders correctly on all pages
- [ ] Create, publish, and delete a blog post on `/admin/posts.html`
- [ ] Create and delete a travel memory on `/admin/travel.html`
- [ ] Fetch on `/admin/deploy.html` streams output
- [ ] CV upload status loads on `/admin/media.html`
- [ ] Stats load on `/admin/stats.html`
- [ ] Passkey list loads on `/admin/settings.html`
- [ ] Logout link works from any sub-page

## Documentation

- [x] No doc changes needed — this is a self-contained UI restructure with no API, workflow, or operator-behaviour changes

Closes #378

---

## Squash commit message

```
feat: admin sub-pages with responsive subnav (#378)

Replace monolithic admin/index.html with a dashboard and six dedicated
sub-pages (Option B). Shared admin-subnav.js injects a responsive
horizontal sub-nav bar; each page loads only its own JS module entry
point. No nginx or CSP changes required. E2E test updated to navigate
sub-pages; public-page JS check extended to cover all admin pages.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)