### PR TITLE
fix: prevent projects grid overflow at narrow viewports

### DIFF
--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -829,8 +829,10 @@ footer a:hover {
     flex-wrap: wrap;
     justify-content: center;
     gap: 1.5rem;
+    width: 100%;
     max-width: 1100px;
     margin: 0 auto;
+    padding: 0 1rem;
 }
 
 .project-card {


### PR DESCRIPTION
## Summary

- Added `width: 100%` to `.projects-grid` to constrain it within the column-flex `.sec-cont` container (which uses `align-items: center` — without explicit width the grid could expand beyond the viewport)
- Added `padding: 0 1rem` for breathing room at narrow viewports
- `max-width: 1100px` still caps width on wide screens; global `box-sizing: border-box` means the padding doesn't add to the total width

Issue 2 from #322 (orange nav logo inconsistency across pages) is a Firefox self-signed cert behaviour, documented in `docs/DEV_ENVIRONMENT.md` — not a code bug.

## Changes

- `resources/css/styles.css` — `.projects-grid`: add `width: 100%` and `padding: 0 1rem`

## Test plan

### Automated

```bash
# Run the full test suite (no backend changes — smoke-check passes)
docker compose exec backend npm test
```

### Manual

1. Open the homepage at various viewport widths (320px, 375px, 768px, 1280px, 1920px)
2. Verify the Featured Projects section does not produce a horizontal scrollbar at any width
3. Verify cards wrap and centre correctly on narrow viewports
4. Verify layout looks correct on wide viewports (cards remain capped at 420px, grid at 1100px)

### Smoke tests

```bash
# Confirm homepage loads without layout errors
curl -s -o /dev/null -w "%{http_code}" https://localhost:3001 -k
# Expected: 200
```

## Documentation

- N/A: behaviour change is a pure CSS fix; no operator docs affected

Closes #322

---

## Squash commit message

```
fix: prevent projects grid overflow at narrow viewports

Added width: 100% and padding: 0 1rem to .projects-grid to stop it
expanding past the viewport inside the column-flex .sec-cont container.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```