### PR TITLE
feat: round public travel coordinates to 2 decimal places for privacy

### DIFF
--- a/backend/routes/travel.js
+++ b/backend/routes/travel.js
@@ -23,6 +23,23 @@ const TRAVEL_COLS = `
   ) AS media
 `;
 
+// Public variant: coordinates rounded to ~1km precision for privacy
+const TRAVEL_COLS_PUBLIC = `
+  p.id, p.title, p.slug, p.location,
+  p.body_markdown AS notes,
+  p.media_url, p.media_type, ROUND(p.lat, 2) AS lat, ROUND(p.lng, 2) AS lng,
+  p.post_date,
+  p.location_estimated, p.published_at, p.created_at,
+  COALESCE(
+    (SELECT json_agg(
+       json_build_object('id', pm.id, 'url', pm.media_url, 'type', pm.media_type)
+       ORDER BY pm.order_index, pm.created_at
+     )
+     FROM post_media pm WHERE pm.post_id = p.id
+    ), '[]'::json
+  ) AS media
+`;
+
 async function replaceMedia(client, postId, mediaItems) {
   await client.query('DELETE FROM post_media WHERE post_id = $1', [postId]);
   if (!mediaItems || !mediaItems.length) {
@@ -48,7 +65,7 @@ async function replaceMedia(client, postId, mediaItems) {
 router.get('/', async (req, res) => {
   try {
     const result = await pool.query(
-      `SELECT ${TRAVEL_COLS}
+      `SELECT ${TRAVEL_COLS_PUBLIC}
        FROM posts p
        WHERE p.post_type = 'travel' AND p.published_at IS NOT NULL
        ORDER BY p.post_date DESC, p.created_at DESC`
@@ -95,7 +112,7 @@ router.get('/admin/:id', authenticate, async (req, res) => {
 router.get('/:id', async (req, res) => {
   try {
     const result = await pool.query(
-      `SELECT ${TRAVEL_COLS} FROM posts p
+      `SELECT ${TRAVEL_COLS_PUBLIC} FROM posts p
        WHERE p.id = $1 AND p.post_type = 'travel' AND p.published_at IS NOT NULL`,
       [req.params.id]
     );


### PR DESCRIPTION
## Summary

- Added `TRAVEL_COLS_PUBLIC` constant with `ROUND(p.lat, 2) AS lat, ROUND(p.lng, 2) AS lng` (~1km precision)
- Public endpoints `GET /travel` and `GET /travel/:id` now use `TRAVEL_COLS_PUBLIC`
- Admin endpoints (`GET /travel/all`, `GET /travel/admin/:id`) are unchanged — full precision retained for editing
- No schema changes — query-layer only. `lat`/`lng` are `DECIMAL(9,6)` so `ROUND(col, 2)` works directly

## Changes

- `backend/routes/travel.js` — add `TRAVEL_COLS_PUBLIC` constant; switch two public routes to use it

## Test plan

### Automated

```bash
# Run travel route tests — all 4 should pass
docker compose exec backend npm test -- tests/routes/travel
# Expected: 4 passed
```

### Manual

```bash
# 1. Create a travel post with known coordinates via admin, or check an existing one
# GET the post from the public endpoint and verify coordinates are rounded to 2dp

# From inside the container (replace <id> with a real travel post id):
curl -s http://localhost:8080/travel/<id> | grep -E '"lat"|"lng"'
# Expected: values like 51.51 and -0.13, not 51.507400 and -0.127800

# 2. Confirm admin endpoint still returns full precision
# (requires valid JWT — check via admin panel network tab)
```

```bash
# 3. Confirm public listing is also rounded
curl -s http://localhost:8080/travel | python3 -c "import sys,json; rows=json.load(sys.stdin); print(rows[0]['lat'], rows[0]['lng']) if rows else print('no rows')"
# Expected: values with at most 2 decimal places
```

### Smoke tests

```bash
# Confirm travel listing endpoint responds
curl -s -o /dev/null -w "%{http_code}" https://localhost:3001/api/travel -k
# Expected: 200
```

## Documentation

- N/A: no operator workflow or API contract change that affects docs (rounding is a transparent privacy improvement; field names unchanged)

Closes #244

---

## Squash commit message

```
feat: round public travel coordinates to 2 decimal places for privacy

Added TRAVEL_COLS_PUBLIC with ROUND(lat, 2)/ROUND(lng, 2); public
GET /travel and GET /travel/:id use it. Admin endpoints unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```