### PR TITLE
release: 2026-05-31

### DIFF
--- a/.env.dev-server.example
+++ b/.env.dev-server.example
@@ -39,7 +39,7 @@ UPLOADS_VOLUME_NAME=
 # ── Deploy ───────────────────────────────────────────────────────────────────
 CERT_MODE=self-signed
 ROLLBACK_BRANCH=dev
-BACKUP_DIR=~/backups/dev
+BACKUP_DIR=~/backups/dev       # ~/... is expanded to $HOME by deploy-lib.sh; absolute paths also work
 
 # ── Database ─────────────────────────────────────────────────────────────────
 DB_NAME=portfolio_dev

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __MACOSX/
 uploads/*
 !uploads/.gitkeep
 test-results/
+backend/coverage/
+scripts/config/certs/
+.env.bak-*
+/~/

--- a/admin/deploy.html
+++ b/admin/deploy.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Deploy | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card" id="deploy-section">
+                <h2 class="admin-card-title">Deployment</h2>
+                <div id="deploy-status-row" class="deploy-status-row">
+                    <span class="hint">Loading…</span>
+                </div>
+                <div class="form-actions" style="margin-top:1rem">
+                    <button type="button" id="fetch-btn" class="btn-secondary" disabled>Fetch</button>
+                    <button type="button" id="deploy-btn" class="btn-primary" disabled>Deploy latest</button>
+                    <button type="button" id="rollback-btn" class="btn-secondary" disabled>Rollback…</button>
+                </div>
+                <div id="rollback-picker" class="hidden" style="margin-top:0.75rem">
+                    <label>Roll back to
+                        <select id="rollback-sha-select"></select>
+                    </label>
+                    <div class="form-actions" style="margin-top:0.5rem">
+                        <button type="button" id="rollback-confirm-btn" class="btn-small btn-danger">Confirm rollback</button>
+                        <button type="button" id="rollback-cancel-btn" class="btn-secondary">Cancel</button>
+                    </div>
+                </div>
+                <pre id="deploy-output" class="deploy-output hidden"></pre>
+                <p id="deploy-message" class="admin-message"></p>
+                <div id="deploy-log-section" style="margin-top:1.5rem">
+                    <h3 style="font-size:0.9rem;color:var(--color-text-muted);margin-bottom:0.5rem">Deploy history</h3>
+                    <div id="deploy-log-list"><p class="hint">Loading…</p></div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script type="module" src="/resources/js/admin-deploy-page.js"></script>
+</body>
+</html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -5,22 +5,19 @@
     <script type="module" src="/resources/js/error-logger.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Admin Dashboard | AK Portfolio</title>
+    <title>Admin | AK Portfolio</title>
     <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
     <link rel="stylesheet" href="/resources/css/reset.css" />
     <link rel="stylesheet" href="/resources/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <!-- Leaflet for geocode confirmation map -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </head>
 <body>
     <header>
         <h1>A|K</h1>
         <h2>Andy | Keys</h2>
-        <h2>Admin Dashboard</h2>
+        <h2>Admin</h2>
     </header>
     <nav>
         <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
@@ -37,204 +34,46 @@
     </nav>
 
     <main class="admin-page">
-        <section class="sec-cont admin-panel">
-
-            <!-- ── Travel memories ───────────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2 class="admin-card-title">Travel memories</h2>
-                <form id="travel-form">
-                    <input type="hidden" id="travel-edit-id" value="" />
-                    <label>Title
-                        <input id="travel-title" type="text" placeholder="Trip title" />
-                    </label>
-                    <label>Date of visit
-                        <input id="travel-date" type="date" />
-                    </label>
-                    <label>Location
-                        <div class="location-row">
-                            <input id="travel-location" type="text" placeholder="City, country" />
-                            <button type="button" id="geocode-btn" class="btn-secondary" title="Look up coordinates from location name">Geocode</button>
-                        </div>
-                    </label>
-                    <label>Notes
-                        <textarea id="travel-notes" rows="4" placeholder="Describe the moment…"></textarea>
-                    </label>
-                    <!-- Issue #30: multi-file input with preview list -->
-                    <label>Photos / videos
-                        <div class="file-input-wrap">
-                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photos or videos">Add files…</button>
-                            <span class="file-input-label">No files chosen</span>
-                            <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" multiple />
-                        </div>
-                    </label>
-                    <div id="travel-media-list" class="media-list hidden"></div>
-                    <!-- Issue #39: custom coordinate steppers replacing native spinners -->
-                    <div class="coord-row">
-                        <label>Latitude
-                            <div class="coord-stepper">
-                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="-1" aria-label="Decrease latitude">−</button>
-                                <input id="travel-lat" type="number" step="0.000001" placeholder="e.g. 51.5074" />
-                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="1" aria-label="Increase latitude">+</button>
-                            </div>
-                        </label>
-                        <label>Longitude
-                            <div class="coord-stepper">
-                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="-1" aria-label="Decrease longitude">−</button>
-                                <input id="travel-lng" type="number" step="0.000001" placeholder="e.g. -0.1278" />
-                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="1" aria-label="Increase longitude">+</button>
-                            </div>
-                        </label>
-                    </div>
-                    <!-- Geocode confirmation map: hidden until coords are set -->
-                    <div id="geoconfirm-map" class="hidden" style="height:200px;margin-top:0.5rem;border-radius:var(--radius-md);overflow:hidden;"></div>
-                    <div class="form-actions">
-                        <button type="submit" id="travel-save-btn" class="btn-primary">Save draft</button>
-                        <button type="submit" id="travel-publish-btn" class="btn-primary">Publish</button>
-                        <button type="button" id="travel-clear" class="btn-secondary">Clear</button>
-                        <button type="button" id="travel-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
-                    </div>
-                </form>
-                <p id="travel-message" class="admin-message"></p>
-                <div id="travel-preview" class="travel-preview hidden">
-                    <h4>Preview</h4>
-                    <div class="preview-media"></div>
-                    <div class="preview-text"></div>
-                </div>
-                <div class="saved-memories">
-                    <h3 class="saved-list-title">Saved memories</h3>
-                    <div id="saved-memories-list">
-                        <p class="hint">Loading…</p>
-                    </div>
-                </div>
+        <section class="sec-cont">
+            <div class="admin-dashboard-grid">
+                <a href="/admin/posts.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">✏</span>
+                    <span class="admin-dashboard-card-title">Posts</span>
+                    <span class="admin-dashboard-card-desc">Write and manage blog posts</span>
+                </a>
+                <a href="/admin/travel.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">✈</span>
+                    <span class="admin-dashboard-card-title">Travel</span>
+                    <span class="admin-dashboard-card-desc">Log travel memories and photos</span>
+                </a>
+                <a href="/admin/deploy.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">⚡</span>
+                    <span class="admin-dashboard-card-title">Deploy</span>
+                    <span class="admin-dashboard-card-desc">Deploy, rollback, and monitor</span>
+                </a>
+                <a href="/admin/media.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">📁</span>
+                    <span class="admin-dashboard-card-title">Media</span>
+                    <span class="admin-dashboard-card-desc">CV upload and private notes</span>
+                </a>
+                <a href="/admin/stats.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">📊</span>
+                    <span class="admin-dashboard-card-title">Stats</span>
+                    <span class="admin-dashboard-card-desc">Site visit statistics</span>
+                </a>
+                <a href="/admin/settings.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">⚙</span>
+                    <span class="admin-dashboard-card-title">Settings</span>
+                    <span class="admin-dashboard-card-desc">Manage passkeys and account</span>
+                </a>
             </div>
-
-            <!-- ── Blog posts ──────────────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2 class="admin-card-title">Blog posts</h2>
-                <form id="post-form">
-                    <input type="hidden" id="post-edit-id" value="" />
-                    <label>Title
-                        <input id="post-title" type="text" placeholder="Post title" />
-                    </label>
-                    <label>Date
-                        <input id="post-date" type="date" />
-                    </label>
-                    <label>Body (Markdown)
-                        <textarea id="post-body" rows="10" placeholder="Write in Markdown…"></textarea>
-                    </label>
-                    <div class="form-actions">
-                        <button type="submit" id="post-save-btn" class="btn-primary">Save draft</button>
-                        <button type="submit" id="post-publish-btn" class="btn-primary">Publish</button>
-                        <button type="button" id="post-template-btn" class="btn-secondary">Insert template</button>
-                        <button type="button" id="post-clear-btn" class="btn-secondary">Clear</button>
-                        <button type="button" id="post-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
-                    </div>
-                </form>
-                <p id="post-message" class="admin-message"></p>
-                <div class="saved-memories">
-                    <h3 class="saved-list-title">All posts</h3>
-                    <div id="posts-admin-list">
-                        <p class="hint">Loading…</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- ── CV management (#101) ──────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2 class="admin-card-title">CV</h2>
-                <p class="hint" style="margin-bottom:1rem">
-                    Upload a PDF CV to make it available for download on the site.
-                    The file will be scanned for obvious private information before publishing.
-                </p>
-                <div style="margin-bottom:1rem">
-                    <span id="cv-status-badge" class="cv-status-badge not-uploaded">Checking…</span>
-                </div>
-                <div class="file-input-wrap" style="margin-bottom:0.25rem">
-                    <button type="button" id="cv-file-btn" class="btn-secondary" aria-label="Choose CV PDF">Choose PDF…</button>
-                    <span id="cv-file-label" class="file-input-label">No file chosen</span>
-                    <input id="cv-file-input" type="file" accept="application/pdf" class="file-input-hidden" />
-                </div>
-                <!-- Rename notice: shown when selected file is not already named cv.pdf (#110) -->
-                <p id="cv-rename-notice" class="hint" style="display:none;margin-bottom:0.75rem;color:var(--color-text-secondary)">
-                    ℹ Your file will be saved as <strong>cv.pdf</strong>
-                </p>
-                <div class="form-actions">
-                    <button type="button" id="cv-upload-btn" class="btn-primary" disabled>Upload CV</button>
-                    <button type="button" id="cv-delete-btn" class="btn-small btn-danger" disabled>Delete CV</button>
-                </div>
-                <p id="cv-message" class="admin-message"></p>
-            </div>
-
-            <!-- ── Private notes ─────────────────────────────────────────────────── -->
-            <div class="admin-card private-card">
-                <h2 class="admin-card-title">Private coding projects</h2>
-                <label>Private notes
-                    <textarea id="private-notes" rows="6" placeholder="Save private project ideas here…"></textarea>
-                </label>
-                <div class="form-actions">
-                    <button id="save-private" type="button" class="btn-primary">Save notes</button>
-                    <button id="clear-private" type="button" class="btn-secondary">Clear notes</button>
-                </div>
-                <p class="hint" style="margin-top:0.75rem">Notes are saved locally in your browser.</p>
-            </div>
-
-            <!-- ── Site stats ──────────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2>Site visits</h2>
-                <div id="stats-list">
-                    <p class="hint">Loading…</p>
-                </div>
-            </div>
-
-            <!-- ── Deployment (#98 / #117 / #129) ───────────────────────────────── -->
-            <div class="admin-card" id="deploy-section">
-                <h2 class="admin-card-title">Deployment</h2>
-                <div id="deploy-status-row" class="deploy-status-row">
-                    <span class="hint">Loading…</span>
-                </div>
-                <div class="form-actions" style="margin-top:1rem">
-                    <button type="button" id="fetch-btn" class="btn-secondary" disabled>Fetch</button>
-                    <button type="button" id="deploy-btn" class="btn-primary" disabled>Deploy latest</button>
-                    <button type="button" id="rollback-btn" class="btn-secondary" disabled>Rollback…</button>
-                </div>
-                <div id="rollback-picker" class="hidden" style="margin-top:0.75rem">
-                    <label>Roll back to
-                        <select id="rollback-sha-select"></select>
-                    </label>
-                    <div class="form-actions" style="margin-top:0.5rem">
-                        <button type="button" id="rollback-confirm-btn" class="btn-small btn-danger">Confirm rollback</button>
-                        <button type="button" id="rollback-cancel-btn" class="btn-secondary">Cancel</button>
-                    </div>
-                </div>
-                <pre id="deploy-output" class="deploy-output hidden"></pre>
-                <p id="deploy-message" class="admin-message"></p>
-                <div id="deploy-log-section" style="margin-top:1.5rem">
-                    <h3 style="font-size:0.9rem;color:var(--color-text-muted);margin-bottom:0.5rem">Deploy history</h3>
-                    <div id="deploy-log-list"><p class="hint">Loading…</p></div>
-                </div>
-            </div>
-
-            <!-- ── Passkeys ─────────────────────────────────────────────────────── -->
-            <div class="admin-card">
-                <h2 class="admin-card-title">Manage passkeys</h2>
-                <p style="color:var(--color-text-secondary);margin-bottom:1rem">Passkeys let you sign in with your device's biometrics or PIN — no password needed.</p>
-                <div id="passkey-list">
-                    <p class="hint">Loading passkeys…</p>
-                </div>
-                <div class="form-actions" style="margin-top:1rem">
-                    <button id="add-passkey-btn" type="button" class="btn-primary">Add passkey</button>
-                </div>
-                <p id="passkey-message" class="admin-message"></p>
-            </div>
-
         </section>
     </main>
 
-    <!-- Issue #33: dev environment indicator -->
     <script src="/resources/js/dev-env.js"></script>
     <script src="/resources/js/darkmode.js"></script>
     <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
     <script type="module" src="/resources/js/admin.js"></script>
-    <script src="/resources/js/admin-init.js"></script>
 </body>
 </html>

--- a/admin/media.html
+++ b/admin/media.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Media | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+
+            <!-- CV management -->
+            <div class="admin-card">
+                <h2 class="admin-card-title">CV</h2>
+                <p class="hint" style="margin-bottom:1rem">
+                    Upload a PDF CV to make it available for download on the site.
+                    The file will be scanned for obvious private information before publishing.
+                </p>
+                <div style="margin-bottom:1rem">
+                    <span id="cv-status-badge" class="cv-status-badge not-uploaded">Checking…</span>
+                </div>
+                <div class="file-input-wrap" style="margin-bottom:0.25rem">
+                    <button type="button" id="cv-file-btn" class="btn-secondary" aria-label="Choose CV PDF">Choose PDF…</button>
+                    <span id="cv-file-label" class="file-input-label">No file chosen</span>
+                    <input id="cv-file-input" type="file" accept="application/pdf" class="file-input-hidden" />
+                </div>
+                <p id="cv-rename-notice" class="hint" style="display:none;margin-bottom:0.75rem;color:var(--color-text-secondary)">
+                    ℹ Your file will be saved as <strong>cv.pdf</strong>
+                </p>
+                <div class="form-actions">
+                    <button type="button" id="cv-upload-btn" class="btn-primary" disabled>Upload CV</button>
+                    <button type="button" id="cv-delete-btn" class="btn-small btn-danger" disabled>Delete CV</button>
+                </div>
+                <p id="cv-message" class="admin-message"></p>
+            </div>
+
+            <!-- Private notes -->
+            <div class="admin-card private-card">
+                <h2 class="admin-card-title">Private coding projects</h2>
+                <label>Private notes
+                    <textarea id="private-notes" rows="6" placeholder="Save private project ideas here…"></textarea>
+                </label>
+                <div class="form-actions">
+                    <button id="save-private" type="button" class="btn-primary">Save notes</button>
+                    <button id="clear-private" type="button" class="btn-secondary">Clear notes</button>
+                </div>
+                <p class="hint" style="margin-top:0.75rem">Notes are saved locally in your browser.</p>
+            </div>
+
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script src="/resources/js/admin-init.js"></script>
+    <script type="module" src="/resources/js/admin-media-page.js"></script>
+</body>
+</html>

--- a/admin/posts.html
+++ b/admin/posts.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Posts | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card">
+                <h2 class="admin-card-title">Blog posts</h2>
+                <form id="post-form">
+                    <input type="hidden" id="post-edit-id" value="" />
+                    <label>Title
+                        <input id="post-title" type="text" placeholder="Post title" />
+                    </label>
+                    <label>Date
+                        <input id="post-date" type="date" />
+                    </label>
+                    <label>Body (Markdown)
+                        <textarea id="post-body" rows="10" placeholder="Write in Markdown…"></textarea>
+                    </label>
+                    <div class="form-actions">
+                        <button type="submit" id="post-save-btn" class="btn-primary">Save draft</button>
+                        <button type="submit" id="post-publish-btn" class="btn-primary">Publish</button>
+                        <button type="button" id="post-template-btn" class="btn-secondary">Insert template</button>
+                        <button type="button" id="post-clear-btn" class="btn-secondary">Clear</button>
+                        <button type="button" id="post-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
+                    </div>
+                </form>
+                <p id="post-message" class="admin-message"></p>
+                <div class="saved-memories">
+                    <h3 class="saved-list-title">All posts</h3>
+                    <div id="posts-admin-list">
+                        <p class="hint">Loading…</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script src="/resources/js/admin-init.js"></script>
+    <script type="module" src="/resources/js/admin-posts-page.js"></script>
+</body>
+</html>

--- a/admin/settings.html
+++ b/admin/settings.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Settings | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card">
+                <h2 class="admin-card-title">Manage passkeys</h2>
+                <p style="color:var(--color-text-secondary);margin-bottom:1rem">Passkeys let you sign in with your device's biometrics or PIN — no password needed.</p>
+                <div id="passkey-list">
+                    <p class="hint">Loading passkeys…</p>
+                </div>
+                <div class="form-actions" style="margin-top:1rem">
+                    <button id="add-passkey-btn" type="button" class="btn-primary">Add passkey</button>
+                </div>
+                <p id="passkey-message" class="admin-message"></p>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script type="module" src="/resources/js/admin-settings-page.js"></script>
+</body>
+</html>

--- a/admin/stats.html
+++ b/admin/stats.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Stats | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card">
+                <h2 class="admin-card-title">Site visits</h2>
+                <div id="stats-list">
+                    <p class="hint">Loading…</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script type="module" src="/resources/js/admin-stats-page.js"></script>
+</body>
+</html>

--- a/admin/travel.html
+++ b/admin/travel.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Travel | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Leaflet for geocode confirmation map -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card">
+                <h2 class="admin-card-title">Travel memories</h2>
+                <form id="travel-form">
+                    <input type="hidden" id="travel-edit-id" value="" />
+                    <label>Title
+                        <input id="travel-title" type="text" placeholder="Trip title" />
+                    </label>
+                    <label>Date of visit
+                        <input id="travel-date" type="date" />
+                    </label>
+                    <label>Location
+                        <div class="location-row">
+                            <input id="travel-location" type="text" placeholder="City, country" />
+                            <button type="button" id="geocode-btn" class="btn-secondary" title="Look up coordinates from location name">Geocode</button>
+                        </div>
+                    </label>
+                    <label>Notes
+                        <textarea id="travel-notes" rows="4" placeholder="Describe the moment…"></textarea>
+                    </label>
+                    <label>Photos / videos
+                        <div class="file-input-wrap">
+                            <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photos or videos">Add files…</button>
+                            <span class="file-input-label">No files chosen</span>
+                            <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" multiple />
+                        </div>
+                    </label>
+                    <div id="travel-media-list" class="media-list hidden"></div>
+                    <div class="coord-row">
+                        <label>Latitude
+                            <div class="coord-stepper">
+                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="-1" aria-label="Decrease latitude">−</button>
+                                <input id="travel-lat" type="number" step="0.000001" placeholder="e.g. 51.5074" />
+                                <button type="button" class="coord-step-btn" data-target="travel-lat" data-dir="1" aria-label="Increase latitude">+</button>
+                            </div>
+                        </label>
+                        <label>Longitude
+                            <div class="coord-stepper">
+                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="-1" aria-label="Decrease longitude">−</button>
+                                <input id="travel-lng" type="number" step="0.000001" placeholder="e.g. -0.1278" />
+                                <button type="button" class="coord-step-btn" data-target="travel-lng" data-dir="1" aria-label="Increase longitude">+</button>
+                            </div>
+                        </label>
+                    </div>
+                    <div id="geoconfirm-map" class="hidden" style="height:200px;margin-top:0.5rem;border-radius:var(--radius-md);overflow:hidden;"></div>
+                    <div class="form-actions">
+                        <button type="submit" id="travel-save-btn" class="btn-primary">Save draft</button>
+                        <button type="submit" id="travel-publish-btn" class="btn-primary">Publish</button>
+                        <button type="button" id="travel-clear" class="btn-secondary">Clear</button>
+                        <button type="button" id="travel-cancel-btn" class="btn-secondary hidden">Cancel edit</button>
+                    </div>
+                </form>
+                <p id="travel-message" class="admin-message"></p>
+                <div id="travel-preview" class="travel-preview hidden">
+                    <h4>Preview</h4>
+                    <div class="preview-media"></div>
+                    <div class="preview-text"></div>
+                </div>
+                <div class="saved-memories">
+                    <h3 class="saved-list-title">Saved memories</h3>
+                    <div id="saved-memories-list">
+                        <p class="hint">Loading…</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script src="/resources/js/admin-init.js"></script>
+    <script type="module" src="/resources/js/admin-travel-page.js"></script>
+</body>
+</html>

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "test:error-logger:browser": "node ./scripts/tests/test-error-logger-browser.js",
     "test:csp-violations": "node ./scripts/tests/test-csp-violations.js",
     "test:admin-e2e": "node ./scripts/tests/test-admin-e2e.js",
-    "test:admin-e2e-csp": "node ./scripts/tests/test-admin-e2e-csp.js"
+    "test:admin-e2e-csp": "node ./scripts/tests/test-admin-e2e-csp.js",
+    "test:public-pages": "node ./scripts/tests/test-public-pages.js"
   },
   "dependencies": {
     "@simplewebauthn/server": "^7.4.0",

--- a/backend/routes/travel.js
+++ b/backend/routes/travel.js
@@ -23,6 +23,23 @@ const TRAVEL_COLS = `
   ) AS media
 `;
 
+// Public variant: coordinates rounded to ~1km precision for privacy
+const TRAVEL_COLS_PUBLIC = `
+  p.id, p.title, p.slug, p.location,
+  p.body_markdown AS notes,
+  p.media_url, p.media_type, ROUND(p.lat, 2) AS lat, ROUND(p.lng, 2) AS lng,
+  p.post_date,
+  p.location_estimated, p.published_at, p.created_at,
+  COALESCE(
+    (SELECT json_agg(
+       json_build_object('id', pm.id, 'url', pm.media_url, 'type', pm.media_type)
+       ORDER BY pm.order_index, pm.created_at
+     )
+     FROM post_media pm WHERE pm.post_id = p.id
+    ), '[]'::json
+  ) AS media
+`;
+
 async function replaceMedia(client, postId, mediaItems) {
   await client.query('DELETE FROM post_media WHERE post_id = $1', [postId]);
   if (!mediaItems || !mediaItems.length) {
@@ -48,7 +65,7 @@ async function replaceMedia(client, postId, mediaItems) {
 router.get('/', async (req, res) => {
   try {
     const result = await pool.query(
-      `SELECT ${TRAVEL_COLS}
+      `SELECT ${TRAVEL_COLS_PUBLIC}
        FROM posts p
        WHERE p.post_type = 'travel' AND p.published_at IS NOT NULL
        ORDER BY p.post_date DESC, p.created_at DESC`
@@ -95,7 +112,7 @@ router.get('/admin/:id', authenticate, async (req, res) => {
 router.get('/:id', async (req, res) => {
   try {
     const result = await pool.query(
-      `SELECT ${TRAVEL_COLS} FROM posts p
+      `SELECT ${TRAVEL_COLS_PUBLIC} FROM posts p
        WHERE p.id = $1 AND p.post_type = 'travel' AND p.published_at IS NOT NULL`,
       [req.params.id]
     );

--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -152,10 +152,14 @@ try {
     req.continue();
   });
 
-  // Collect console errors from the page for smoke checks.
+  // Collect console errors and unhandled JS exceptions for smoke checks (#397).
   const consoleErrors = [];
+  const pageErrors = [];
   page.on('console', msg => {
     if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', err => {
+    if (!err.message.includes('-extension://')) pageErrors.push(err.message);
   });
 
   // Auto-accept all confirm() dialogs (delete confirmations, etc.).
@@ -184,6 +188,10 @@ try {
   // Filter known noise (zlib warning from exifr is cosmetic and not a code error)
   const realErrors = consoleErrors.filter(e => !e.includes('zlib'));
   smoke('No JS console errors on page load', realErrors.length === 0, realErrors.join('; '));
+
+  // S2b: no unhandled JS exceptions on load (#397)
+  smoke('No unhandled JS exceptions on page load', pageErrors.length === 0, pageErrors.join('; '));
+  const pageErrorsAtLoad = pageErrors.length; // snapshot — S-final only reports new errors from interactions
 
   // S3–S8: each section present in DOM
   const sections = [
@@ -330,46 +338,58 @@ try {
     interact('Deploy fetch — output appeared', false, e.message);
   }
 
+  // S-final: no unhandled JS exceptions fired during interactions (#397)
+  // Uses pageErrorsAtLoad snapshot so errors already reported in S2b aren't double-counted.
+  const interactionPageErrors = pageErrors.slice(pageErrorsAtLoad);
+  smoke(
+    'No unhandled JS exceptions during interactions',
+    interactionPageErrors.length === 0,
+    interactionPageErrors.join('; '),
+  );
+
 } catch (err) {
   console.error('\n💥 Test runner crashed:', err.message);
   failures.push('runner crash: ' + err.message);
 } finally {
   // ── Cleanup: delete any [E2E] test data the tests didn't clean up ─────────
-  // Uses the API directly with the test token — no browser page needed.
-  // Best-effort: failures here don't affect the test result.
-  try {
-    const headers = { Authorization: `Bearer ${testToken}`, 'Content-Type': 'application/json' };
-    const https = await import('https');
-    const agent = new https.Agent({ rejectUnauthorized: false });
-
-    const checkAndDelete = async (listUrl, deleteBase) => {
-      try {
-        const { default: fetch } = await import('node-fetch').catch(() => ({ default: null }));
-        if (!fetch) return; // node-fetch not available — skip best-effort cleanup
-        const r = await fetch(listUrl, { headers, agent });
-        if (!r.ok) return;
-        const items = await r.json();
-        for (const item of items) {
-          if (item.title?.startsWith(TEST_PREFIX)) {
-            await fetch(`${deleteBase}/${item.id}`, { method: 'DELETE', headers, agent });
-            console.log(`  cleaned up: ${item.title}`);
-          }
-        }
-      } catch { /* best effort */ }
-    };
-
-    await checkAndDelete(`${baseUrl}/api/posts/all`, `${baseUrl}/api/posts`);
-    await checkAndDelete(`${baseUrl}/api/travel/all`, `${baseUrl}/api/travel`);
-  } catch { /* best effort */ }
-
+  // Uses the browser page (still open) to make authenticated API calls so the
+  // browser's --ignore-certificate-errors covers the self-signed dev cert —
+  // no rejectUnauthorized bypass in Node code. Best-effort: failures here
+  // don't affect the test result.
   if (browser) {
     try {
+      const cleanupPage = await browser.newPage();
+      const authHeaders = { Authorization: `Bearer ${testToken}`, 'Content-Type': 'application/json' };
+
+      const checkAndDelete = async (listUrl, deleteBase) => {
+        try {
+          const items = await cleanupPage.evaluate(async (url, headers) => {
+            try {
+              const r = await fetch(url, { headers });
+              return r.ok ? r.json() : [];
+            } catch { return []; }
+          }, listUrl, authHeaders);
+          for (const item of (items || [])) {
+            if (item.title?.startsWith(TEST_PREFIX)) {
+              await cleanupPage.evaluate(async (url, headers) => {
+                try { await fetch(url, { method: 'DELETE', headers }); } catch {}
+              }, `${deleteBase}/${item.id}`, authHeaders);
+              console.log(`  cleaned up: ${item.title}`);
+            }
+          }
+        } catch { /* best effort */ }
+      };
+
+      await checkAndDelete(`${baseUrl}/api/posts/all`, `${baseUrl}/api/posts`);
+      await checkAndDelete(`${baseUrl}/api/travel/all`, `${baseUrl}/api/travel`);
+
       const pages = await browser.pages();
       for (const p of pages) {
         await p.evaluate(() => {
           try { localStorage.removeItem('adminToken'); } catch {}
         }).catch(() => {});
       }
+      await cleanupPage.close();
     } catch {}
     await browser.close();
   }

--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -193,30 +193,17 @@ try {
   smoke('No unhandled JS exceptions on page load', pageErrors.length === 0, pageErrors.join('; '));
   const pageErrorsAtLoad = pageErrors.length; // snapshot — S-final only reports new errors from interactions
 
-  // S3–S8: each section present in DOM
-  const sections = [
-    ['Travel form',       '#travel-form'],
-    ['Posts form',        '#post-form'],
-    ['Deploy section',    '#deploy-section'],
-    ['CV section',        '#cv-status-badge'],
-    ['Stats section',     '#stats-list'],
-    ['Notes section',     '#private-notes'],
-    ['Passkeys section',  '#passkey-list'],
-  ];
-  for (const [label, sel] of sections) {
-    const exists = await page.$(sel) !== null;
-    smoke(`${label} present`, exists, `${sel} not found`);
+  // S3: admin sub-nav present and Dashboard is the active item (#378)
+  const subnavExists = await page.$('.admin-subnav') !== null;
+  smoke('Admin sub-nav present', subnavExists, '.admin-subnav not found');
+  if (subnavExists) {
+    const activeLabel = await page.$eval('.admin-subnav-item.active', el => el.textContent.trim()).catch(() => '');
+    smoke('Dashboard active in sub-nav', activeLabel.includes('Dashboard'), `active item: "${activeLabel}"`);
   }
 
-  // S9: deploy status loaded (not crashing — text is not the loading placeholder)
-  try {
-    await waitForText(page, '#deploy-status-row', '?', 5000)
-      .catch(() => {}); // may already have content
-    const statusText = await page.$eval('#deploy-status-row', el => el.textContent.trim());
-    smoke('Deploy status row has content', statusText.length > 0, 'empty status row');
-  } catch (e) {
-    smoke('Deploy status row has content', false, e.message);
-  }
+  // S4: all 6 dashboard navigation cards present (#378)
+  const cardCount = await page.$$eval('.admin-dashboard-card', els => els.length).catch(() => 0);
+  smoke('Dashboard has 6 navigation cards', cardCount === 6, `found ${cardCount}`);
 
   // ── Interaction tests ────────────────────────────────────────────────────
 
@@ -224,6 +211,7 @@ try {
 
   // ── I1: create a blog post ───────────────────────────────────────────────
   console.log('\n📝 I1 — create blog post');
+  await page.goto(`${baseUrl}/admin/posts.html`, { waitUntil: 'networkidle0', timeout: 20000 });
   try {
     await page.waitForSelector('#post-title', { timeout: 5000 });
     await page.$eval('#post-title', el => { el.value = ''; });
@@ -273,6 +261,7 @@ try {
 
   // ── I3: create a travel memory ───────────────────────────────────────────
   console.log('\n🌍 I3 — create travel memory');
+  await page.goto(`${baseUrl}/admin/travel.html`, { waitUntil: 'networkidle0', timeout: 20000 });
   try {
     await page.waitForSelector('#travel-title', { timeout: 5000 });
     await page.$eval('#travel-title', el => { el.value = ''; });
@@ -319,6 +308,7 @@ try {
 
   // ── I5: deploy fetch streams output ──────────────────────────────────────
   console.log('\n📡 I5 — deploy fetch (git fetch origin)');
+  await page.goto(`${baseUrl}/admin/deploy.html`, { waitUntil: 'networkidle0', timeout: 20000 });
   try {
     await page.waitForSelector('#fetch-btn:not([disabled])', { timeout: 8000 });
     await page.click('#fetch-btn');

--- a/backend/scripts/tests/test-public-pages.js
+++ b/backend/scripts/tests/test-public-pages.js
@@ -28,7 +28,12 @@ if (!baseUrl) {
 }
 
 // Static pages always included — individual content pages added dynamically below.
-const STATIC_PAGES = ['/', '/blog/', '/travel/', '/login/', '/setup/'];
+const STATIC_PAGES = [
+    '/', '/blog/', '/travel/', '/login/', '/setup/',
+    // Admin sub-pages (#378) — unauthenticated load still runs all page JS before the auth redirect
+    '/admin/', '/admin/posts.html', '/admin/travel.html', '/admin/deploy.html',
+    '/admin/media.html', '/admin/stats.html', '/admin/settings.html',
+];
 
 // ── Dynamic slug discovery ────────────────────────────────────────────────────
 

--- a/backend/scripts/tests/test-public-pages.js
+++ b/backend/scripts/tests/test-public-pages.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Load each public page in a real browser and fail if any unhandled JS
+ * exceptions occur. Catches the class of errors (null dereferences, failed
+ * imports) that curl-based smoke tests cannot see.
+ *
+ * Discovered during #389 (jQuery removal): blog and travel pages had JS errors
+ * that the HTTP smoke suite did not flag. Only visible once a browser ran the
+ * page JS.
+ *
+ * Usage: node test-public-pages.js <base-url>
+ * Example: node test-public-pages.js https://nginx:3001
+ *
+ * Exits 0 if all pages load without unhandled JS errors.
+ * Exits 1 if any page throws an unhandled exception.
+ *
+ * IMPORTANT: intercepts POST /api/debug/errors so headless-Chromium internal
+ * noise ("Couldn't load fs/zlib" etc.) does not write to the live client_errors
+ * table and trigger false alert emails.
+ */
+
+import puppeteer from 'puppeteer';
+
+const baseUrl = process.argv[2];
+if (!baseUrl) {
+  console.error('Usage: node test-public-pages.js <base-url>');
+  process.exit(1);
+}
+
+// Static pages always included — individual content pages added dynamically below.
+const STATIC_PAGES = ['/', '/blog/', '/travel/', '/login/', '/setup/'];
+
+// ── Dynamic slug discovery ────────────────────────────────────────────────────
+
+// Fetch the first item from an API endpoint and return the value of `field`.
+// Uses a puppeteer page so the browser's --ignore-certificate-errors flag
+// handles the self-signed dev cert — no Node-level TLS bypass needed.
+// Returns null if the request fails or no item is found.
+async function fetchFirstField(browser, apiPath, field) {
+  const page = await browser.newPage();
+  try {
+    const items = await page.evaluate(async (url) => {
+      try {
+        const res = await fetch(url);
+        return res.ok ? res.json() : null;
+      } catch { return null; }
+    }, `${baseUrl}${apiPath}`);
+    const found = Array.isArray(items) ? items.find((i) => i[field]) : null;
+    return found ? found[field] : null;
+  } catch {
+    return null;
+  } finally {
+    await page.close();
+  }
+}
+
+// ── Test runner ───────────────────────────────────────────────────────────────
+
+let browser;
+const results = { passed: [], failed: [] };
+
+async function testPage(page, path) {
+  const url = `${baseUrl}${path}`;
+  const pageErrors = [];
+
+  await page.setRequestInterception(true);
+  page.on('request', (req) => {
+    if (req.method() === 'POST' && req.url().includes('/api/debug/errors')) {
+      req.respond({ status: 200, contentType: 'application/json', body: '{"received":true}' });
+      return;
+    }
+    req.continue();
+  });
+
+  page.on('pageerror', (err) => {
+    if (!err.message.includes('-extension://')) {
+      pageErrors.push(err.message);
+    }
+  });
+
+  let response;
+  try {
+    response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
+  } catch (err) {
+    results.failed.push(`${path} — navigation failed: ${err.message}`);
+    console.log(`  ❌ ${path} — navigation failed: ${err.message}`);
+    return;
+  }
+
+  const status = response ? response.status() : 0;
+  // 401 is expected for pages that redirect unauthenticated users — still load the page JS
+  if (!response || (status >= 400 && status !== 401)) {
+    results.failed.push(`${path} — HTTP ${status}`);
+    console.log(`  ❌ ${path} — HTTP ${status}`);
+    return;
+  }
+
+  // Allow deferred module imports and inline scripts to finish executing
+  await new Promise((r) => setTimeout(r, 1500));
+
+  if (pageErrors.length === 0) {
+    results.passed.push(path);
+    console.log(`  ✅ ${path}`);
+  } else {
+    results.failed.push(`${path} — ${pageErrors.length} JS error(s): ${pageErrors[0]}`);
+    console.log(`  ❌ ${path} — ${pageErrors.length} unhandled JS error(s):`);
+    pageErrors.forEach((e) => console.log(`     • ${e}`));
+  }
+}
+
+async function run() {
+  console.log(`\n🧪 Public Pages — JS Runtime Error Check`);
+  console.log(`📍 Base URL: ${baseUrl}\n`);
+
+  try {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--ignore-certificate-errors',
+      ],
+    });
+
+    // Discover live content slugs/ids so post pages are exercised too (#397).
+    // Done via a browser page so --ignore-certificate-errors covers the self-signed
+    // dev cert — no rejectUnauthorized bypass in Node code.
+    const [blogSlug, travelId] = await Promise.all([
+      fetchFirstField(browser, '/api/posts', 'slug'),
+      fetchFirstField(browser, '/api/travel', 'id'),
+    ]);
+
+    const pages = [...STATIC_PAGES];
+
+    if (blogSlug) {
+      pages.push(`/blog/post/?slug=${encodeURIComponent(blogSlug)}`);
+      console.log(`  ℹ️  blog post discovered: /blog/post/?slug=${blogSlug}`);
+    } else {
+      console.log('  ⚠️  no published blog post found — /blog/post/ skipped');
+    }
+
+    if (travelId) {
+      pages.push(`/travel/post/?id=${encodeURIComponent(travelId)}`);
+      console.log(`  ℹ️  travel post discovered: /travel/post/?id=${travelId}`);
+    } else {
+      console.log('  ⚠️  no travel memory found — /travel/post/ skipped');
+    }
+
+    console.log('');
+
+    for (const path of pages) {
+      const page = await browser.newPage();
+      await testPage(page, path);
+      await page.close();
+    }
+  } catch (err) {
+    results.failed.push(`Test runner crashed: ${err.message}`);
+    console.error(`\n❌ Test runner crashed: ${err.message}`);
+  } finally {
+    if (browser) await browser.close();
+
+    const total = results.passed.length + results.failed.length;
+    console.log(`\n${'='.repeat(50)}`);
+    console.log(`✅ Passed: ${results.passed.length} / ${total}`);
+    if (results.failed.length) {
+      console.log(`❌ Failed: ${results.failed.length}`);
+      results.failed.forEach((r) => console.log(`   • ${r}`));
+    }
+    console.log(`${'='.repeat(50)}`);
+    const status = results.failed.length > 0 ? 'FAIL' : 'OK';
+    console.log(
+      `[public-pages] status=${status} passed=${results.passed.length} ` +
+        `failed=${results.failed.length} total=${total}\n`,
+    );
+    process.exit(results.failed.length > 0 ? 1 : 0);
+  }
+}
+
+run().catch((err) => {
+  console.error('Unhandled error:', err);
+  process.exit(1);
+});

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,61 @@
 # Release Notes
 
+## Release 2026-05-31
+
+**Released:** 2026-05-31
+**Branch:** release/2026-05-31
+**Closes:** [#244](https://github.com/AndyRKeys/MyPortfolioSite/issues/244), [#282](https://github.com/AndyRKeys/MyPortfolioSite/issues/282), [#283](https://github.com/AndyRKeys/MyPortfolioSite/issues/283), [#322](https://github.com/AndyRKeys/MyPortfolioSite/issues/322), [#346](https://github.com/AndyRKeys/MyPortfolioSite/issues/346), [#378](https://github.com/AndyRKeys/MyPortfolioSite/issues/378), [#385](https://github.com/AndyRKeys/MyPortfolioSite/issues/385), [#387](https://github.com/AndyRKeys/MyPortfolioSite/issues/387), [#390](https://github.com/AndyRKeys/MyPortfolioSite/issues/390), [#391](https://github.com/AndyRKeys/MyPortfolioSite/issues/391), [#399](https://github.com/AndyRKeys/MyPortfolioSite/issues/399)
+
+### Summary
+
+Frontend modernisation, admin UX, auth hardening, and deploy reliability release. Removes jQuery from all public pages (87KB, −1,575 lines), refactors the admin panel into dedicated sub-pages with responsive navigation, retires the POST /auth/setup endpoint in favour of magic-link bootstrapping, and adds JS runtime checks for all pages on every deploy. Also reduces public travel coordinate precision to ~1km for privacy, fixes stale JS after deploys, protects dev certs from branch-switch deletions, and corrects a regression-script bug that was rate-locking the admin IP after every deploy.
+
+### Features
+
+**Admin sub-pages with responsive subnav (#378)**
+- Monolithic `admin/index.html` replaced with a dashboard and six dedicated sub-pages (posts, travel, deploy, CV, stats, notes/auth/passkeys)
+- `admin-subnav.js` injects a shared responsive horizontal navigation bar across all admin pages
+- Each page loads only its own JS module entry point — no unrelated code runs on load
+- E2E test updated to navigate sub-pages; JS runtime check extended to cover all admin pages
+
+**Puppeteer JS runtime check for all public pages (#390)**
+- `test-public-pages.js` added to the deploy pipeline: loads `/`, `/blog/`, `/travel/`, `/login/`, `/setup/`, and dynamically discovered blog/travel post pages after every deploy
+- Fails the deploy (warn-only) on any unhandled JS exception on public pages
+- `test-admin-e2e.js` extended with `pageerror` tracking during CRUD interactions
+- All Puppeteer API calls use browser-page fetch so `--ignore-certificate-errors` covers self-signed dev certs without Node-level overrides
+
+**Travel coordinate privacy (#244)**
+- Public endpoints `GET /travel` and `GET /travel/:id` now return coordinates rounded to 2 decimal places (~1km precision)
+- Admin endpoints (`GET /travel/all`, `GET /travel/admin/:id`) retain full 6-decimal precision for editing
+- Query-layer only via `TRAVEL_COLS_PUBLIC` constant — no schema changes
+
+### Changed
+
+**jQuery removed from all public pages (#385)**
+- `script.js`, `blog.js`, `travel.js`, `travel-post.js`, and `utils/dom.js` migrated to vanilla DOM APIs
+- `jquery-3.5.1.min.js` (87KB) removed from all public pages — no external JS dependency on the public site
+- Net: −1,575 lines; no behaviour change
+- Also adds hover lift to timeline cards and improves error logging in blog/travel catch handlers
+
+**Auth setup endpoint retired (#282, #283)**
+- `POST /auth/setup` returns 410 Gone; account creation now happens automatically on the first magic-link send via the existing upsert in `POST /api/auth/email/send`
+- `setup/index.html` replaces the account-creation form with a redirect to `/login/`
+- Deleting the last passkey now shows a warning that magic-link sign-in remains available
+
+### Bug Fixes
+
+- **fix(#391, #346, PR #395):** Three deploy-hygiene fixes: (1) `Cache-Control: no-cache` added for `*.js` in all nginx templates — browsers revalidate JS after every deploy, eliminating stale-module bugs; (2) `scripts/config/certs/` gitignored so `git clean -fd` during branch switches no longer deletes dev certs; (3) leading `~/` in `BACKUP_DIR` now expanded to `$HOME/` in `load_env`, preventing a literal `~/` directory from being created inside the repo
+- **fix(#387, PR #388):** Rate-limit reset and JWT generation in the regression test script were silently failing because `node -e` inline scripts were missing `--input-type=module`; rate-limit counters now clear correctly after the smoke suite, preventing admin IP lockout after every deploy
+- **fix(#399, PR #400):** Overflow cards (`.projects-grid`, `.ai-dev-points`, `.github-repos-grid`) converted from auto-fit grid to flexbox with `justify-content: center`; consistent hover lift added to `.skill-category`, `.ai-point`, and `.cert-card`
+- **fix(#322, PR #401):** `.projects-grid` constrained with `width: 100%` and `padding: 0 1rem` to prevent horizontal overflow inside the column-flex container at narrow viewports
+
+### Breaking Changes / Deployment Notes
+
+- `POST /api/auth/setup` is removed and returns 410 Gone; admin bootstrap now goes through `POST /api/auth/email/send` followed by the magic-link flow at `/login/`
+- No DB schema changes required
+
+---
+
 ## Release 2026-05-26
 
 **Released:** 2026-05-26

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -102,9 +102,10 @@ Puppeteer scripts run automatically inside the backend container after every dev
 | `test-error-logger-browser.js` | `test:error-logger:browser` | Behavioural **contracts** (see below) via request interception |
 | `test-csp-violations.js` | `test:csp-violations` | No first-party CSP violations on any page — catches missing allowlist entries (#341) |
 | `test-admin-e2e-csp.js` | `test:admin-e2e-csp` | Authenticated admin interactions (Nominatim geocoding etc.) produce no CSP violations (#342) |
-| `test-admin-e2e.js` | `test:admin-e2e` | Full admin CRUD E2E — blog create/delete, travel create/delete, deploy panel smoke (#175) |
+| `test-admin-e2e.js` | `test:admin-e2e` | Full admin CRUD E2E — blog create/delete, travel create/delete, deploy panel smoke (#175); also checks for unhandled JS exceptions on load and during interactions (#397) |
+| `test-public-pages.js` | `test:public-pages` | All public pages load without unhandled JS exceptions (`/`, `/blog/`, `/travel/`, `/login/`, `/setup/`, plus dynamically discovered blog post and travel post pages) — catches null dereferences and import failures invisible to curl-based checks (#390, #397) |
 
-> **Important:** every script that loads live pages (`test-error-logger-all-pages.js`, `test-csp-violations.js`, `test-admin-e2e-csp.js`, `test-admin-e2e.js`) intercepts and mocks `POST /api/debug/errors` responses. Headless Chromium generates internal noise errors (e.g. "Couldn't load fs/zlib") that `error-logger.js` would otherwise capture and POST as real entries, polluting the `client_errors` table and triggering false alert emails. Any new Puppeteer script that loads pages must do the same — add `page.setRequestInterception(true)` and mock the endpoint before calling `page.goto()`.
+> **Important:** every script that loads live pages (`test-error-logger-all-pages.js`, `test-csp-violations.js`, `test-admin-e2e-csp.js`, `test-admin-e2e.js`, `test-public-pages.js`) intercepts and mocks `POST /api/debug/errors` responses. Headless Chromium generates internal noise errors (e.g. "Couldn't load fs/zlib") that `error-logger.js` would otherwise capture and POST as real entries, polluting the `client_errors` table and triggering false alert emails. Any new Puppeteer script that loads pages must do the same — add `page.setRequestInterception(true)` and mock the endpoint before calling `page.goto()`.
 
 ### Contract test (`test-error-logger-browser.js`)
 
@@ -472,7 +473,7 @@ Mounts each router against the full Express app via Supertest with the `pg` pool
 | Email delivery (nodemailer) | Requires real SMTP credentials; nodemailer is mocked — the send path is covered by the contact route tests |
 | Contact form in local dev | When `SMTP_HOST`/`SMTP_USER`/`SMTP_PASS` are not set, the route logs the submission to the backend console and returns `{ success: true }` — no email is sent. This is the expected behaviour in the Docker dev environment; the form UI will appear to succeed. Check the backend container logs (`docker compose logs backend`) to see the submitted values. |
 | Database queries | Integration tests mock the pg pool; real DB behaviour is covered by manual smoke testing against the dev Docker DB |
-| Frontend JavaScript | Out of scope for the backend suite; covered by manual browser testing |
+| Frontend JavaScript (unit/integration) | Out of scope for the backend suite; JS runtime errors on public pages are caught by `test-public-pages.js` (puppeteer, runs every deploy) |
 
 ---
 

--- a/docs/UNTRACKED_FILES.md
+++ b/docs/UNTRACKED_FILES.md
@@ -159,17 +159,20 @@ docker compose -f docker-compose.dev-server.yml up -d --build
 - `uploads/` (user data)
 
 **Always use .gitignore:**
-These are already in `.gitignore`:
+These are in `.gitignore`:
 ```
 .env
-.env.local
 scripts/config/certs/
 uploads/
 node_modules/
 .DS_Store
+.env.bak-*          # deploy script .env backups
+backend/coverage/   # vitest coverage output
 ```
 
 Verify with: `git check-ignore .env`
+
+**Note on `BACKUP_DIR=~/backups/dev` in `.env`:** The deploy script reads `.env` verbatim (not via `source`), so `~` is expanded to `$HOME` by deploy-lib.sh itself. If a `~/` directory ever appears inside the repo root, it means a deploy ran before this expansion fix was in place — move any backups to `$HOME/backups/dev/` and delete the directory.
 
 ## Reference: How Variables Flow
 

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -825,19 +825,23 @@ footer a:hover {
 
 /* Projects Grid */
 .projects-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 1.5rem;
-    max-width: 1200px;
+    max-width: 1100px;
     margin: 0 auto;
 }
 
 .project-card {
+    flex: 1 1 300px;
+    max-width: 420px;
+    text-align: left;
     background: var(--color-surface);
     border-radius: 10px;
     padding: 1.75rem;
     box-shadow: 0 2px 12px var(--color-shadow);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
     border-left: 4px solid var(--color-border-strong);
 }
 
@@ -902,6 +906,12 @@ footer a:hover {
     padding: 1.75rem;
     border-radius: 10px;
     box-shadow: 0 2px 12px var(--color-shadow);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.skill-category:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px var(--color-shadow-hover);
 }
 
 .skill-category h3 {
@@ -1203,17 +1213,26 @@ footer {
 }
 
 .ai-dev-points {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 1.25rem;
     margin-top: 1.5rem;
 }
 
 .ai-point {
+    flex: 1 1 220px;
+    max-width: 300px;
     background: var(--color-surface-alt);
     border-radius: 8px;
     padding: 1.25rem;
     border-left: 3px solid var(--color-border-strong);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.ai-point:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px var(--color-shadow-hover);
 }
 
 .ai-point h3 {
@@ -1253,6 +1272,12 @@ footer {
     border-radius: 10px;
     padding: 1.25rem 1.5rem;
     box-shadow: 0 2px 12px var(--color-shadow);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.cert-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px var(--color-shadow-hover);
 }
 
 .cert-info {
@@ -1370,11 +1395,6 @@ footer {
 
     .about-text {
         text-align: center;
-    }
-
-    .projects-grid,
-    .skills-container {
-        grid-template-columns: 1fr;
     }
 
     .contact-wrapper {
@@ -1573,8 +1593,9 @@ footer {
 /* ── GitHub activity widget (Issue #5) ─────────────────────────────────────── */
 
 .github-repos-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 1rem;
     max-width: 1100px;
     margin: 0 auto 1.5rem;
@@ -1582,6 +1603,8 @@ footer {
 }
 
 .github-repo-card {
+    flex: 1 1 260px;
+    max-width: 380px;
     display: block;
     background: var(--color-surface);
     border-radius: 10px;

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -203,9 +203,9 @@ strong {
 }
 
 
-/* Nav box */
+/* Nav box — exclude admin-subnav so its flex-direction:row is not overridden */
 
-nav {
+nav:not(.admin-subnav) {
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -300,6 +300,92 @@ ul.nav {
     padding: 10px;
     display: inline-block;
     line-height: 1.5em;
+}
+
+/* ── Admin sub-navigation (#378) ────────────────────────────────────────── */
+
+.admin-subnav {
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+    gap: 0;
+    padding: 0 1.25rem;
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+
+.admin-subnav::-webkit-scrollbar { display: none; }
+
+.admin-subnav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.75rem 0.9rem;
+    color: var(--color-text-secondary);
+    text-decoration: none;
+    font-size: 0.85rem;
+    font-weight: 500;
+    white-space: nowrap;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.admin-subnav-item:hover {
+    color: var(--color-text);
+}
+
+.admin-subnav-item.active {
+    color: var(--color-accent);
+    border-bottom-color: var(--color-accent);
+    font-weight: 600;
+}
+
+@media (max-width: 600px) {
+    .admin-subnav { padding: 0 0.75rem; justify-content: flex-start; }
+    .admin-subnav-item { padding: 0.65rem 0.65rem; font-size: 0.8rem; }
+}
+
+/* ── Admin dashboard (#378) ─────────────────────────────────────────────── */
+
+.admin-dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+    gap: 1rem;
+    padding: 1.5rem 0 0.5rem;
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.admin-dashboard-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1.25rem 1.25rem 1rem;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: var(--color-text);
+    box-shadow: 0 1px 4px var(--color-shadow);
+    transition: box-shadow 0.15s, border-color 0.15s, transform 0.1s;
+}
+
+.admin-dashboard-card:hover {
+    box-shadow: 0 3px 12px var(--color-shadow-hover);
+    border-color: var(--color-accent);
+    transform: translateY(-1px);
+}
+
+.admin-dashboard-card-icon { font-size: 1.4rem; line-height: 1; margin-bottom: 0.15rem; }
+.admin-dashboard-card-title { font-weight: 600; font-size: 0.95rem; }
+.admin-dashboard-card-desc { font-size: 0.8rem; color: var(--color-text-secondary); line-height: 1.4; }
+
+@media (max-width: 480px) {
+    .admin-dashboard-grid { grid-template-columns: repeat(2, 1fr); }
 }
 
 .admin-page {
@@ -801,14 +887,17 @@ footer a:hover {
 
 /* Skills section */
 .skills-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 2rem;
     max-width: 1100px;
     margin: 0 auto;
 }
 
 .skill-category {
+    flex: 1 1 280px;
+    max-width: 480px;
     background: var(--color-surface);
     padding: 1.75rem;
     border-radius: 10px;

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -829,8 +829,10 @@ footer a:hover {
     flex-wrap: wrap;
     justify-content: center;
     gap: 1.5rem;
+    width: 100%;
     max-width: 1100px;
     margin: 0 auto;
+    padding: 0 1rem;
 }
 
 .project-card {

--- a/resources/js/admin-deploy-page.js
+++ b/resources/js/admin-deploy-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initDeploy }             from './admin/deploy.js';
+
+requireAuth();
+setLogout();
+initDeploy();

--- a/resources/js/admin-media-page.js
+++ b/resources/js/admin-media-page.js
@@ -1,0 +1,8 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initCv }                 from './admin/cv.js';
+import { initNotes }              from './admin/notes.js';
+
+requireAuth();
+setLogout();
+initCv();
+initNotes();

--- a/resources/js/admin-posts-page.js
+++ b/resources/js/admin-posts-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initPosts }              from './admin/posts.js';
+
+requireAuth();
+setLogout();
+initPosts();

--- a/resources/js/admin-settings-page.js
+++ b/resources/js/admin-settings-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initPasskeys }           from './admin/passkeys.js';
+
+requireAuth();
+setLogout();
+initPasskeys();

--- a/resources/js/admin-stats-page.js
+++ b/resources/js/admin-stats-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initStats }              from './admin/stats.js';
+
+requireAuth();
+setLogout();
+initStats();

--- a/resources/js/admin-subnav.js
+++ b/resources/js/admin-subnav.js
@@ -1,0 +1,47 @@
+// Inject the admin sub-navigation bar and mark the active link (#378).
+// Non-module script — runs synchronously so the nav appears before main content.
+(function () {
+    var NAV_ITEMS = [
+        { href: '/admin/',              label: 'Dashboard', icon: '⊞' },
+        { href: '/admin/posts.html',    label: 'Posts',     icon: '✏' },
+        { href: '/admin/travel.html',   label: 'Travel',    icon: '✈' },
+        { href: '/admin/deploy.html',   label: 'Deploy',    icon: '⚡' },
+        { href: '/admin/media.html',    label: 'Media',     icon: '📁' },
+        { href: '/admin/stats.html',    label: 'Stats',     icon: '📊' },
+        { href: '/admin/settings.html', label: 'Settings',  icon: '⚙' },
+    ];
+
+    var pathname = window.location.pathname;
+
+    var nav = document.createElement('nav');
+    nav.className = 'admin-subnav';
+    nav.setAttribute('aria-label', 'Admin sections');
+
+    NAV_ITEMS.forEach(function (item) {
+        var a = document.createElement('a');
+        a.href = item.href;
+        a.className = 'admin-subnav-item';
+
+        // Match dashboard only on exact path; other items on pathname match.
+        var isActive = item.href === '/admin/'
+            ? (pathname === '/admin/' || pathname === '/admin/index.html')
+            : pathname === item.href;
+
+        if (isActive) {
+            a.classList.add('active');
+            a.setAttribute('aria-current', 'page');
+        }
+
+        a.innerHTML = '<span aria-hidden="true">' + item.icon + '</span>' +
+                      '<span class="admin-subnav-label">' + item.label + '</span>';
+        nav.appendChild(a);
+    });
+
+    // Insert immediately after the main <nav> element.
+    var mainNav = document.querySelector('body > nav');
+    if (mainNav) {
+        mainNav.insertAdjacentElement('afterend', nav);
+    } else {
+        document.body.insertAdjacentElement('afterbegin', nav);
+    }
+}());

--- a/resources/js/admin-travel-page.js
+++ b/resources/js/admin-travel-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initTravel }             from './admin/travel.js';
+
+requireAuth();
+setLogout();
+initTravel();

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -1,19 +1,7 @@
-// ── Admin hub — imports and initialises all admin modules ─────────────────────
+// ── Admin dashboard entry point (#378) ────────────────────────────────────────
+// The dashboard is a static navigation page — no section modules needed here.
+// Each sub-page loads only its own module via admin-*-page.js entry points.
 import { requireAuth, setLogout } from './admin/auth.js';
-import { initTravel }             from './admin/travel.js';
-import { initPosts }              from './admin/posts.js';
-import { initCv }                 from './admin/cv.js';
-import { initDeploy }             from './admin/deploy.js';
-import { initPasskeys }           from './admin/passkeys.js';
-import { initStats }              from './admin/stats.js';
-import { initNotes }              from './admin/notes.js';
 
 requireAuth();
 setLogout();
-initTravel();
-initPosts();
-initCv();
-initDeploy();
-initPasskeys();
-initNotes();
-initStats();

--- a/scripts/config/nginx-dev-server.conf.template
+++ b/scripts/config/nginx-dev-server.conf.template
@@ -59,6 +59,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # JS modules: revalidate on every request to prevent stale-module bugs after deploy
+    location ~* \.js$ {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+
     # Static files
     location / {
         try_files $uri $uri/ $uri.html =404;

--- a/scripts/config/nginx-local.conf.template
+++ b/scripts/config/nginx-local.conf.template
@@ -41,6 +41,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # JS modules: revalidate on every request to prevent stale-module bugs after deploy
+    location ~* \.js$ {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+
     # Static files
     location / {
         try_files $uri $uri/ $uri.html =404;

--- a/scripts/config/nginx-portfolio.conf.template
+++ b/scripts/config/nginx-portfolio.conf.template
@@ -61,6 +61,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # JS modules: revalidate on every request to prevent stale-module bugs after deploy
+    location ~* \.js$ {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+
     # Static files
     location / {
         try_files $uri $uri/ $uri.html =404;

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1506,6 +1506,41 @@ test_error_logger_contracts() {
   fi
 }
 
+# ── Public Page JS Runtime Error Check (#390) ────────────────────────────────
+
+# Load every public page in a real browser and fail if any unhandled JS
+# exception fires (null dereferences, failed imports, etc.). Catches the class
+# of errors invisible to curl-based smoke tests — first caught during #389
+# (jQuery removal), where page JS errors weren't surfaced until a browser ran.
+# Warn-only — surfaces loudly but does not roll back the deploy.
+check_public_page_js() {
+  dsection "Frontend tests — public pages JS runtime errors (#390)"
+
+  local base_url="${NGINX_URL:-}"
+  if [ -z "$base_url" ]; then
+    dwarn "NGINX_URL not set — skipping public page JS runtime check"
+    dstatus public-pages suite=frontend status=skipped reason=no-nginx-url
+    return
+  fi
+
+  dinfo "Loading public pages in headless browser to check for unhandled JS errors..."
+
+  local test_output rc
+  if test_output=$(docker compose -f "$COMPOSE_FILE" exec -T "$BACKEND_SERVICE" \
+      npm run test:public-pages -- "$base_url" 2>&1); then rc=0; else rc=$?; fi
+  local sline; sline=$(printf '%s\n' "$test_output" | grep -E '^\[public-pages\]' | tail -1 || true)
+  local passed failed total
+  passed=$(_kv_num "$sline" passed); failed=$(_kv_num "$sline" failed); total=$(_kv_num "$sline" total)
+  if [ "$rc" -eq 0 ]; then
+    dstatus public-pages suite=frontend status=ok tests="${total:-0}" passed="${passed:-0}" failed="${failed:-0}"
+    dok "Public pages JS check passed — ${passed:-0}/${total:-0} ✓"
+  else
+    dstatus public-pages suite=frontend status=failed tests="${total:-0}" passed="${passed:-0}" failed="${failed:-0}"
+    printf '%s\n' "$test_output" | tee -a "$LOG_FILE"
+    dwarn "JS runtime errors detected on public pages — see output above"
+  fi
+}
+
 # ── CSP Browser Violation Detection (#341) ────────────────────────────────────
 
 # Load every served page in a real browser and listen for securitypolicyviolation

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -387,6 +387,10 @@ load_env() {
       if [[ "$value" =~ ^\"(.*)\"$ ]] || [[ "$value" =~ ^\'(.*)\'$ ]]; then
         value="${BASH_REMATCH[1]}"
       fi
+      # Expand a leading ~/ to $HOME/ for path variables. Pure substitution —
+      # does not execute bash code, so complex passwords with ~ in other positions
+      # are unaffected.
+      [[ "$value" == "~/"* ]] && value="$HOME/${value:2}"
       export "$key=$value"
     fi
   done < "$ENV_FILE"

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -124,6 +124,7 @@ case "$DEPLOY_ENV" in
     RUN_DEV_CERTS=1      # dev uses self-signed certs (no certbot); must be generated before nginx starts
     RUN_VITEST=1         # unified image includes devDependencies; run tests against the live container post-deploy
     RUN_ERROR_LOGGER=1   # unified image includes Chromium/puppeteer; run error-logger checks post-deploy
+    RUN_PUBLIC_PAGES=1   # puppeteer check for unhandled JS errors on all public pages (#390)
     RUN_ADMIN_E2E=1      # smoke + interaction tests for admin panel — hard fail (admin is required for content management)
     RUN_DDNS_CHECK=0     # no public DNS in dev; site is LAN-only
     RUN_BACKUP_CHECK=1   # warn if local backups are absent or stale
@@ -143,6 +144,7 @@ case "$DEPLOY_ENV" in
     RUN_DEV_CERTS=0      # prod uses Let's Encrypt certs managed by certbot, not self-signed
     RUN_VITEST=1         # unified image includes devDependencies; run tests post-deploy on prod too
     RUN_ERROR_LOGGER=1   # unified image includes Chromium/puppeteer; run error-logger on prod too
+    RUN_PUBLIC_PAGES=1   # puppeteer check for unhandled JS errors on all public pages (#390)
     RUN_ADMIN_E2E=1      # smoke + interaction tests for admin panel — hard fail (admin is required for content management)
     RUN_DDNS_CHECK=1     # prod is public; verify DNS points to this server before deploying
     RUN_BACKUP_CHECK=1   # warn if local backups are absent or stale
@@ -387,6 +389,7 @@ if [ "$DRY_RUN" = "1" ]; then
   dinfo "  health URL:   $HEALTH_URL"
   [ "$RUN_VITEST"        = "1" ] && dinfo "  vitest:        would run after health check"
   [ "$RUN_ERROR_LOGGER"  = "1" ] && dinfo "  error-logger:  would run after vitest (incl. CSP violation scan)"
+  [ "$RUN_PUBLIC_PAGES"  = "1" ] && dinfo "  public-pages:  would check all public pages for JS runtime errors"
   [ "$SKIP_REGRESSION"   = "0" ] && dinfo "  regression:    would run smoke tests"
   [ "$RUN_BACKUP_CHECK"  = "1" ] && dinfo "  backup check:  would warn if backups absent/stale"
   dinfo ""
@@ -418,6 +421,7 @@ check_outlook_token "$BACKEND_SERVICE"
 
 [ "$RUN_ERROR_LOGGER" = "1" ] && test_error_logger_all_pages
 [ "$RUN_ERROR_LOGGER" = "1" ] && test_error_logger_contracts
+[ "$RUN_PUBLIC_PAGES" = "1" ] && check_public_page_js
 [ "$RUN_ERROR_LOGGER" = "1" ] && check_csp_violations
 [ "$RUN_ERROR_LOGGER" = "1" ] && check_admin_e2e_csp
 [ "$RUN_ADMIN_E2E"    = "1" ] && check_admin_e2e


### PR DESCRIPTION
## Summary

Release 2026-05-31 — frontend modernisation, admin UX, auth hardening, travel privacy, and deploy reliability. Merges `dev` into `main` via `release/2026-05-31-clean`.

Replaces #404 (same content; clean branch rebuilt via cherry-pick to resolve squash-merge ancestry conflict with the 2026-05-27 release).

Closes [#244](https://github.com/AndyRKeys/MyPortfolioSite/issues/244), [#282](https://github.com/AndyRKeys/MyPortfolioSite/issues/282), [#283](https://github.com/AndyRKeys/MyPortfolioSite/issues/283), [#322](https://github.com/AndyRKeys/MyPortfolioSite/issues/322), [#346](https://github.com/AndyRKeys/MyPortfolioSite/issues/346), [#378](https://github.com/AndyRKeys/MyPortfolioSite/issues/378), [#385](https://github.com/AndyRKeys/MyPortfolioSite/issues/385), [#387](https://github.com/AndyRKeys/MyPortfolioSite/issues/387), [#390](https://github.com/AndyRKeys/MyPortfolioSite/issues/390), [#391](https://github.com/AndyRKeys/MyPortfolioSite/issues/391), [#399](https://github.com/AndyRKeys/MyPortfolioSite/issues/399)

## Changes

See `docs/RELEASE_NOTES.md — Release 2026-05-31` for full detail. Summary by area:

- **feat(#378):** Admin panel replaced with dashboard + six dedicated sub-pages; shared `admin-subnav.js` responsive nav bar
- **feat(#390):** `test-public-pages.js` — Puppeteer JS runtime check for all public and post pages on every deploy (warn-only)
- **feat(#244):** Public travel endpoints return coordinates rounded to 2 dp (~1km); admin endpoints unchanged
- **refactor(#385):** jQuery removed from all public pages — `jquery-3.5.1.min.js` (87KB) gone; −1,575 lines; pure vanilla DOM
- **refactor(#282, #283):** `POST /auth/setup` returns 410 Gone; setup page redirects to `/login/`; account creation is now automatic on first magic-link send
- **fix(#391, #346):** `Cache-Control: no-cache` for `*.js` in all nginx templates; dev certs gitignored; `~/` in `BACKUP_DIR` expanded to `$HOME/` in `load_env`
- **fix(#387):** Regression script `node -e` inline scripts now pass `--input-type=module`; rate-limit reset and JWT generation work correctly — no more admin IP lockout after deploys
- **fix(#399):** Overflow card grids converted to flexbox `justify-content: center`; consistent hover lift across index page sections
- **fix(#322):** `.projects-grid` constrained with `width: 100%` and padding to prevent horizontal overflow at narrow viewports
- **docs:** `docs/RELEASE_NOTES.md` updated (PR #403)

## Test Plan

### Happy path

1. Deploy to prod via `.\scripts\deploy\prod-deploy.ps1` and confirm the deploy completes without rollback
2. Visit `https://andykeys.me` — confirm no horizontal scrollbar at narrow viewports; hover states work on skill, AI, cert, and project cards
3. Visit `https://andykeys.me/travel/` — open DevTools Network, confirm a travel post shows `lat`/`lng` with at most 2 decimal places in the API response
4. Visit `https://andykeys.me/admin/` — confirm sub-nav is present and each sub-page (Posts, Travel, Deploy, CV, Stats, Notes) loads without JS errors
5. Visit `https://andykeys.me/setup/` — confirm it redirects to `/login/` rather than showing an account-creation form

### Edge cases

- [x] Admin endpoints (`GET /api/travel/all`, `GET /api/travel/admin/:id`) still return full-precision coordinates — verify via admin travel edit form (coordinates should show 6 decimal places)
- [x] `POST /api/auth/setup` returns 410 — `curl -s -o /dev/null -w "%{http_code}" -X POST https://andykeys.me/api/auth/setup` should return `410`
- [x] JS files served with `Cache-Control: no-cache` — DevTools → Network → any `.js` file → response headers should include `cache-control: no-cache`

### Regression checks

- [x] Blog listing, post detail, and travel listing/detail load without JS errors
- [x] Admin CRUD (blog post create/edit/delete, travel create/edit/delete) works end-to-end
- [x] Magic-link login flow works (request link → click link → JWT issued → redirect to admin)
- [x] Deploy pipeline completes with all five test phases passing (vitest, error-logger, csp-violations, public-pages, regression)

### Setup required before testing

- None — no DB schema changes; no new env vars required

## Smoke Test

- [x] `scripts/tests/Test-Regression.ps1` — runs automatically as part of the deploy pipeline
- [x] N/A for PR-specific script — all changes are covered by the existing regression and E2E suites wired into deploy

## Documentation

- [x] `docs/RELEASE_NOTES.md` updated — Release 2026-05-31 entry added (PR #403)
- [x] N/A — no behaviour or operator doc changes in this release beyond what was updated in individual PRs
- [x] CSP allowlist — N/A (no new external resources or inline scripts)

## Risk / Impact

- **Auth (medium):** Retiring `POST /auth/setup` is a breaking route removal. Risk is low because the setup page now redirects users to the magic-link flow, and no external clients rely on this endpoint. The 410 response is explicit.
- **jQuery removal (low):** Pure refactor with no behaviour change; all public pages tested via Puppeteer JS runtime check on every deploy.
- **nginx Cache-Control change (low):** `no-cache` triggers revalidation, not cache bypass — 304 responses are cheap. The `*.js` location block is ordered before the generic fallback; `uploads/` `immutable` block is unaffected.
- **Coordinate rounding (low):** Query-layer only; no schema change; admin precision unchanged.

## Squash Commit Message

```text
release: 2026-05-31

Frontend modernisation, admin UX, auth hardening, travel
privacy, and deploy reliability. jQuery removed from all
public pages; admin replaced with responsive sub-pages;
POST /auth/setup retired; travel coordinates rounded to
~1km for public endpoints; JS cache-busting and dev cert
protection added to deploy pipeline.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

- This is a release PR (`release/2026-05-31-clean` → `main`). Merge using the squash commit message above.
- After merging, run `.\scripts\deploy\prod-deploy.ps1` to deploy to production.
- Post-deploy: update all 11 closed issues from `awaiting release` to `released`.