### PR TITLE
release: 2026-05-31-2

### DIFF
--- a/.env.dev-server.example
+++ b/.env.dev-server.example
@@ -49,6 +49,10 @@ DB_PASSWORD=change-me-strong-dev-password
 # ── Auth ─────────────────────────────────────────────────────────────────────
 JWT_SECRET=change-me-dev-jwt-secret-min-32-chars
 JWT_EXPIRY=7d
+# Internal service account key — used by regression tests to bypass contact
+# rate limiting. Generate with: openssl rand -hex 32
+# See: docs/SECURITY.md, issue #406, future: #275 (scoped service JWTs)
+SERVICE_KEY=change-me-dev-service-key-min-32-chars
 
 # ── WebAuthn ─────────────────────────────────────────────────────────────────
 WEBAUTHN_RP_ID=dev.example.com

--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,10 @@ DB_PASSWORD=replace_with_strong_password
 # ── Auth ─────────────────────────────────────────────────────────────────────
 JWT_SECRET=replace_with_long_random_string
 JWT_EXPIRY=7d
+# Internal service account key — used by regression tests to bypass contact
+# rate limiting. Generate with: openssl rand -hex 32
+# See: docs/SECURITY.md, issue #406, future: #275 (scoped service JWTs)
+SERVICE_KEY=replace_with_long_random_string
 
 # ── WebAuthn ─────────────────────────────────────────────────────────────────
 WEBAUTHN_RP_ID=andykeys.me

--- a/backend/middleware/rateLimit.js
+++ b/backend/middleware/rateLimit.js
@@ -7,9 +7,12 @@ export function createRateLimiter(options = {}) {
     windowMs = 60 * 1000, // 1 minute
     keyGenerator = (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
     message = 'Too many requests. Please try again later.',
+    skip = () => false,
   } = options;
 
   return async (req, res, next) => {
+    if (skip(req)) return next();
+
     const key = keyGenerator(req);
     if (!key) {
       return next();

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -10,6 +10,7 @@ import {
 import { pool } from '../db/pool.js';
 import { authenticate } from '../middleware/authenticate.js';
 import { createRateLimiter } from '../middleware/rateLimit.js';
+import { skipIfServiceKey } from '../utils/serviceKey.js';
 import { sendMagicLink } from '../utils/email.js';
 import { logger } from '../utils/logger.js';
 import {
@@ -31,12 +32,14 @@ const emailRateLimit = createRateLimiter({
   limit: 5,
   windowMs: 60 * 60 * 1000, // 5 per hour
   message: 'Too many login attempts. Please try again later.',
+  skip: skipIfServiceKey,
 });
 
 const passkeyRateLimit = createRateLimiter({
   limit: 10,
   windowMs: 60 * 60 * 1000, // 10 per hour
   message: 'Too many authentication attempts. Please try again later.',
+  skip: skipIfServiceKey,
 });
 
 function signJWT(user) {

--- a/backend/routes/contact.js
+++ b/backend/routes/contact.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { validate, ContactSchema } from '../middleware/validate.js';
 import { createRateLimiter } from '../middleware/rateLimit.js';
+import { skipIfServiceKey } from '../utils/serviceKey.js';
 import { isEmailConfigured, sendContactEmail } from '../utils/email.js';
 import { logger } from '../utils/logger.js';
 
@@ -10,6 +11,7 @@ const contactRateLimit = createRateLimiter({
   limit: 3,
   windowMs: 60 * 60 * 1000, // 1 hour
   message: 'Too many requests. Please try again later.',
+  skip: skipIfServiceKey,
 });
 
 // lgtm[js/missing-rate-limiting] -- contactRateLimit middleware applied

--- a/backend/routes/debug.js
+++ b/backend/routes/debug.js
@@ -3,6 +3,7 @@ import { pool } from '../db/pool.js';
 import { logger } from '../utils/logger.js';
 import { authenticate } from '../middleware/authenticate.js';
 import { createRateLimiter } from '../middleware/rateLimit.js';
+import { skipIfServiceKey } from '../utils/serviceKey.js';
 import { isEmailConfigured, sendErrorAlertEmail } from '../utils/email.js';
 
 const router = Router();
@@ -15,6 +16,7 @@ const debugRateLimit = createRateLimiter({
   limit: 50,
   windowMs: 60 * 1000,
   message: 'Rate limited',
+  skip: skipIfServiceKey,
 });
 
 // ── Alert threshold ───────────────────────────────────────────────────────────

--- a/backend/tests/routes/contact.test.js
+++ b/backend/tests/routes/contact.test.js
@@ -2,7 +2,7 @@
  * Priority 2 — contact route integration tests.
  * The pg pool is mocked so no real DB is required.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { createApp } from '../../app.js';
 
@@ -53,5 +53,55 @@ describe('POST /contact', () => {
       .send({ name: 'Alice', email: 'alice@example.com' });
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/message/i);
+  });
+});
+
+describe('POST /contact — SERVICE_KEY rate-limit bypass', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Simulate rate limit exceeded so bypass behaviour is observable
+    const { pool } = vi.mocked(await import('../../db/pool.js'));
+    pool.query.mockResolvedValue({ rows: [{ count: 4 }] });
+  });
+
+  afterEach(() => {
+    delete process.env.SERVICE_KEY;
+  });
+
+  it('returns 429 when rate limit exceeded and no service key sent', async () => {
+    process.env.SERVICE_KEY = 'test-secret';
+    const res = await request(app)
+      .post('/contact')
+      .send({ name: 'Alice', email: 'alice@example.com', message: 'Hi' });
+    expect(res.status).toBe(429);
+  });
+
+  it('returns 429 when rate limit exceeded and wrong service key sent', async () => {
+    process.env.SERVICE_KEY = 'test-secret';
+    const res = await request(app)
+      .post('/contact')
+      .set('X-Service-Key', 'wrong-key')
+      .send({ name: 'Alice', email: 'alice@example.com', message: 'Hi' });
+    expect(res.status).toBe(429);
+  });
+
+  it('bypasses rate limit and reaches validation when correct service key sent', async () => {
+    process.env.SERVICE_KEY = 'test-secret';
+    const res = await request(app)
+      .post('/contact')
+      .set('X-Service-Key', 'test-secret')
+      .send({ name: 'Alice', email: 'not-an-email', message: 'Hi' });
+    // Rate limiter skipped — validation fires and rejects the bad email with 400, not 429
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/email/i);
+  });
+
+  it('does not bypass rate limit when SERVICE_KEY env var is unset', async () => {
+    // SERVICE_KEY deliberately not set
+    const res = await request(app)
+      .post('/contact')
+      .set('X-Service-Key', 'any-value')
+      .send({ name: 'Alice', email: 'alice@example.com', message: 'Hi' });
+    expect(res.status).toBe(429);
   });
 });

--- a/backend/utils/serviceKey.js
+++ b/backend/utils/serviceKey.js
@@ -1,0 +1,9 @@
+// Returns true when the request carries a valid X-Service-Key header matching
+// the SERVICE_KEY env var. Used as the `skip` function in createRateLimiter so
+// the regression test service account bypasses rate limits without consuming
+// user-facing quota. Fails closed: if SERVICE_KEY is unset no request is skipped.
+// See: issue #406, future upgrade path: issue #275 (scoped service JWTs).
+export const skipIfServiceKey = (req) => {
+  const key = process.env.SERVICE_KEY;
+  return !!key && req.headers['x-service-key'] === key;
+};

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,31 @@
 # Release Notes
 
+## Release 2026-05-31-2
+
+**Released:** 2026-05-31
+**Branch:** release/2026-05-31-2
+**Closes:** [#406](https://github.com/AndyRKeys/MyPortfolioSite/issues/406)
+
+### Summary
+
+Mini-release following the 2026-05-31 prod rollback. The regression suite caused a false failure by hitting the contact form rate limit during the post-deploy smoke tests, triggering an automatic rollback. This release adds a service account key bypass to all rate limiters and redesigns the regression test order so rate-limit behaviour is tested deliberately (with a clean reset) rather than accidentally. All 2026-05-31 changes are included via the base branch.
+
+### Bug Fixes
+
+- **fix(#406):** `SERVICE_KEY` env var + `X-Service-Key` header bypass added to all four rate limiters (contact, email auth, passkey auth, debug) via shared `skipIfServiceKey()` utility. Regression tests auto-derive the key from the container and send it on baseline contact checks.
+
+### Ops / Testing
+
+- **ops(#406):** Rate-limit test section runs first in the regression suite (no service key, real limiter exercised), followed by a targeted reset that deletes only loopback/runner IP rows — real user counters are never cleared. Previously the reset cleared the entire `rate_limits` table.
+- **ops(#406):** `RESOLVE_IP` extracted from `--resolve` so the targeted reset covers the LAN IP used by dev (not just `127.0.0.1`, which only applies to prod).
+
+### Deployment Notes
+
+- **Required:** add `SERVICE_KEY=$(openssl rand -hex 32)` to the prod `.env` before deploying — the regression script warns if it is missing but degrades gracefully.
+- No DB schema changes. No new dependencies.
+
+---
+
 ## Release 2026-05-31
 
 **Released:** 2026-05-31

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -1962,7 +1962,6 @@ run_regression_tests() {
       --compose-file "$COMPOSE_FILE" \
       --service "$BACKEND_SERVICE" \
       --insecure \
-      --reset-rate-limits \
       2>&1) || REGRESSION_RC=1
   elif [ -n "${DOMAIN:-}" ]; then
     reg_out=$(bash "${REPO_DIR}/scripts/tests/test-regression.sh" \

--- a/scripts/tests/test-regression.sh
+++ b/scripts/tests/test-regression.sh
@@ -42,8 +42,6 @@ COMPOSE_FILE=""
 SERVICE="backend"
 INSECURE=""
 RESOLVE=""
-RESET_RL=0
-
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --base-url)           BASE_URL="$2";      shift 2 ;;
@@ -52,7 +50,7 @@ while [[ $# -gt 0 ]]; do
     --service)            SERVICE="$2";       shift 2 ;;
     --insecure)           INSECURE="-k";      shift   ;;
     --resolve)            RESOLVE="$2";       shift 2 ;;
-    --reset-rate-limits)  RESET_RL=1;         shift   ;;
+    --reset-rate-limits)                      shift   ;; # no-op: reset now runs unconditionally
     *) shift ;;
   esac
 done
@@ -62,8 +60,10 @@ done
 # Needed because the server cannot route to its own public DNS name (no NAT
 # hairpin), but the deploy must still test via the real hostname.
 RESOLVE_ARGS=()
+RESOLVE_IP=""
 if [ -n "$RESOLVE" ]; then
   RESOLVE_ARGS=(--resolve "$RESOLVE")
+  RESOLVE_IP="${RESOLVE##*:}"  # hostname:port:ip — extract the connect IP
 fi
 
 if [ -z "$BASE_URL" ]; then
@@ -86,26 +86,52 @@ if [ -z "$TOKEN" ] && [ -n "$COMPOSE_FILE" ]; then
   fi
 fi
 
+# ── Service key auto-derivation (#406) ───────────────────────────────────────────
+# Read SERVICE_KEY from the container so contact baseline tests can include the
+# X-Service-Key header and bypass the rate limiter deterministically. Without
+# this, two back-to-back contact requests risk a 429 if prior deploys consumed
+# slots in the same window.
+
+SERVICE_KEY=""
+if [ -n "$COMPOSE_FILE" ]; then
+  SERVICE_KEY=$(docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" \
+    printenv SERVICE_KEY 2>/dev/null | tr -d '\r\n' || true)
+  if [ -n "$SERVICE_KEY" ]; then
+    say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Service key loaded from $SERVICE container"
+  else
+    echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  SERVICE_KEY not set in container — contact rate-limit bypass disabled; add SERVICE_KEY to .env"
+  fi
+fi
+
+# Array form so it expands to nothing when SERVICE_KEY is empty
+SKEY_HEADER=()
+[ -n "$SERVICE_KEY" ] && SKEY_HEADER=(-H "X-Service-Key: $SERVICE_KEY")
+
 # ── Helpers ──────────────────────────────────────────────────────────────────────
 
 PASS=0; FAIL=0; SKIP=0
 TMPFILE=$(mktemp)
 TMPERR=$(mktemp)
 
-# Best-effort reset of the DB-backed rate-limit counters via the backend
-# container's own pool (same mechanism as JWT generation). Dev-only — never
-# called for prod, where clearing real visitors' counters is undesirable.
-# Failing open (warn + continue) matches the rate-limit middleware itself.
+# Deletes rate-limit rows for loopback addresses only (127.0.0.1 / ::1 /
+# ::ffff:127.0.0.1) — the IPs the regression runner uses when connecting via
+# --resolve. Real user counters are left intact. Called before and after the
+# rate-limit section: before for a clean window, after so prod is not left
+# locked out. Failing open matches the rate-limit middleware's own behaviour.
 reset_rate_limits() {
-  [ "$RESET_RL" = "1" ] || return 0
   [ -n "$COMPOSE_FILE" ] || return 0
-  if docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" node --input-type=module -e "
+  if docker compose -f "$COMPOSE_FILE" exec -T -e "RESOLVE_IP=${RESOLVE_IP}" "$SERVICE" node --input-type=module -e "
     import('./db/pool.js')
-      .then(async ({ pool }) => { await pool.query('DELETE FROM rate_limits'); await pool.end(); })
+      .then(async ({ pool }) => {
+        const ips = ['127.0.0.1', '::1', '::ffff:127.0.0.1'];
+        if (process.env.RESOLVE_IP) ips.push(process.env.RESOLVE_IP);
+        await pool.query('DELETE FROM rate_limits WHERE ip = ANY(\$1)', [ips]);
+        await pool.end();
+      })
       .then(() => process.exit(0))
       .catch((e) => { process.stderr.write(String(e) + '\n'); process.exit(1); });
   " >/dev/null 2>&1; then
-    say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Rate-limit counters reset (dev)"
+    say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Loopback rate-limit counters reset"
   else
     echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  Could not reset rate-limit counters — continuing"
   fi
@@ -169,17 +195,43 @@ check_auth() {
 
 if [ "$QUIET" != "1" ]; then
   _reg_token_text=$([ -n "$TOKEN" ] && echo 'auto-generated from container' || echo 'not provided — auth tests skipped')
+  _reg_skey_text=$([ -n "$SERVICE_KEY" ] && echo 'loaded from container' || echo 'not set — contact tests may be flaky')
   _print_multi_box "${C_CYAN}${C_BOLD}" 60 \
     "🧪 Regression Test Run — $(date '+%Y-%m-%d %H:%M:%S')" \
-    "Base URL : $BASE_URL" \
-    "Token    : $_reg_token_text"
+    "Base URL    : $BASE_URL" \
+    "Token       : $_reg_token_text" \
+    "Service key : $_reg_skey_text"
 fi
 
-# Clean slate so contact validation checks aren't tripped by counters left
-# over from earlier deploys within the rate-limit window (dev only).
+# ── Rate limiting ────────────────────────────────────────────────────────────────
+# Runs first, before the service key is in use, so the real limiter is exercised
+# without any bypass. /api/contact is limited to 3 requests/hour; the limiter
+# fires before validation so invalid payloads still increment the counter (no
+# emails sent). Targeted reset before (clean window) and after (leave prod clean —
+# only loopback IPs deleted, real user counters are untouched).
+
+say "${C_CYAN}${C_BOLD}🔷 ── Rate limiting ─────────────────────────────────────────${C_RESET}"
 reset_rate_limits
 
+for n in 1 2 3; do
+  check "POST /api/contact #$n within limit returns 400" \
+    POST "$BASE_URL/api/contact" 400 "" \
+    -H "Content-Type: application/json" \
+    -d '{"email":"bad","message":"x"}'
+done
+
+check "POST /api/contact #4 over limit returns 429" \
+  POST "$BASE_URL/api/contact" 429 "Too many requests" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"bad","message":"x"}'
+
+reset_rate_limits  # targeted cleanup — loopback rows only
+
+say ""
+
 # ── No-auth baseline ─────────────────────────────────────────────────────────────
+# Service key is active for contact checks so they are never rate-limited by prior
+# test runs or real traffic sharing the same window.
 
 say "${C_CYAN}${C_BOLD}🔷 ── No-auth baseline ──────────────────────────────────────${C_RESET}"
 
@@ -188,11 +240,13 @@ check "GET /api/posts returns 200" \
 
 check "POST /api/contact missing name returns 400" \
   POST "$BASE_URL/api/contact" 400 "" \
+  "${SKEY_HEADER[@]}" \
   -H "Content-Type: application/json" \
   -d '{"email":"test@example.com","message":"hello"}'
 
 check "POST /api/contact invalid email returns 400" \
   POST "$BASE_URL/api/contact" 400 "" \
+  "${SKEY_HEADER[@]}" \
   -H "Content-Type: application/json" \
   -d '{"name":"Test","email":"not-an-email","message":"hello"}'
 
@@ -270,31 +324,6 @@ check "GET /api/stats/visits without auth returns 401" \
   GET "$BASE_URL/api/stats/visits" 401
 
 say ""
-
-# ── Rate limiting (dev only) ──────────────────────────────────────────────────────
-# /api/contact is limited to 3 requests/hour. The limiter runs BEFORE validation,
-# so invalid payloads still increment the counter (no emails sent). Reset first
-# for a deterministic window, then prove the 4th request is blocked with 429.
-# Gated on --reset-rate-limits so it only runs where we can reset (dev).
-
-if [ "$RESET_RL" = "1" ]; then
-  say "${C_CYAN}${C_BOLD}🔷 ── Rate limiting ─────────────────────────────────────────${C_RESET}"
-  reset_rate_limits
-
-  for n in 1 2 3; do
-    check "POST /api/contact #$n within limit returns 400" \
-      POST "$BASE_URL/api/contact" 400 "" \
-      -H "Content-Type: application/json" \
-      -d '{"email":"bad","message":"x"}'
-  done
-
-  check "POST /api/contact #4 over limit returns 429" \
-    POST "$BASE_URL/api/contact" 429 "Too many requests" \
-    -H "Content-Type: application/json" \
-    -d '{"email":"bad","message":"x"}'
-
-  say ""
-fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Mini-release following the 2026-05-31 prod rollback. The regression suite triggered an automatic rollback by hitting the contact form rate limit during post-deploy smoke tests. This release fixes the regression pipeline so it cannot cause a false rollback, and deploys all 2026-05-31 changes that were rolled back.

Closes [#406](https://github.com/AndyRKeys/MyPortfolioSite/issues/406)

## Changes

See `docs/RELEASE_NOTES.md — Release 2026-05-31-2` for full detail.

- **fix(#406):** `SERVICE_KEY` + `X-Service-Key` bypass added to all four rate limiters via shared `skipIfServiceKey()`. Regression tests auto-derive the key from the container.
- **ops(#406):** Rate-limit tests run first (no bypass, real limiter exercised), then targeted reset of runner IPs only — real user counters untouched. `RESOLVE_IP` extracted from `--resolve` so the targeted reset covers dev's LAN IP as well as prod's loopback.
- **docs:** `RELEASE_NOTES.md` updated.

## Test Plan

### Vitest

```bash
# Confirm all 94 tests pass including the 4 new SERVICE_KEY bypass tests
docker compose exec backend npm test
# Expected: 94 passed, 0 failed
```

### Regression — confirm clean run

```bash
# Ensure SERVICE_KEY is set in prod .env, then deploy normally.
# The regression header should show:
#   Service key : loaded from container
# And the rate-limit section should show:
#   ✅ POST /api/contact #1 within limit returns 400
#   ✅ POST /api/contact #2 within limit returns 400
#   ✅ POST /api/contact #3 within limit returns 400
#   ✅ POST /api/contact #4 over limit returns 429
#   ℹ  Loopback rate-limit counters reset  (×2)
```

### Smoke Test

- [x] Full regression suite ran 21/21 on dev after PR #408 merged — output verified manually

## Documentation

- [x] `docs/RELEASE_NOTES.md` — Release 2026-05-31-2 entry added
- [x] `SERVICE_KEY` documented in `.env.example` and `.env.dev-server.example`

## Risk / Impact

**Low.** Service key bypass is fail-closed. Rate limiting is unchanged for real-user traffic. Targeted reset is strictly safer than the previous full `DELETE FROM rate_limits`.

## Pre-deploy action required

Add `SERVICE_KEY` to the prod `.env` before running the deploy script:

```bash
echo "SERVICE_KEY=$(openssl rand -hex 32)" >> ~/MyPortfolioSite/.env
```

## Squash Commit Message

```text
release: 2026-05-31-2

Service key rate-limit bypass for all four rate-limited routes;
targeted regression reset (runner IPs only, not full table clear);
rate-limit tests run first in the regression suite. Fixes the
false rollback from the 2026-05-31 prod deploy.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

- This is a release PR (`release/2026-05-31-2` → `main`). Merge using the squash commit message above.
- After merging, add `SERVICE_KEY` to prod `.env`, then run `.\scripts\deploy\prod-deploy.ps1`.
- Post-deploy: update issue #406 from `awaiting release` → `released`. Remaining 11 issues from the 2026-05-31 release also become `released` at this point.