### PR TITLE
fix: detect Docker bridge gateway for regression rate-limit reset (#410)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       SMTP_PASS: ${SMTP_PASS:-}
       ADMIN_EMAIL: ${ADMIN_EMAIL}
       LOG_LEVEL: ${LOG_LEVEL:-info}
+      SERVICE_KEY: ${SERVICE_KEY:-}
       UPLOADS_DIR: /app/uploads
     volumes:
       - uploads_data:/app/uploads

--- a/scripts/tests/test-regression.sh
+++ b/scripts/tests/test-regression.sh
@@ -107,31 +107,53 @@ fi
 SKEY_HEADER=()
 [ -n "$SERVICE_KEY" ] && SKEY_HEADER=(-H "X-Service-Key: $SERVICE_KEY")
 
+# ── Docker bridge gateway detection (#410) ───────────────────────────────────────
+# When curl connects to the host via loopback (e.g. 127.0.0.1:443 on prod),
+# Docker's NAT rewrites the source IP before the nginx container sees it, so
+# the backend stores the bridge gateway (e.g. 172.20.0.1) rather than loopback.
+# Detect it by reading the default route inside the container.
+DOCKER_GW=""
+if [ -n "$COMPOSE_FILE" ]; then
+  DOCKER_GW=$(docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" \
+    sh -c "ip route show default 2>/dev/null | awk '/default/ {print \$3}' | head -1" \
+    2>/dev/null | tr -d '\r\n' || true)
+  if [ -n "$DOCKER_GW" ]; then
+    say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Docker bridge gateway detected: $DOCKER_GW"
+  else
+    echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  Could not detect Docker bridge gateway — rate-limit reset may be incomplete"
+  fi
+fi
+
 # ── Helpers ──────────────────────────────────────────────────────────────────────
 
 PASS=0; FAIL=0; SKIP=0
 TMPFILE=$(mktemp)
 TMPERR=$(mktemp)
 
-# Deletes rate-limit rows for loopback addresses only (127.0.0.1 / ::1 /
-# ::ffff:127.0.0.1) — the IPs the regression runner uses when connecting via
-# --resolve. Real user counters are left intact. Called before and after the
-# rate-limit section: before for a clean window, after so prod is not left
-# locked out. Failing open matches the rate-limit middleware's own behaviour.
+# Deletes rate-limit rows for all IPs the regression runner may appear as:
+# loopback (127.0.0.1 / ::1 / ::ffff:127.0.0.1), RESOLVE_IP (LAN IP on dev),
+# and the Docker bridge gateway (the IP nginx sees when curl connects via
+# loopback NAT on prod). Real user counters on other IPs are left intact.
+# Called before and after the rate-limit section. Failing open matches the
+# rate-limit middleware's own behaviour.
 reset_rate_limits() {
   [ -n "$COMPOSE_FILE" ] || return 0
-  if docker compose -f "$COMPOSE_FILE" exec -T -e "RESOLVE_IP=${RESOLVE_IP}" "$SERVICE" node --input-type=module -e "
+  if docker compose -f "$COMPOSE_FILE" exec -T \
+      -e "RESOLVE_IP=${RESOLVE_IP}" \
+      -e "DOCKER_GW=${DOCKER_GW}" \
+      "$SERVICE" node --input-type=module -e "
     import('./db/pool.js')
       .then(async ({ pool }) => {
         const ips = ['127.0.0.1', '::1', '::ffff:127.0.0.1'];
         if (process.env.RESOLVE_IP) ips.push(process.env.RESOLVE_IP);
+        if (process.env.DOCKER_GW)  ips.push(process.env.DOCKER_GW);
         await pool.query('DELETE FROM rate_limits WHERE ip = ANY(\$1)', [ips]);
         await pool.end();
       })
       .then(() => process.exit(0))
       .catch((e) => { process.stderr.write(String(e) + '\n'); process.exit(1); });
   " >/dev/null 2>&1; then
-    say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Loopback rate-limit counters reset"
+    say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Rate-limit counters reset"
   else
     echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  Could not reset rate-limit counters — continuing"
   fi
@@ -196,11 +218,13 @@ check_auth() {
 if [ "$QUIET" != "1" ]; then
   _reg_token_text=$([ -n "$TOKEN" ] && echo 'auto-generated from container' || echo 'not provided — auth tests skipped')
   _reg_skey_text=$([ -n "$SERVICE_KEY" ] && echo 'loaded from container' || echo 'not set — contact tests may be flaky')
+  _reg_gw_text=$([ -n "$DOCKER_GW" ] && echo "$DOCKER_GW" || echo 'not detected — reset may be incomplete')
   _print_multi_box "${C_CYAN}${C_BOLD}" 60 \
     "🧪 Regression Test Run — $(date '+%Y-%m-%d %H:%M:%S')" \
     "Base URL    : $BASE_URL" \
     "Token       : $_reg_token_text" \
-    "Service key : $_reg_skey_text"
+    "Service key : $_reg_skey_text" \
+    "Bridge GW   : $_reg_gw_text"
 fi
 
 # ── Rate limiting ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the regression rate-limit reset so it reliably clears counters on prod, and ensures `SERVICE_KEY` reaches the backend container so the service account exemption actually works.

Two root causes identified after inspecting the `rate_limits` table on prod:

1. **Wrong IP in reset**: When curl connects via `127.0.0.1:443` (prod), Docker NATs the connection through the bridge, so nginx stores `172.20.0.1` (the bridge gateway) — not loopback. The reset only deleted loopback IPs and `RESOLVE_IP`, leaving the gateway row intact and causing 429s in the no-auth baseline.
2. **`SERVICE_KEY` not in container**: `docker-compose.yml` never declared `SERVICE_KEY` in the backend `environment:` block, so the service account exemption was silently inactive on all Docker-deployed environments.

## Changes

- **`docker-compose.yml`** — add `SERVICE_KEY: ${SERVICE_KEY:-}` to backend environment block
- **`scripts/tests/test-regression.sh`**:
  - Detect the Docker bridge gateway at startup via `ip route show default` inside the container
  - Pass `DOCKER_GW` into the reset node script alongside `RESOLVE_IP`
  - Update reset comment and INFO message
  - Add gateway to the header box so it's visible in logs

## Test plan

```bash
# Inside the dev server, verify 21/21 pass with gateway detected
bash scripts/tests/test-regression.sh \
  --base-url https://dev.andykeys.me:3001 \
  --compose-file ~/MyPortfolioSite-dev/docker-compose.yml \
  --service backend \
  --insecure \
  --resolve "dev.andykeys.me:3001:192.168.68.81"
```

Expected: header shows `Bridge GW : 172.20.0.1` (or similar), all 21 tests pass.

### Smoke tests

```bash
# Confirm SERVICE_KEY is now visible inside the container after a down+up
docker compose exec backend printenv SERVICE_KEY
# Expected: the value set in .env (non-empty)

# Confirm the bridge gateway entry is deleted after a reset (run once to generate a counter,
# then check the table is clean)
docker compose exec postgres psql -U postgres -d portfolio_prod \
  -c "SELECT ip, COUNT(*) FROM rate_limits GROUP BY ip;"
# Expected: 172.20.0.1 row absent after regression completes
```

## Documentation

- `docker-compose.yml` — `SERVICE_KEY` env var addition is self-documenting alongside the `.env.example` entry added in #406
- Closes #410

## Squash commit message

```
fix: detect Docker bridge gateway for regression rate-limit reset (#410)

Prod rate-limit reset was missing the Docker bridge gateway IP (172.20.x.x)
that nginx stores when curl connects via loopback NAT. Detects it dynamically
via `ip route` inside the container and adds it to the targeted DELETE list.
Also wires SERVICE_KEY into docker-compose.yml so the service account
exemption actually reaches the backend container.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)