### PR TITLE
refactor: rename service key 'bypass' framing to service account exemption (#413)

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -10,7 +10,7 @@ import {
 import { pool } from '../db/pool.js';
 import { authenticate } from '../middleware/authenticate.js';
 import { createRateLimiter } from '../middleware/rateLimit.js';
-import { skipIfServiceKey } from '../utils/serviceKey.js';
+import { exemptIfServiceAccount } from '../utils/serviceKey.js';
 import { sendMagicLink } from '../utils/email.js';
 import { logger } from '../utils/logger.js';
 import {
@@ -32,14 +32,14 @@ const emailRateLimit = createRateLimiter({
   limit: 5,
   windowMs: 60 * 60 * 1000, // 5 per hour
   message: 'Too many login attempts. Please try again later.',
-  skip: skipIfServiceKey,
+  skip: exemptIfServiceAccount,
 });
 
 const passkeyRateLimit = createRateLimiter({
   limit: 10,
   windowMs: 60 * 60 * 1000, // 10 per hour
   message: 'Too many authentication attempts. Please try again later.',
-  skip: skipIfServiceKey,
+  skip: exemptIfServiceAccount,
 });
 
 function signJWT(user) {

--- a/backend/routes/contact.js
+++ b/backend/routes/contact.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { validate, ContactSchema } from '../middleware/validate.js';
 import { createRateLimiter } from '../middleware/rateLimit.js';
-import { skipIfServiceKey } from '../utils/serviceKey.js';
+import { exemptIfServiceAccount } from '../utils/serviceKey.js';
 import { isEmailConfigured, sendContactEmail } from '../utils/email.js';
 import { logger } from '../utils/logger.js';
 
@@ -11,7 +11,7 @@ const contactRateLimit = createRateLimiter({
   limit: 3,
   windowMs: 60 * 60 * 1000, // 1 hour
   message: 'Too many requests. Please try again later.',
-  skip: skipIfServiceKey,
+  skip: exemptIfServiceAccount,
 });
 
 // lgtm[js/missing-rate-limiting] -- contactRateLimit middleware applied

--- a/backend/routes/debug.js
+++ b/backend/routes/debug.js
@@ -3,7 +3,7 @@ import { pool } from '../db/pool.js';
 import { logger } from '../utils/logger.js';
 import { authenticate } from '../middleware/authenticate.js';
 import { createRateLimiter } from '../middleware/rateLimit.js';
-import { skipIfServiceKey } from '../utils/serviceKey.js';
+import { exemptIfServiceAccount } from '../utils/serviceKey.js';
 import { isEmailConfigured, sendErrorAlertEmail } from '../utils/email.js';
 
 const router = Router();
@@ -16,7 +16,7 @@ const debugRateLimit = createRateLimiter({
   limit: 50,
   windowMs: 60 * 1000,
   message: 'Rate limited',
-  skip: skipIfServiceKey,
+  skip: exemptIfServiceAccount,
 });
 
 // ── Alert threshold ───────────────────────────────────────────────────────────

--- a/backend/tests/routes/contact.test.js
+++ b/backend/tests/routes/contact.test.js
@@ -56,10 +56,10 @@ describe('POST /contact', () => {
   });
 });
 
-describe('POST /contact — SERVICE_KEY rate-limit bypass', () => {
+describe('POST /contact — SERVICE_KEY service account exemption', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    // Simulate rate limit exceeded so bypass behaviour is observable
+    // Simulate rate limit exceeded so exemption behaviour is observable
     const { pool } = vi.mocked(await import('../../db/pool.js'));
     pool.query.mockResolvedValue({ rows: [{ count: 4 }] });
   });
@@ -85,18 +85,18 @@ describe('POST /contact — SERVICE_KEY rate-limit bypass', () => {
     expect(res.status).toBe(429);
   });
 
-  it('bypasses rate limit and reaches validation when correct service key sent', async () => {
+  it('exempts service account and reaches validation when correct service key sent', async () => {
     process.env.SERVICE_KEY = 'test-secret';
     const res = await request(app)
       .post('/contact')
       .set('X-Service-Key', 'test-secret')
       .send({ name: 'Alice', email: 'not-an-email', message: 'Hi' });
-    // Rate limiter skipped — validation fires and rejects the bad email with 400, not 429
+    // Service account exempted — validation fires and rejects the bad email with 400, not 429
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/email/i);
   });
 
-  it('does not bypass rate limit when SERVICE_KEY env var is unset', async () => {
+  it('does not exempt when SERVICE_KEY env var is unset', async () => {
     // SERVICE_KEY deliberately not set
     const res = await request(app)
       .post('/contact')

--- a/backend/utils/serviceKey.js
+++ b/backend/utils/serviceKey.js
@@ -1,9 +1,10 @@
 // Returns true when the request carries a valid X-Service-Key header matching
-// the SERVICE_KEY env var. Used as the `skip` function in createRateLimiter so
-// the regression test service account bypasses rate limits without consuming
-// user-facing quota. Fails closed: if SERVICE_KEY is unset no request is skipped.
+// the SERVICE_KEY env var. Used as the `skip` function in createRateLimiter to
+// exempt authenticated service accounts (e.g. the regression test runner) from
+// rate limiting — trusted callers are not in scope for user-facing quotas.
+// Fails closed: if SERVICE_KEY is unset, no request is exempted.
 // See: issue #406, future upgrade path: issue #275 (scoped service JWTs).
-export const skipIfServiceKey = (req) => {
+export const exemptIfServiceAccount = (req) => {
   const key = process.env.SERVICE_KEY;
   return !!key && req.headers['x-service-key'] === key;
 };

--- a/scripts/tests/test-regression.sh
+++ b/scripts/tests/test-regression.sh
@@ -87,10 +87,9 @@ if [ -z "$TOKEN" ] && [ -n "$COMPOSE_FILE" ]; then
 fi
 
 # ── Service key auto-derivation (#406) ───────────────────────────────────────────
-# Read SERVICE_KEY from the container so contact baseline tests can include the
-# X-Service-Key header and bypass the rate limiter deterministically. Without
-# this, two back-to-back contact requests risk a 429 if prior deploys consumed
-# slots in the same window.
+# Read SERVICE_KEY from the container so contact baseline tests can identify as
+# the trusted service account and be exempt from rate limiting. Without this,
+# back-to-back contact requests risk a 429 if prior test runs consumed slots.
 
 SERVICE_KEY=""
 if [ -n "$COMPOSE_FILE" ]; then
@@ -99,7 +98,7 @@ if [ -n "$COMPOSE_FILE" ]; then
   if [ -n "$SERVICE_KEY" ]; then
     say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Service key loaded from $SERVICE container"
   else
-    echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  SERVICE_KEY not set in container — contact rate-limit bypass disabled; add SERVICE_KEY to .env"
+    echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  SERVICE_KEY not set in container — service account not authenticated; contact tests may be rate-limited; add SERVICE_KEY to .env"
   fi
 fi
 
@@ -204,8 +203,8 @@ if [ "$QUIET" != "1" ]; then
 fi
 
 # ── Rate limiting ────────────────────────────────────────────────────────────────
-# Runs first, before the service key is in use, so the real limiter is exercised
-# without any bypass. /api/contact is limited to 3 requests/hour; the limiter
+# Runs first, without the service account header, so the real limiter is exercised
+# against an anonymous caller. /api/contact is limited to 3 requests/hour; the limiter
 # fires before validation so invalid payloads still increment the counter (no
 # emails sent). Targeted reset before (clean window) and after (leave prod clean —
 # only loopback IPs deleted, real user counters are untouched).


### PR DESCRIPTION
## Summary

Rate limiting exists to protect against untrusted, anonymous callers. A correctly authenticated service account (the regression test runner) is a legitimate, trusted caller and should simply not be in scope for it — this is an identity-based exemption, not a circumvention of a security control.

Renames and rewords the "bypass" framing throughout to reflect this correctly.

## Changes

| File | Change |
|------|--------|
| `backend/utils/serviceKey.js` | `skipIfServiceKey` → `exemptIfServiceAccount`, updated comment |
| `backend/routes/contact.js` | import + usage renamed |
| `backend/routes/auth.js` | import + usage renamed (×2) |
| `backend/routes/debug.js` | import + usage renamed |
| `backend/tests/routes/contact.test.js` | describe label + test names reworded |
| `scripts/tests/test-regression.sh` | comment + warn message reworded |

No behaviour changes. `rateLimit.js`'s internal `skip` option name is unchanged — it's a technical implementation term, not user-facing framing.

## Test plan

```bash
# Run contact route tests — all 7 must pass with updated describe/it labels
docker compose exec backend npm test -- tests/routes/contact
# Expected: 7 passed
```

## Documentation

N/A — changes are naming/comments only. Closes #413.

## Squash commit message

```
refactor: rename service key 'bypass' framing to service account exemption (#413)

Rate limiting applies to untrusted callers. Authenticated service accounts
are trusted and exempt — not bypassing a control. Renames skipIfServiceKey
→ exemptIfServiceAccount and updates all surrounding comments and tests.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)