### PR TITLE
release: 2026-05-31-3

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -10,7 +10,7 @@ import {
 import { pool } from '../db/pool.js';
 import { authenticate } from '../middleware/authenticate.js';
 import { createRateLimiter } from '../middleware/rateLimit.js';
-import { skipIfServiceKey } from '../utils/serviceKey.js';
+import { exemptIfServiceAccount } from '../utils/serviceKey.js';
 import { sendMagicLink } from '../utils/email.js';
 import { logger } from '../utils/logger.js';
 import {
@@ -32,14 +32,14 @@ const emailRateLimit = createRateLimiter({
   limit: 5,
   windowMs: 60 * 60 * 1000, // 5 per hour
   message: 'Too many login attempts. Please try again later.',
-  skip: skipIfServiceKey,
+  skip: exemptIfServiceAccount,
 });
 
 const passkeyRateLimit = createRateLimiter({
   limit: 10,
   windowMs: 60 * 60 * 1000, // 10 per hour
   message: 'Too many authentication attempts. Please try again later.',
-  skip: skipIfServiceKey,
+  skip: exemptIfServiceAccount,
 });
 
 function signJWT(user) {

--- a/backend/routes/contact.js
+++ b/backend/routes/contact.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { validate, ContactSchema } from '../middleware/validate.js';
 import { createRateLimiter } from '../middleware/rateLimit.js';
-import { skipIfServiceKey } from '../utils/serviceKey.js';
+import { exemptIfServiceAccount } from '../utils/serviceKey.js';
 import { isEmailConfigured, sendContactEmail } from '../utils/email.js';
 import { logger } from '../utils/logger.js';
 
@@ -11,7 +11,7 @@ const contactRateLimit = createRateLimiter({
   limit: 3,
   windowMs: 60 * 60 * 1000, // 1 hour
   message: 'Too many requests. Please try again later.',
-  skip: skipIfServiceKey,
+  skip: exemptIfServiceAccount,
 });
 
 // lgtm[js/missing-rate-limiting] -- contactRateLimit middleware applied

--- a/backend/routes/debug.js
+++ b/backend/routes/debug.js
@@ -3,7 +3,7 @@ import { pool } from '../db/pool.js';
 import { logger } from '../utils/logger.js';
 import { authenticate } from '../middleware/authenticate.js';
 import { createRateLimiter } from '../middleware/rateLimit.js';
-import { skipIfServiceKey } from '../utils/serviceKey.js';
+import { exemptIfServiceAccount } from '../utils/serviceKey.js';
 import { isEmailConfigured, sendErrorAlertEmail } from '../utils/email.js';
 
 const router = Router();
@@ -16,7 +16,7 @@ const debugRateLimit = createRateLimiter({
   limit: 50,
   windowMs: 60 * 1000,
   message: 'Rate limited',
-  skip: skipIfServiceKey,
+  skip: exemptIfServiceAccount,
 });
 
 // ── Alert threshold ───────────────────────────────────────────────────────────

--- a/backend/tests/routes/contact.test.js
+++ b/backend/tests/routes/contact.test.js
@@ -56,10 +56,10 @@ describe('POST /contact', () => {
   });
 });
 
-describe('POST /contact — SERVICE_KEY rate-limit bypass', () => {
+describe('POST /contact — SERVICE_KEY service account exemption', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    // Simulate rate limit exceeded so bypass behaviour is observable
+    // Simulate rate limit exceeded so exemption behaviour is observable
     const { pool } = vi.mocked(await import('../../db/pool.js'));
     pool.query.mockResolvedValue({ rows: [{ count: 4 }] });
   });
@@ -85,18 +85,18 @@ describe('POST /contact — SERVICE_KEY rate-limit bypass', () => {
     expect(res.status).toBe(429);
   });
 
-  it('bypasses rate limit and reaches validation when correct service key sent', async () => {
+  it('exempts service account and reaches validation when correct service key sent', async () => {
     process.env.SERVICE_KEY = 'test-secret';
     const res = await request(app)
       .post('/contact')
       .set('X-Service-Key', 'test-secret')
       .send({ name: 'Alice', email: 'not-an-email', message: 'Hi' });
-    // Rate limiter skipped — validation fires and rejects the bad email with 400, not 429
+    // Service account exempted — validation fires and rejects the bad email with 400, not 429
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/email/i);
   });
 
-  it('does not bypass rate limit when SERVICE_KEY env var is unset', async () => {
+  it('does not exempt when SERVICE_KEY env var is unset', async () => {
     // SERVICE_KEY deliberately not set
     const res = await request(app)
       .post('/contact')

--- a/backend/utils/serviceKey.js
+++ b/backend/utils/serviceKey.js
@@ -1,9 +1,10 @@
 // Returns true when the request carries a valid X-Service-Key header matching
-// the SERVICE_KEY env var. Used as the `skip` function in createRateLimiter so
-// the regression test service account bypasses rate limits without consuming
-// user-facing quota. Fails closed: if SERVICE_KEY is unset no request is skipped.
+// the SERVICE_KEY env var. Used as the `skip` function in createRateLimiter to
+// exempt authenticated service accounts (e.g. the regression test runner) from
+// rate limiting — trusted callers are not in scope for user-facing quotas.
+// Fails closed: if SERVICE_KEY is unset, no request is exempted.
 // See: issue #406, future upgrade path: issue #275 (scoped service JWTs).
-export const skipIfServiceKey = (req) => {
+export const exemptIfServiceAccount = (req) => {
   const key = process.env.SERVICE_KEY;
   return !!key && req.headers['x-service-key'] === key;
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       SMTP_PASS: ${SMTP_PASS:-}
       ADMIN_EMAIL: ${ADMIN_EMAIL}
       LOG_LEVEL: ${LOG_LEVEL:-info}
+      SERVICE_KEY: ${SERVICE_KEY:-}
       UPLOADS_DIR: /app/uploads
     volumes:
       - uploads_data:/app/uploads

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,32 @@
 # Release Notes
 
+## Release 2026-05-31-3
+
+**Released:** 2026-05-31
+**Branch:** release/2026-05-31-3
+**PR:** [#415](https://github.com/AndyRKeys/MyPortfolioSite/pull/415)
+**Closes:** [#410](https://github.com/AndyRKeys/MyPortfolioSite/issues/410), [#413](https://github.com/AndyRKeys/MyPortfolioSite/issues/413)
+
+### Summary
+
+Second follow-up mini-release to 2026-05-31. Fixes the regression rate-limit reset on prod (the Docker bridge gateway IP was never being cleared, causing 429s in the no-auth baseline despite a reset running), wires `SERVICE_KEY` into `docker-compose.yml` so the service account exemption actually reaches the backend container, and reframes all "bypass" language to "service account exemption" to reflect the correct mental model (rate limiting applies to untrusted callers; authenticated service accounts are simply not in scope).
+
+### Bug Fixes
+
+- **fix(#410):** Regression rate-limit reset now detects the Docker bridge gateway IP (`172.20.x.x`) dynamically via `ip route show default` inside the container and includes it in the targeted DELETE. Previously loopback-only deletes missed the gateway IP that Docker NAT writes when curl connects via loopback, leaving stale counters that caused 429s in the no-auth baseline.
+- **fix(#410):** `SERVICE_KEY` added to `docker-compose.yml` backend `environment:` block — it was set in `.env` but never passed through to the container, silently disabling the service account exemption on all Docker-deployed environments.
+
+### Refactoring
+
+- **refactor(#413):** `skipIfServiceKey` renamed to `exemptIfServiceAccount` across all routes, tests, and the regression script. Surrounding comments and log messages updated to reflect the correct model: rate limits protect against untrusted callers; authenticated service accounts are exempt by identity, not by circumventing a control.
+
+### Deployment Notes
+
+- No `.env` changes required — `SERVICE_KEY` was already added in the 2026-05-31-2 deployment.
+- No DB schema changes. No new dependencies.
+
+---
+
 ## Release 2026-05-31-2
 
 **Released:** 2026-05-31

--- a/scripts/tests/test-regression.sh
+++ b/scripts/tests/test-regression.sh
@@ -87,10 +87,9 @@ if [ -z "$TOKEN" ] && [ -n "$COMPOSE_FILE" ]; then
 fi
 
 # ── Service key auto-derivation (#406) ───────────────────────────────────────────
-# Read SERVICE_KEY from the container so contact baseline tests can include the
-# X-Service-Key header and bypass the rate limiter deterministically. Without
-# this, two back-to-back contact requests risk a 429 if prior deploys consumed
-# slots in the same window.
+# Read SERVICE_KEY from the container so contact baseline tests can identify as
+# the trusted service account and be exempt from rate limiting. Without this,
+# back-to-back contact requests risk a 429 if prior test runs consumed slots.
 
 SERVICE_KEY=""
 if [ -n "$COMPOSE_FILE" ]; then
@@ -99,7 +98,7 @@ if [ -n "$COMPOSE_FILE" ]; then
   if [ -n "$SERVICE_KEY" ]; then
     say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Service key loaded from $SERVICE container"
   else
-    echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  SERVICE_KEY not set in container — contact rate-limit bypass disabled; add SERVICE_KEY to .env"
+    echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  SERVICE_KEY not set in container — service account not authenticated; contact tests may be rate-limited; add SERVICE_KEY to .env"
   fi
 fi
 
@@ -228,8 +227,8 @@ if [ "$QUIET" != "1" ]; then
 fi
 
 # ── Rate limiting ────────────────────────────────────────────────────────────────
-# Runs first, before the service key is in use, so the real limiter is exercised
-# without any bypass. /api/contact is limited to 3 requests/hour; the limiter
+# Runs first, without the service account header, so the real limiter is exercised
+# against an anonymous caller. /api/contact is limited to 3 requests/hour; the limiter
 # fires before validation so invalid payloads still increment the counter (no
 # emails sent). Targeted reset before (clean window) and after (leave prod clean —
 # only loopback IPs deleted, real user counters are untouched).

--- a/scripts/tests/test-regression.sh
+++ b/scripts/tests/test-regression.sh
@@ -107,31 +107,53 @@ fi
 SKEY_HEADER=()
 [ -n "$SERVICE_KEY" ] && SKEY_HEADER=(-H "X-Service-Key: $SERVICE_KEY")
 
+# ── Docker bridge gateway detection (#410) ───────────────────────────────────────
+# When curl connects to the host via loopback (e.g. 127.0.0.1:443 on prod),
+# Docker's NAT rewrites the source IP before the nginx container sees it, so
+# the backend stores the bridge gateway (e.g. 172.20.0.1) rather than loopback.
+# Detect it by reading the default route inside the container.
+DOCKER_GW=""
+if [ -n "$COMPOSE_FILE" ]; then
+  DOCKER_GW=$(docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" \
+    sh -c "ip route show default 2>/dev/null | awk '/default/ {print \$3}' | head -1" \
+    2>/dev/null | tr -d '\r\n' || true)
+  if [ -n "$DOCKER_GW" ]; then
+    say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Docker bridge gateway detected: $DOCKER_GW"
+  else
+    echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  Could not detect Docker bridge gateway — rate-limit reset may be incomplete"
+  fi
+fi
+
 # ── Helpers ──────────────────────────────────────────────────────────────────────
 
 PASS=0; FAIL=0; SKIP=0
 TMPFILE=$(mktemp)
 TMPERR=$(mktemp)
 
-# Deletes rate-limit rows for loopback addresses only (127.0.0.1 / ::1 /
-# ::ffff:127.0.0.1) — the IPs the regression runner uses when connecting via
-# --resolve. Real user counters are left intact. Called before and after the
-# rate-limit section: before for a clean window, after so prod is not left
-# locked out. Failing open matches the rate-limit middleware's own behaviour.
+# Deletes rate-limit rows for all IPs the regression runner may appear as:
+# loopback (127.0.0.1 / ::1 / ::ffff:127.0.0.1), RESOLVE_IP (LAN IP on dev),
+# and the Docker bridge gateway (the IP nginx sees when curl connects via
+# loopback NAT on prod). Real user counters on other IPs are left intact.
+# Called before and after the rate-limit section. Failing open matches the
+# rate-limit middleware's own behaviour.
 reset_rate_limits() {
   [ -n "$COMPOSE_FILE" ] || return 0
-  if docker compose -f "$COMPOSE_FILE" exec -T -e "RESOLVE_IP=${RESOLVE_IP}" "$SERVICE" node --input-type=module -e "
+  if docker compose -f "$COMPOSE_FILE" exec -T \
+      -e "RESOLVE_IP=${RESOLVE_IP}" \
+      -e "DOCKER_GW=${DOCKER_GW}" \
+      "$SERVICE" node --input-type=module -e "
     import('./db/pool.js')
       .then(async ({ pool }) => {
         const ips = ['127.0.0.1', '::1', '::ffff:127.0.0.1'];
         if (process.env.RESOLVE_IP) ips.push(process.env.RESOLVE_IP);
+        if (process.env.DOCKER_GW)  ips.push(process.env.DOCKER_GW);
         await pool.query('DELETE FROM rate_limits WHERE ip = ANY(\$1)', [ips]);
         await pool.end();
       })
       .then(() => process.exit(0))
       .catch((e) => { process.stderr.write(String(e) + '\n'); process.exit(1); });
   " >/dev/null 2>&1; then
-    say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Loopback rate-limit counters reset"
+    say "  ${C_CYAN}${C_BOLD}ℹ  [INFO]${C_RESET}  Rate-limit counters reset"
   else
     echo -e "  ${C_YELLOW}${C_BOLD}⚠️  [WARN]${C_RESET}  Could not reset rate-limit counters — continuing"
   fi
@@ -196,11 +218,13 @@ check_auth() {
 if [ "$QUIET" != "1" ]; then
   _reg_token_text=$([ -n "$TOKEN" ] && echo 'auto-generated from container' || echo 'not provided — auth tests skipped')
   _reg_skey_text=$([ -n "$SERVICE_KEY" ] && echo 'loaded from container' || echo 'not set — contact tests may be flaky')
+  _reg_gw_text=$([ -n "$DOCKER_GW" ] && echo "$DOCKER_GW" || echo 'not detected — reset may be incomplete')
   _print_multi_box "${C_CYAN}${C_BOLD}" 60 \
     "🧪 Regression Test Run — $(date '+%Y-%m-%d %H:%M:%S')" \
     "Base URL    : $BASE_URL" \
     "Token       : $_reg_token_text" \
-    "Service key : $_reg_skey_text"
+    "Service key : $_reg_skey_text" \
+    "Bridge GW   : $_reg_gw_text"
 fi
 
 # ── Rate limiting ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Third mini-release following the 2026-05-31 prod rollbacks. Fixes the regression rate-limit reset on prod and corrects the service account exemption framing.

- **#410** — Docker bridge gateway IP now detected dynamically and included in the rate-limit reset; `SERVICE_KEY` wired into `docker-compose.yml` so it reaches the container
- **#413** — `skipIfServiceKey` → `exemptIfServiceAccount` rename throughout; "bypass" framing corrected to "service account exemption"

## Changes

- `docker-compose.yml` — `SERVICE_KEY` added to backend environment block
- `scripts/tests/test-regression.sh` — gateway detection, updated reset logic, corrected comments
- `backend/utils/serviceKey.js` — renamed export
- `backend/routes/contact.js`, `auth.js`, `debug.js` — renamed import/usage
- `backend/tests/routes/contact.test.js` — renamed describe/it labels
- `docs/RELEASE_NOTES.md` — release notes for 2026-05-31-3

## Test plan

```bash
# On dev server — verify 21/21 with gateway detected and reset working
bash scripts/tests/test-regression.sh \
  --base-url https://dev.andykeys.me:3001 \
  --compose-file ~/MyPortfolioSite-dev/docker-compose.yml \
  --service backend \
  --insecure \
  --resolve "dev.andykeys.me:3001:192.168.68.81"
# Expected: Bridge GW shown in header, all 21 tests pass
```

## Deployment notes

- No `.env` changes required — `SERVICE_KEY` was added in the 2026-05-31-2 deployment
- No DB schema changes. No new dependencies.

## Squash commit message

```
release: 2026-05-31-3 (#416)

Fixes prod regression rate-limit reset (Docker bridge gateway IP now
detected and cleared) and wires SERVICE_KEY through docker-compose.yml.
Also renames skipIfServiceKey → exemptIfServiceAccount throughout.
Closes #410, #413.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)