### PR TITLE
housekeeping: fix markdownlint warnings across all .md files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,9 +10,9 @@ labels: bug
 
 ## Steps to Reproduce
 
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ## Expected Behaviour
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,9 +18,9 @@ labels: enhancement
 
 ## Acceptance Criteria
 
-- [ ] 
-- [ ] 
-- [ ] 
+- [ ]
+- [ ]
+- [ ]
 
 ## Out of Scope
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,8 @@ Closes #<!-- issue number -->
 
 <!-- Bullet list of files/areas changed and what changed -->
 
-- 
-- 
+-
+-
 
 ## Test Plan
 
@@ -17,9 +17,9 @@ Closes #<!-- issue number -->
 
 ### Happy path
 
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ### Edge cases
 
@@ -31,8 +31,8 @@ Closes #<!-- issue number -->
 
 <!-- Features that could have been affected and should be verified still work -->
 
-- [ ] 
-- [ ] 
+- [ ]
+- [ ]
 
 ### Setup required before testing
 
@@ -63,7 +63,7 @@ Closes #<!-- issue number -->
 
 <!-- For security/infra/ops changes, briefly note risk, impact, or threat mitigated. -->
 
-- 
+-
 
 ## Squash Commit Message
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD024": false,
+  "MD036": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **What is this?** A personal portfolio site at andykeys.me — blog, travel posts, admin console for managing content, and AI lab experiments. Self-hosted on an Ubuntu Server (`ak-home-server`, a repurposed gaming PC); the original Raspberry Pi has been retired. See `docs/TERMINOLOGY.md` for canonical names.
 
 **Tech stack:**
+
 - Frontend: vanilla JS/HTML/CSS (no build step), jQuery for legacy compatibility
 - Backend: Node.js/Express (ES modules), WebAuthn + JWT auth
 - Database: PostgreSQL
@@ -17,6 +18,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - AI pair programmer: Claude Sonnet via Anthropic API
 
 **Key files:**
+
 - `backend/server.js` — Express app entry point, middleware, route registration
 - `backend/routes/` — API endpoints (auth, posts, travel, deploy, etc.)
 - `backend/db/schema.sql` — PostgreSQL schema (idempotent, uses IF NOT EXISTS)
@@ -133,6 +135,7 @@ gh pr create --base dev --title "Title" --body "Description. Closes #N"
 **Every PR must use and fully fill in the template at `.github/pull_request_template.md`** — summary, changes, detailed test plan, smoke test section, and documentation checklist (including ops docs). Treat any unchecked or "N/A" box as a deliberate decision that needs to be correct.
 
 **Issue labelling (AI-managed):**
+
 - **State labels**
   - When starting work on an issue: apply the `in progress` label.
   - When opening a PR to `dev` for that issue: switch the label to `awaiting review`.
@@ -164,6 +167,7 @@ gh pr create --base dev --title "Title" --body "Description. Closes #N"
 No build step. HTML pages load ES modules directly via `<script type="module">`.
 
 **Frontend JS structure:**
+
 - `resources/js/config.js` — exports `API_BASE` (empty string for same-origin, auto-detects localhost in dev)
 - `resources/js/script.js` — homepage only: GitHub widget, contact form, home visit counter
 - `resources/js/blog.js` — blog listing page
@@ -181,6 +185,7 @@ No build step. HTML pages load ES modules directly via `<script type="module">`.
 Express app in `backend/server.js`. Routes are well-separated by concern.
 
 **Key routes:**
+
 - `backend/routes/auth.js` (12KB) — WebAuthn registration/auth, JWT issuance, email magic links, passkey verification. Highest-risk route to modify.
 - `backend/routes/posts.js` — blog and travel CRUD
 - `backend/routes/travel.js` — travel listing + detail
@@ -189,11 +194,13 @@ Express app in `backend/server.js`. Routes are well-separated by concern.
 - `backend/routes/contact.js` — contact form with nodemailer
 
 **Middleware:**
+
 - `backend/middleware/errorHandler.js` — catches and formats errors
 - `backend/middleware/validate.js` — schema validation for request bodies
 - JWT auth check: routes check for valid JWT before running
 
 **Database:**
+
 - `schema.sql` is idempotent (IF NOT EXISTS throughout) — safe to re-run
 - Tables: users, passkeys, email_tokens, posts (blog and travel unified), uploads, audit_log (coming), stats
 - No migration tool yet — uses raw SQL applied at boot
@@ -211,12 +218,14 @@ Express app in `backend/server.js`. Routes are well-separated by concern.
 - **Protected routes:** Check `Authorization: Bearer <JWT>` header; JWT contains user ID + issued-at timestamp
 
 **JWT structure:**
+
 - Signed with `JWT_SECRET` (backend only)
 - 7-day expiry (configurable)
 - Contains userId
 - Verified on every protected route
 
 **Email magic links:**
+
 - User requests link at `/api/auth/email/send`
 - Backend generates random token, stores bcrypt hash in email_tokens table
 - Email contains `/login/?token=<raw-token>`
@@ -226,6 +235,7 @@ Express app in `backend/server.js`. Routes are well-separated by concern.
 ### Admin Panel
 
 Single HTML file (`admin/index.html`) with JS split across modular ES modules. Handles:
+
 - Blog post CRUD (`admin/posts.js`)
 - Travel memory CRUD (`admin/travel.js`)
 - CV upload + file browser (`admin/cv.js`)
@@ -242,23 +252,27 @@ Single HTML file (`admin/index.html`) with JS split across modular ES modules. H
 ### Code style
 
 **Naming:**
+
 - Camel case for JS variables and functions
 - Kebab case for HTML IDs, CSS classes
 - Underscore case for database columns (post_date, user_id, etc.)
 
 **Button variants (CSS):**
+
 - `.btn-primary` — large blue (0.8rem padding, 1.5rem horizontal)
 - `.btn-secondary` — large outlined (same padding, transparent bg, border)
 - `.btn-small` — compact dark (0.35rem padding, 0.85rem horizontal)
 - `.btn-danger` — red modifier (use with size class: `class="btn-small btn-danger"`)
 
 **Section headers (JS comments):**
+
 ```js
 // ── Section name (two em-dashes, space, label, NO trailing fill)
 function doSomething() { ... }
 ```
 
 **Database:** Always parameterised queries. Never string concatenation.
+
 ```js
 // Good
 const result = await pool.query('SELECT * FROM posts WHERE id = $1', [postId]);
@@ -267,6 +281,7 @@ const result = await pool.query(`SELECT * FROM posts WHERE id = ${postId}`);
 ```
 
 **DRY principle (Don't Repeat Yourself):**
+
 - **Frontend:** Reuse utility functions from `resources/js/utils/`. Don't duplicate escapeHtml, formatDate, buildDOM patterns across modules.
 - **Backend:** Extract common logic into middleware or route helpers. Don't repeat validation, error handling, or CORS logic.
 - **Deployment scripts:** Extract reusable functions into `scripts/deploy/deploy-lib.sh` (shared helpers like `ensure_repo_cloned()`, `update_to_branch()`, `validate_env()`, `ensure_dev_certs()`). Each `*-deploy.sh` focuses on environment-specific logic only. PowerShell wrappers (`.ps1`) are thin — mostly SSH + arg passing.
@@ -306,16 +321,19 @@ bash -c 'source /home/modnar3/MyPortfolioSite-dev/scripts/deploy/deploy-lib.sh &
 ### Testing
 
 **Vitest suite:**
+
 - `tests/` folder mirrors `backend/` structure
 - Tests for middleware, validators, route handlers
 - Run via `npm test` inside the backend container
 - Coverage tracked; aim for routes and middleware, not 100% everywhere
 
 **Smoke tests (per-PR):**
+
 - `scripts/tests/test-regression.sh` — baseline (all basic flows); runs automatically post-deploy on the server
 - `scripts/tests/Test-PRNNN.ps1` — specific PR tests (created as needed); run from Windows against dev server
 
 **PR test plan rules (every PR that touches backend code):**
+
 - Every step must include the **exact copy-paste command** — no assumed knowledge, no "run the usual command"
 - Add a `# comment` above every command explaining what it verifies and why it matters for this PR
 - State the **expected output** after each command so the tester knows pass vs fail at a glance
@@ -329,29 +347,34 @@ bash -c 'source /home/modnar3/MyPortfolioSite-dev/scripts/deploy/deploy-lib.sh &
 **Docs must move in lockstep with code.** Keeping them accurate is part of the change, not a later clean-up.
 
 **When to update docs (same PR):**
+
 - Scripts are added, removed, or renamed
 - Deploy / testing / operational workflows change (e.g. adding deploy-time Vitest or regression steps)
 - Routes, APIs, or env vars are added or changed
 - Any behaviour change that affects how someone develops, deploys, tests, or debugs the system
 
 **What to update:**
+
 - `README.md` — top-level workflow, script tables, command examples, directory trees
 - `docs/AI.md` — working rules for AI helpers (scope, branching, testing expectations, documentation hygiene)
 - `docs/TESTING.md` — test commands, deploy-time checks, regression scripts, PR smoke tests
 - Ops docs — `docs/RUNBOOK.md`, `docs/BACKUP.md`, `docs/INCIDENTS.md`, `docs/INFRASTRUCTURE.md`, `docs/DEV_ENVIRONMENT.md`, `docs/PROD_ENVIRONMENT.md`
 
 **How to avoid drift:**
+
 - Treat the documentation checklist in the PR template as mandatory. If no docs change is needed, explicitly state why (`N/A: behaviour and operator docs already match`).
 - When code and docs disagree, fix both in the same PR so history stays coherent.
 - Prefer small, incremental doc edits tied to each behavioural change over broad "docs tidy-up" PRs.
 - For detailed rules, follow **[docs/AI.md](docs/AI.md) → Documentation Hygiene**; this section is a summary, not a replacement.
 
 **When NOT to add extra docs:**
+
 - Generic "what this function does" explanations — prefer clear naming
 - Obvious patterns that match the existing style
 - Implementation details that don't affect future work or operator behaviour
 
 **Commit messages:**
+
 - Imperative present tense: "fix", "add", "refactor", not "fixed", "added", "refactored"
 - Short summary (50 chars), blank line, optional explanation
 - Always include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` footer
@@ -411,6 +434,7 @@ bash -c 'source /home/modnar3/MyPortfolioSite-dev/scripts/deploy/deploy-lib.sh &
   - Mouse support for selection and clicking
 
 Set as your default editor:
+
 ```bash
 echo 'export EDITOR=micro' >> ~/.bashrc
 source ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A full-stack personal portfolio site built with plain HTML/CSS/JS on the fronten
 
 ## Architecture
 
-```
+```text
 Browser → andykeys.me
        → Nginx :80/:443
            ├── /auth/*  → proxy → Node.js backend (Docker)
@@ -41,6 +41,7 @@ For a high-level view of where the project is heading and current priorities, se
 ## Local Development
 
 ### Prerequisites
+
 - Docker Desktop (recommended)
 - A passkey-capable browser (Chrome, Safari, Edge)
 - Node.js 20+ only needed if running without Docker
@@ -50,6 +51,7 @@ For a high-level view of where the project is heading and current priorities, se
 The canonical environment for development and testing is the shared dev server on `ak-home-server`. Local Docker dev via `dev-local.ps1` is kept as a fallback and may lag behind.
 
 When working on a feature or fix:
+
 - Use the usual git branching model (`feature/issue-N-*` / `fix/issue-N-*` from `dev`)
 - Push your branch and open a PR to `dev` as soon as there is something to test
 - Use the dev-server deployment scripts (see `docs/INFRASTRUCTURE.md` and `docs/DEV_ENVIRONMENT.md`) to run the latest `dev` branch on the server for manual testing
@@ -90,6 +92,7 @@ Visit `http://localhost/setup/` to create the admin account and register your fi
 ```
 
 **Troubleshooting:**
+
 - **Port already in use**: Change `PORT`, `DB_PORT`, or Nginx port in `.env` or `docker-compose.yml`
 - **Backend can't connect to DB**: Wait for PostgreSQL to be healthy — `docker compose logs postgres`
 - **Schema not initialized**: `docker compose exec postgres psql -U postgres -d portfolio_dev -f /docker-entrypoint-initdb.d/01-schema.sql`
@@ -117,7 +120,7 @@ cp .env.example .env
 npm run dev
 ```
 
-Serve the frontend with VS Code Live Server and open **http://localhost:3000** (not 127.0.0.1 — WebAuthn requires `localhost` or HTTPS).
+Serve the frontend with VS Code Live Server and open **<http://localhost:3000>** (not 127.0.0.1 — WebAuthn requires `localhost` or HTTPS).
 
 ---
 
@@ -141,7 +144,7 @@ No `-Token` flag needed — the script auto-generates a JWT from the container. 
 
 ## Branching Strategy
 
-```
+```text
 main  ←── release/YYYY-MM-DD ←── dev ←── feature/issue-N-description
                                      ←── fix/issue-N-description
 main  ←── hotfix/issue-N-description (emergency fixes only)
@@ -178,7 +181,7 @@ gh pr create --base main --head dev --title "Release: ..."
 
 ### Commit style
 
-```
+```text
 Short imperative summary (50 chars max)
 
 Optional explanation if the why isn't obvious.
@@ -197,6 +200,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 This SSHs into the server (`ak-home-server`), runs `switch-branch.sh main` to update the working tree, then runs `deploy.sh --env prod`, which:
+
 1. Validates `.env` and checks prerequisites
 2. Builds and restarts containers via `docker compose up -d --build` (unified `docker-compose.yml`, project `portfolio_prod`)
 3. Runs health checks and rolls back automatically on failure
@@ -240,7 +244,7 @@ ssh <hostname> "sudo certbot renew"
 
 ## Scripts
 
-```
+```text
 scripts/
 ├── dev/
 │   ├── dev-local.ps1       Windows wrapper for all local dev commands
@@ -315,7 +319,7 @@ Feature backlog is tracked in [GitHub Issues](https://github.com/AndyRKeys/MyPor
 
 Copy and paste the prompt below at the start of any new AI pair programming session. It instructs the agent to read all project documentation and familiarise itself with the codebase before doing any work.
 
-```
+```text
 You are pair programming with me on my personal portfolio site. Before we start
 any work, please familiarise yourself with the project by reading the following
 documents in order — do not skip any:

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -26,6 +26,7 @@ For high-level direction and current priorities, AI models may treat `ROADMAP.md
 **The owner's strong preference is always a proper fix.** Workarounds — commenting out checks, skipping pipeline steps, adding bypass flags, or patching over symptoms — are a last resort reserved for genuine site-down emergencies where there is no time for a correct fix.
 
 If a workaround is unavoidable:
+
 1. Apply the minimum workaround needed to restore service
 2. Raise a GitHub issue immediately documenting what was bypassed and why
 3. Treat the proper fix as the next highest-priority task — do not move on to other work first
@@ -54,6 +55,7 @@ Whenever a file is added, moved, renamed, or removed, update all relevant docume
 - Any other doc that contains the old path or filename
 
 This applies to:
+
 - Scripts being added or reorganised (e.g. moving `scripts/foo.ps1` → `scripts/tests/foo.ps1`)
 - Source files being renamed or relocated
 - New docs or config files being introduced
@@ -75,7 +77,7 @@ Use this rule consistently throughout this file and in all docs written by the A
 
 This project follows a three-tier branching model:
 
-```
+```text
 main (production)
  ↑
 dev (integration)
@@ -84,6 +86,7 @@ feature/* or fix/* (per GitHub issue)
 ```
 
 **Branch naming:**
+
 - `feature/issue-N-short-description` — for new features
 - `fix/issue-N-short-description` — for bug fixes
 - `release/YYYY-MM-DD` — for production releases (with optional `-N` suffix for same-day releases)
@@ -91,6 +94,7 @@ feature/* or fix/* (per GitHub issue)
 - One branch per GitHub issue only
 
 **Critical guardrails:**
+
 - **One branch at a time for ops and security work.** Do not open or develop multiple branches simultaneously when the work touches deployment/infrastructure or security (auth, tokens, secrets, rate limiting). These changes are interdependent and easy to get subtly wrong in parallel — finish, PR, and get one merged before starting the next. Independent low-risk work (e.g. a docs tweak, an unrelated UI fix) may still proceed in parallel; this restriction is specific to ops/security.
 - **Always develop on a feature or fix branch** (`feature/issue-N-*` or `fix/issue-N-*`). Never commit directly to `dev` or `main`.
 - **Pull requests** go `feature|fix/* → dev` for integration testing and review.
@@ -103,7 +107,9 @@ feature/* or fix/* (per GitHub issue)
 ## Expected AI Workflow
 
 ### 1. Issue Creation
+
 If the issue doesn't exist yet, create it on GitHub with:
+
 - Clear title and description
 - Steps to reproduce (for bugs)
 - Expected vs actual behaviour
@@ -134,13 +140,16 @@ Always apply both a **state label** and any relevant **type labels**:
 The AI is responsible for adding/removing these labels as the issue moves through its lifecycle; do not wait for a separate prompt to update them.
 
 ### 2. Planning
+
 Before writing code:
+
 1. Read the issue and any linked context
 2. Examine existing code patterns and architecture
 3. Comment a plan on the issue before starting work
 4. Ask for clarification if requirements are ambiguous
 
 ### 3. Implementation
+
 1. Create a `feature/issue-N-*` or `fix/issue-N-*` branch from `dev`
 2. Commit regularly with clear messages
 3. Keep changes focused — one issue per branch
@@ -152,6 +161,7 @@ Before writing code:
 **PR creation is the default.** Once the work is committed and the branch is pushed, open the PR to `dev` automatically — do not ask "shall I open a PR?" first. The standing authorisation is: branch + push + complete work ⇒ open the PR. (You still do **not** merge it — review and merge remain the owner's.) Only skip or defer the PR if the owner explicitly says so for that piece of work, or the work is genuinely incomplete/experimental (say so explicitly).
 
 Once implementation is complete:
+
 1. Raise a PR from the branch → `dev`
 2. Link the issue number (`Closes #N`)
 3. Include a clear summary of what changed and why
@@ -164,6 +174,7 @@ The AI does not merge PRs — you will review, test locally, and merge when read
 **Recommend a squash commit message with every PR.** After opening the PR, post (in the PR description or as a chat reply) a ready-to-copy squash commit message for the owner to paste when squash-merging on test completion. The repo merges via squash, so the PR's individual commits are discarded — this message becomes the permanent history entry. Format it the same as a normal commit: imperative summary ≤50 chars, blank line, a short body covering what changed and why, and the `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` footer. Present it in a fenced code block so it can be copied verbatim.
 
 **PR test plans must include:**
+
 - Specific steps to verify the happy path (e.g. exact URL, action, expected result)
 - Edge cases to check (e.g. empty state, error handling, mobile view)
 - Regression checks for related features that could have been affected
@@ -172,6 +183,7 @@ The AI does not merge PRs — you will review, test locally, and merge when read
 - The documentation checklist: confirm `docs/CHANGELOG.md` updated and any relevant doc updated, or N/A
 
 **Test plan commands — mandatory rules:**
+
 - Every step that requires a terminal command must include the **exact, copy-paste command** — no placeholders left unexplained, no "run the usual command".
 - **Target the dev server first.** The dev server is the canonical test environment (real DB, auth, file uploads). Write the test plan for someone SSHed into `ak-home-server`. **Important:** `dev.andykeys.me` does not resolve from the server itself — use `https://localhost:3001` with `-k` (self-signed cert) for on-server curl commands. `dev.andykeys.me` works only from external machines (browser, Windows). Local Docker is a fallback only — if a step only makes sense locally, label it clearly as `# Local Docker fallback (if dev server unavailable)`.
 - Use the correct compose file and service name for the environment being tested: `docker-compose.yml` with services `backend` / `postgres` for the dev server (project `portfolio_dev`) and prod (project `portfolio_prod`); `docker-compose.local.yml` with services `backend` / `postgres` for local laptop dev.
@@ -183,11 +195,13 @@ The AI does not merge PRs — you will review, test locally, and merge when read
 ### 5. Release to Production
 
 When you are ready to release to production, instruct the AI with:
-```
+
+```text
 Create a release branch for today and raise a PR to main
 ```
 
 The AI will:
+
 1. Create a `release/YYYY-MM-DD` branch from `dev` (or `release/YYYY-MM-DD-2`, etc. if already released today)
 2. Fetch all commits since the last release
 3. Raise a PR from `release/YYYY-MM-DD` → `main` with a summary:
@@ -201,6 +215,7 @@ The AI will:
    - Change state label from `awaiting release` to `released`.
 
 You will:
+
 1. Review the release summary
 2. Test any critical paths on `release/YYYY-MM-DD` if needed
 3. Approve and merge the PR to `main` (the AI does not merge)
@@ -209,6 +224,7 @@ You will:
 ### 6. Hotfixes (Emergency Production Fixes)
 
 If a critical bug is discovered on production:
+
 1. Instruct the AI to create a hotfix: `Create hotfix/issue-N-short-description for the production bug`
 2. The AI will branch from `main`, fix, commit, and raise a PR → `main`
 3. You review and approve the hotfix PR
@@ -219,7 +235,7 @@ If a critical bug is discovered on production:
 
 ### Branching diagram
 
-```
+```text
 main  ←(you approve)── release/YYYY-MM-DD ←── dev ←── feature/issue-N-*
  ↑                                              ←── fix/issue-N-*
  └── hotfix/issue-N-* ────────────────────────(emergency fixes only)
@@ -279,7 +295,7 @@ The AI performs doc lifecycle steps **as part of the release PR commit**, so the
 
 Follow imperative style with optional Co-Authored-By:
 
-```
+```text
 Short imperative summary (50 chars max)
 
 Optional explanation if the why isn't obvious.
@@ -290,6 +306,7 @@ Co-Authored-By: AI Model Name <noreply@ai-provider.com>
 Replace "AI Model Name" with your actual model (e.g., `Claude Haiku`, `Perplexity Sonar`, `GPT-4`).
 
 **Examples:**
+
 - ✅ `fix(#81): use /api as API_BASE in blog-post.js`
 - ✅ `feat(#78): add travel-post detail page`
 - ✅ `refactor: simplify lightbox initialization`
@@ -323,17 +340,20 @@ Key points summarised here:
 ### Comments
 
 Keep comments **concise and rare**. Add them only when:
+
 - The logic is unusual or non-obvious
 - Explaining a workaround for a specific bug
 - Documenting a hidden constraint or invariant
 - The code does something surprising
 
 Do NOT comment:
+
 - What the code does (use clear variable names instead)
 - The current task (that belongs in PR descriptions)
 - Obvious operations
 
 **Examples:**
+
 ```javascript
 // Good: explains why, not what
 var dateObj = new Date(String(d).slice(0, 10) + 'T00:00:00');
@@ -345,6 +365,7 @@ var name = user.name; // Get the user's name
 ### HTML / CSS / JS
 
 **ES Modules & Code Organization**
+
 - Frontend uses ES modules for all JavaScript (no inline scripts except minimal setup)
 - Create shared utilities in `resources/js/utils/*` instead of duplicating functions
 - Example patterns: `escapeHtml()`, `formatVisitDate()`, `formatRelativeDate()` are shared exports
@@ -352,12 +373,14 @@ var name = user.name; // Get the user's name
 - Avoid copy-pasting logic across multiple files — extract to utils first
 
 **HTML & CSS**
+
 - Keep CSS organized by component/feature
 - Prefer editing existing files over creating new ones
 - Delete unused code completely (no `// removed` comments)
 - Use semantic HTML (`<article>`, `<header>`, `<nav>`, `<button>` with proper `aria-` attributes)
 
 **JavaScript**
+
 - Use vanilla JS — jQuery has been fully removed (#385)
 - Use `const/let` in modern ES modules
 - For security-critical operations (escaping, DOM manipulation), always use shared utilities
@@ -365,6 +388,7 @@ var name = user.name; // Get the user's name
 - Prevent SQL injection: use parameterized queries on backend (never string concatenation)
 
 **Design Patterns (Anti-Debt)**
+
 - **DRY (Don't Repeat Yourself):** Extract repeated logic to utilities or shared functions
 - **Single Responsibility:** Each function/module has one clear purpose
 - **No Quick Fixes:** If tempted to duplicate code, create a utility instead

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ This document describes the system architecture at a high level — how the piec
 
 ## System Diagram
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                         Browser                                  │
 │                  (user visits andykeys.me)                      │
@@ -89,7 +89,7 @@ This document describes the system architecture at a high level — how the piec
 
 ### Top-level directories
 
-```
+```text
 MyPortfolioSite/
 ├── backend/                ← Node.js/Express application
 ├── resources/              ← Frontend (HTML, CSS, JS)
@@ -105,7 +105,7 @@ MyPortfolioSite/
 
 ### Backend structure
 
-```
+```text
 backend/
 ├── server.js               ← Express app setup, middleware, route registration
 ├── routes/
@@ -134,7 +134,7 @@ backend/
 
 ### Frontend structure
 
-```
+```text
 resources/
 ├── java/                   ← JavaScript ES modules
 │   ├── config.js           ← API_BASE, environment detection
@@ -167,7 +167,7 @@ resources/
 
 ### HTML pages
 
-```
+```text
 Root level (served as static files by Nginx):
 ├── index.html              ← Homepage (23KB, sections for projects, timeline, contact)
 ├── blog/index.html               ← Blog listing page
@@ -243,7 +243,7 @@ As an example of how the system works end-to-end:
 
 | Component | Risk | Impact | Mitigation |
 |-----------|------|--------|-----------|
-| `resources/js/admin/travel.js` | Largest admin module (495 lines); geocoding, EXIF, map | Read full file before editing; test travel CRUD + map flows |
+| `resources/js/admin/travel.js` | Largest admin module (495 lines); geocoding, EXIF, map | All travel admin features break if incorrectly modified | Read full file before editing; test travel CRUD + map flows |
 | `auth.js` | Complex WebAuthn + JWT state machine | Auth bugs have security implications | High test coverage, careful code review |
 | PostgreSQL (single instance) | No replication, no backup | Data loss if the server disk fails | Backup hardening outstanding — see ROADMAP §4.5 (#164) |
 | Nginx reverse proxy | Single point of failure | If Nginx breaks, entire site is down | Keep Nginx config simple and tested |
@@ -253,7 +253,7 @@ As an example of how the system works end-to-end:
 
 ## Deployment Pipeline
 
-```
+```text
 Feature branch
     ↓
 Create PR to `dev`

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -83,7 +83,7 @@ cp ~/backups/YYYY-MM-DD/prod.env ~/MyPortfolioSite/.env
 cp ~/backups/YYYY-MM-DD/dev.env  ~/MyPortfolioSite-dev/.env
 ```
 
-3. **Restore PostgreSQL data**
+1. **Restore PostgreSQL data**
 
 After bringing up the stacks once to create the DB containers:
 
@@ -99,7 +99,7 @@ docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml exec -T postgres pg_r
 
 Adjust service names if they differ (see **docs/DEV_ENVIRONMENT.md** and **docs/PROD_ENVIRONMENT.md**).
 
-4. **Bring services up**
+1. **Bring services up**
 
 ```bash
 # Prod
@@ -111,9 +111,10 @@ cd ~/MyPortfolioSite-dev
 docker compose -f docker-compose.dev-server.yml up -d --build
 ```
 
-5. **Smoke test**
+1. **Smoke test**
 
 Use the runbook and testing docs to verify:
+
 - Homepage and key pages load
 - Basic API calls work
 - Admin login and deployment flows succeed
@@ -127,5 +128,6 @@ When backup automation is added (cron job, offsite sync, etc.), document it here
 For now, aim to run the manual backup steps before major changes and periodically (e.g. monthly).
 
 See also:
+
 - **[docs/INFRASTRUCTURE.md](./INFRASTRUCTURE.md)** for host-level details
 - **[docs/UNTRACKED_FILES.md](./UNTRACKED_FILES.md)** for other files not in git but required

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 ## Release 2026-05-25
 
 ### Added
+
 - Frontend error logger (#333, #336): `error-logger.js` captures uncaught JS errors, resource-load failures, unhandled promise rejections, CSP violations, and explicit `console.error`/`console.warn` calls. Reports delivered to `POST /api/debug/errors`, persisted to `client_errors` table, and surfaced in the admin stats panel. Resilient delivery: failed sends buffered in `localStorage` and flushed on next page load (#334). Request-ID correlation (#336) groups all errors from the same page view and links frontend reports to the exact backend log line via `X-Request-Id`.
 - Error alert emails (#333): admin receives an email when 20+ frontend errors arrive within a 15-minute window (configurable via `ERROR_ALERT_THRESHOLD` / `ERROR_ALERT_WINDOW_MS`). In-memory cooldown prevents repeated emails during sustained storms. Top error types/messages included in the alert body.
 - Backend startup env validation (#357): `backend/utils/validateEnv.js` asserts every required env var (`PORT`, `DB_*`, `JWT_SECRET`, `WEBAUTHN_*`, `FRONTEND_URL`, `SITE_HOST`, `ADMIN_EMAIL`) is present and non-empty at startup via `validateEnvOrExit()`. A var defined in `.env` but not bridged into the compose `environment:` block resolves to empty in the container — the backend logs each missing var and exits 1, so the deploy rolls back instead of serving traffic with broken config.
@@ -23,6 +24,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Vitest test coverage for upload, cv, and debug routes (#335): auth gating, MIME filtering, size limits, private-info scan warnings, error ingestion/persistence, pagination, and sanitisation. `posts` tests extended with happy-path INSERT (201), PUT 404, and DELETE flows. Bug fix: `cv.js` `MulterError` now correctly returns 400 (was 500) via callback pattern.
 
 ### Fixed
+
 - Browser-extension errors filtered from error-logger (#356): uncaught errors and resource-load failures originating from `chrome-extension://`, `moz-extension://`, or `safari-extension://` URLs are discarded before reaching `/api/debug/errors`. Deploy-time Puppeteer tests now intercept and mock `POST /api/debug/errors` to prevent headless-Chromium noise (`Couldn't load fs/zlib`) from writing to `client_errors` and triggering false alert emails.
 - CORS smoke check added to regression suite (#357): `GET /api/health` with `Origin: https://<SITE_HOST>` (port omitted, as browsers send it) must succeed — catches the case where `SITE_HOST` is missing in the container and every site-origin request returns 500.
 - CSP violations handler made `async` (#360): `POST /api/debug/csp-violations` handler is now correctly `async` for CodeQL rate-limit pattern recognition.
@@ -31,11 +33,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Backup bootstrap on deploy (#352): deploy now creates the backup directory, installs the cron job, and takes an initial DB dump if none exists — ensures the backup schedule is active immediately after a fresh provision.
 
 ### Security
+
 - CSP `report-to` added alongside deprecated `report-uri` (#337): `Reporting-Endpoints` header names `/api/debug/csp-violations`; both directives present during transition.
 - Debug endpoint rate limiting migrated to DB-backed `createRateLimiter` (#337): limits survive container restarts and are consistent with auth/contact limiters.
 - `qs` dependency bumped (#321): resolves upstream prototype-pollution advisory.
 
 ### Changed
+
 - Deploy test-suite reporting normalised (#366): all five test phases (`vitest`, `error-logger`, `error-logger-contracts`, `csp-violations`, `regression`) now emit consistent `suite= tests= passed= failed=` counts in the deploy report. Backend Vitest counts read from the json reporter (immune to text-summary format drift). Deploy-time Puppeteer tests use `setRequestInterception` to mock `POST /api/debug/errors` so test sessions never write to `client_errors`. DEPLOY COMPLETE banner moved to after the report box.
 - Unified bash deploy scripts (#300): `dev-deploy.sh` and `prod-deploy.sh` replaced by a single `deploy.sh --env dev|prod`.
 - Project structure reorg (#307): HTML pages moved into feature subfolders (`blog/`, `travel/`, `admin/`, `login/`, `setup/`) giving clean URLs. `resources/java/` renamed to `resources/js/`. All internal links and the magic link email URL updated.
@@ -45,9 +49,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 ## Release 2026-05-26
 
 ### Added
+
 - Admin CRUD E2E test suite (#175): `test-admin-e2e.js` runs full authenticated Puppeteer CRUD flows (blog create/delete, travel create/delete, deploy panel smoke) on every deploy. Hard-fail on assertion error (triggers rollback); warn-only if Puppeteer fails to launch. Test records prefixed `[E2E]` are cleaned up at start and end of each run.
 
 ### Changed
+
 - Admin JS modularised (#175): 1,173-line `admin.js` monolith split into eight focused modules under `resources/js/admin/` (`posts.js`, `travel.js`, `deploy.js`, `cv.js`, `auth.js`, `passkeys.js`, `stats.js`, `notes.js`). `admin.js` is now a thin entry point that imports and initialises each module.
 - jQuery removed from admin panel (#176): all admin JS migrated to vanilla DOM APIs and `fetch`. No behaviour change.
 - Travel date field unified (#132): `visit_date`/`visitDate` alias removed from `TRAVEL_COLS`; field is now consistently `post_date` throughout the stack (backend routes, middleware schemas, frontend JS, utils, tests).
@@ -57,6 +63,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 ## Release 2026-05-25
 
 ### Added
+
 - Frontend error logger (#333, #336): `error-logger.js` captures uncaught JS errors, resource-load failures, unhandled promise rejections, CSP violations, and explicit `console.error`/`console.warn` calls. Reports delivered to `POST /api/debug/errors`, persisted to `client_errors` table, and surfaced in the admin stats panel. Resilient delivery: failed sends buffered in `localStorage` and flushed on next page load (#334). Request-ID correlation (#336) groups all errors from the same page view and links frontend reports to the exact backend log line via `X-Request-Id`.
 - Error alert emails (#333): admin receives an email when 20+ frontend errors arrive within a 15-minute window (configurable via `ERROR_ALERT_THRESHOLD` / `ERROR_ALERT_WINDOW_MS`). In-memory cooldown prevents repeated emails during sustained storms. Top error types/messages included in the alert body.
 - Backend startup env validation (#357): `backend/utils/validateEnv.js` asserts every required env var (`PORT`, `DB_*`, `JWT_SECRET`, `WEBAUTHN_*`, `FRONTEND_URL`, `SITE_HOST`, `ADMIN_EMAIL`) is present and non-empty at startup via `validateEnvOrExit()`. A var defined in `.env` but not bridged into the compose `environment:` block resolves to empty in the container — the backend logs each missing var and exits 1, so the deploy rolls back instead of serving traffic with broken config.
@@ -67,6 +74,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Vitest test coverage for upload, cv, and debug routes (#335): auth gating, MIME filtering, size limits, private-info scan warnings, error ingestion/persistence, pagination, and sanitisation. `posts` tests extended with happy-path INSERT (201), PUT 404, and DELETE flows. Bug fix: `cv.js` `MulterError` now correctly returns 400 (was 500) via callback pattern.
 
 ### Fixed
+
 - Browser-extension errors filtered from error-logger (#356): uncaught errors and resource-load failures originating from `chrome-extension://`, `moz-extension://`, or `safari-extension://` URLs are discarded before reaching `/api/debug/errors`. Deploy-time Puppeteer tests now intercept and mock `POST /api/debug/errors` to prevent headless-Chromium noise (`Couldn't load fs/zlib`) from writing to `client_errors` and triggering false alert emails.
 - CORS smoke check added to regression suite (#357): `GET /api/health` with `Origin: https://<SITE_HOST>` (port omitted, as browsers send it) must succeed — catches the case where `SITE_HOST` is missing in the container and every site-origin request returns 500.
 - CSP violations handler made `async` (#360): `POST /api/debug/csp-violations` handler is now correctly `async` for CodeQL rate-limit pattern recognition.
@@ -75,11 +83,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Backup bootstrap on deploy (#352): deploy now creates the backup directory, installs the cron job, and takes an initial DB dump if none exists — ensures the backup schedule is active immediately after a fresh provision.
 
 ### Security
+
 - CSP `report-to` added alongside deprecated `report-uri` (#337): `Reporting-Endpoints` header names `/api/debug/csp-violations`; both directives present during transition.
 - Debug endpoint rate limiting migrated to DB-backed `createRateLimiter` (#337): limits survive container restarts and are consistent with auth/contact limiters.
 - `qs` dependency bumped (#321): resolves upstream prototype-pollution advisory.
 
 ### Changed
+
 - Deploy test-suite reporting normalised (#366): all five test phases (`vitest`, `error-logger`, `error-logger-contracts`, `csp-violations`, `regression`) now emit consistent `suite= tests= passed= failed=` counts in the deploy report. Backend Vitest counts read from the json reporter (immune to text-summary format drift). Deploy-time Puppeteer tests use `setRequestInterception` to mock `POST /api/debug/errors` so test sessions never write to `client_errors`. DEPLOY COMPLETE banner moved to after the report box.
 - Unified bash deploy scripts (#300): `dev-deploy.sh` and `prod-deploy.sh` replaced by a single `deploy.sh --env dev|prod`.
 - Project structure reorg (#307): HTML pages moved into feature subfolders (`blog/`, `travel/`, `admin/`, `login/`, `setup/`) giving clean URLs. `resources/java/` renamed to `resources/js/`. All internal links and the magic link email URL updated.
@@ -89,6 +99,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 ## Release 2026-05-18
 
 ### Added
+
 - Deployment hardening (#263 A+B+C, #270): `check_disk_space`, `prompt_missing_vars`, `auto_detect_lan_ip`, `log_deploy_summary`, and `run_deploy_tests` (Vitest in the live container post-health-check; failure triggers rollback). Non-blocking backend startup preflight (DB + Outlook OAuth2) in `server.js` — warns, never crashes
 - `scripts/tests/test-regression.sh` — server-side bash regression smoke suite, run as the final step of every deploy; JWT generated from the running container so it matches the server's `JWT_SECRET`. Covers public baseline, auth gating (deploy/upload/posts/travel must 401 without a token), and (dev only) rate-limit enforcement
 - Machine-readable deploy output (#276): `[deploy:<phase>]` checkpoint lines at every decision point plus a final AI-readable deploy-report box aggregating the current run's checkpoints; `-Quiet` mode suppresses verbose noise while keeping checkpoints, warnings, errors, and the report
@@ -104,10 +115,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - `/health` endpoint made internal-only (#279): nginx no longer proxies the path; reachable only on the backend's direct port (localhost-bound in all compose files). Deploy health checks updated to use the direct port; `/api/health` alias removed
 
 ### Security
+
 - `POST /auth/setup` now enforces `ADMIN_EMAIL` server-side — wrong email and unconfigured server both return a generic 403; guard runs before any DB access (#274)
 - `/health` removed from public nginx routing — version, uptime, and DB status no longer exposed to the internet (#279)
 
 ### Changed
+
 - Regression tests moved server-side: `scripts/tests/Test-Regression.ps1` replaced by `test-regression.sh`; `dev-deploy.ps1` / `prod-deploy.ps1` stripped to thin SSH wrappers. Deploy scripts reach the running site via curl `--resolve` (server can't route to its own public DNS name); regression failure now always prints the report and exits non-zero rather than aborting silently
 - GitHub Actions CI disabled (`workflow_dispatch` only) — tests run in the deployed container instead (#270)
 - `docs/TESTING.md`, `docs/AI.md`, `CLAUDE.md` — updated for deploy-time Vitest + regression, `-SkipRegression`/`-Quiet`, the report box, and `test-regression.sh` replacing `Test-Regression.ps1`
@@ -119,6 +132,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Backend: all runtime `console.*` calls replaced with the structured logger (routes, middleware, utils, server/app entry); test/CLI scripts left as-is (#153)
 
 ### Removed
+
 - `docker/.env.example` — duplicate of root `.env.example`; README updated to reference the canonical file
 
 ---
@@ -126,6 +140,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 ## Release 2026-05-07
 
 ### Added
+
 - `/api/health` endpoint for deploy verification and uptime monitoring (#163)
 - Security headers to Nginx reverse proxy configuration (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)
 - `docs/INFRASTRUCTURE.md` — comprehensive server layout, service architecture, operational procedures, troubleshooting guide (#167)
@@ -140,10 +155,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - Dropbear SSH in initramfs for remote disk decryption on server reboot (#171)
 
 ### Fixed
+
 - Nginx template path bug in `docker-compose.yml` (was `scripts/nginx-*.conf.template`, now `scripts/config/nginx-*.conf.template`) (#152 merged)
 - SSH deploy target hostname changed from `portfolio-server` to `ak-home-server` (#179)
 
 ### Changed
+
 - Production architecture: from PM2 on host to Docker Compose containerized services (#165)
 - Nginx now reverse-proxies from Docker instead of system service (#165)
 - PostgreSQL now containerized with persistent volumes (#165)
@@ -151,6 +168,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - `.env` now loaded by Docker Compose at repo root instead of per-service (#171)
 
 ### Removed
+
 - `test-results/` directory from version control; added to `.gitignore` (#170)
 
 ---
@@ -158,6 +176,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 ## Release 2026-05-06
 
 ### Fixed
+
 - Admin page completely non-functional — `initDeploySection()` declared twice in `admin.js` causing a `SyntaxError` that prevented the entire file from parsing (#144)
 - Root cause: bad merge conflict resolution in `release/2026-05-05-2` kept both the old and new versions of the function; `type="module"` strict mode made this fatal in browsers
 
@@ -166,6 +185,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 ## Release 2026-05-05-2
 
 ### Added
+
 - Git fetch button in deployment panel — retrieves latest commits from remote before deploying (#129)
 - `POST /api/deploy/fetch` endpoint with SSE streaming output (#129)
 - Contact form dev stub — returns success in local dev when SMTP not configured; returns 503 in production with no SMTP (#100)
@@ -175,6 +195,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - All root-level docs consolidated under `docs/` (#130)
 
 ### Fixed
+
 - Deploy script uses `git reset --hard` instead of `git pull` to prevent local change conflicts (#123)
 - Blog and travel admin clear buttons now show confirmation prompt before resetting (#94)
 - Date slicing — travel and blog edit forms now correctly populate date fields (#93, #95)
@@ -182,6 +203,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - `$Host` reserved variable error in `prod-deploy.ps1` — renamed to `$Hostname`
 
 ### Changed
+
 - Scripts reorganised into logical subdirectories: `deploy/`, `dev/`, `infra/`, `monitoring/`, `config/`, `tests/`
 - All cross-references in docs updated to new `docs/` paths (#130)
 - PR template updated with smoke test and documentation checklist (#130)
@@ -191,6 +213,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 ## Release 2026-05-05
 
 ### Added
+
 - Admin deployment panel with live status, deploy history, and rollback capability (#98, #117)
 - `POST /api/deploy/` — SSE-streaming deploy endpoint
 - `POST /api/deploy/rollback` — rollback to a previous commit
@@ -199,6 +222,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - `backend/utils/shell.js` — shared spawn utilities for streaming child processes
 
 ### Fixed
+
 - Unhandled `spawn` error (`ENOENT`) when git not available in dev — backend no longer crashes (#118)
 - Deploy endpoints gracefully degrade when git unavailable rather than returning 500
 
@@ -207,9 +231,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 ## [Unreleased] — on `dev`, not yet in production
 
 ### Fixed
+
 - Delete button size/shape inconsistency — add `.btn-danger` variant to button system; `.travel-delete-btn` now composes from it, removing `!important` overrides (#137)
 
 ### Added
+
 - Travel post detail page (`travel-post.html`) with media gallery, Leaflet map, and lightbox (#78)
 - Public `GET /api/travel/:id` route for individual travel memories (#78)
 - Visit counter — tracks page visits per route, displayed in footer (#14)
@@ -236,6 +262,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - `.github/pull_request_template.md` — Smoke Test and Documentation checklist sections added (#130)
 
 ### Fixed
+
 - Blog post 404 errors — corrected `API_BASE` in `blog-post.js` to always use `/api` (#81)
 - Lightbox close/escape/arrow key handlers rewritten using native `addEventListener` (#82)
 - Map rendering on travel detail page — initialise Leaflet after `post-body` is visible (#78)
@@ -245,6 +272,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 - `npm test` in `docs/DEPENDENCIES.md` replaced with Docker wrapper command — aligns with project-wide rule (#130)
 
 ### Changed
+
 - Blog and travel post detail pages unified with consistent `.post-meta` date styling
 - Travel post section order changed to: map → gallery → notes
 - All cross-references in docs updated to new `docs/` paths (#130)
@@ -257,6 +285,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 > This is the state of `main` as of the initial CHANGELOG creation. Releases prior to this point are documented via git history.
 
 ### Fixed
+
 - API_BASE set correctly for prod vs localhost environments (#69, #70)
 - Nginx SSL template and deploy script reliability (#65, #67, #68)
 - npm install always runs in deploy script

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -36,6 +36,7 @@ Justification: [brief explanation of why this dependency is needed]"
 ```
 
 **Always use caret ranges** in package.json:
+
 - ✅ `^1.2.3` — Allows minor and patch updates (safe for breaking changes)
 - ❌ `1.2.3` — Pinned to exact version (prevents updates)
 - ❌ `*` — Any version (unpredictable)
@@ -67,12 +68,14 @@ Dependabot automatically suggests dependency updates:
 3. **Merge when ready** — Use auto-merge or manual merge
 
 **Major version updates** require:
+
 - ✅ Full test suite passing
 - ✅ Manual testing of affected features
 - ✅ Review of breaking change documentation
 - ✅ Explicit approval before merge
 
 **Minor/patch updates** can merge faster:
+
 - ✅ Tests passing
 - ✅ Quick skim of changelog
 - ✅ No manual testing usually needed

--- a/docs/DEPLOYMENT_LESSONS_LEARNED.md
+++ b/docs/DEPLOYMENT_LESSONS_LEARNED.md
@@ -21,6 +21,7 @@ The first production deployment to Ubuntu Server (2026-05-07) succeeded but enco
 **Resolution:** Reverted CSP entirely (see issue #181 for proper implementation plan). Other security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy) remained intact.
 
 **Lesson Learned:** CSP requires careful planning. Don't deploy restrictive CSP without:
+
 - Auditing all inline scripts in HTML
 - Identifying all external resources (APIs, CDNs)
 - Testing with actual external requests
@@ -37,10 +38,12 @@ The first production deployment to Ubuntu Server (2026-05-07) succeeded but enco
 **Impact:** Certbot validation failed repeatedly. Nginx container crashed at startup.
 
 **Resolution:**
+
 - Killed Apache processes: `sudo killall -9 httpd`
 - Removed Nextcloud: `sudo snap remove nextcloud`
 
 **Lesson Learned:**
+
 - For fresh deployments, use a **clean Ubuntu Server installation** (minimal packages only)
 - If reusing an existing server, verify no conflicting services are installed
 - Pre-flight checks should detect and warn about:
@@ -60,10 +63,12 @@ The first production deployment to Ubuntu Server (2026-05-07) succeeded but enco
 **Impact:** Unnecessary manual file creation. Wasted time on workarounds.
 
 **What Actually Happened:**
+
 1. Certbot failed (no port forwarding) → we created files manually
 2. Could have simply: Fixed port forwarding → Re-run certbot → Files created automatically
 
 **Resolution (Correct Approach):**
+
 ```bash
 # After fixing port forwarding on router:
 sudo certbot certonly --standalone -d yourdomain.com
@@ -71,12 +76,14 @@ sudo certbot certonly --standalone -d yourdomain.com
 ```
 
 **Lesson Learned:**
+
 - **When certbot fails, re-run it after fixing the root cause — don't manually create files**
 - Certbot handles all file creation automatically on successful runs
 - The root causes (port forwarding, DNS resolution) matter more than file creation
 - Manual file creation should only be used if certbot repeatedly fails for unrelated reasons
 
 **For server-setup.sh:**
+
 - Don't pre-create certbot files
 - Verify port forwarding works before running certbot
 - Let certbot create all necessary files on first successful run
@@ -94,6 +101,7 @@ sudo certbot certonly --standalone -d yourdomain.com
 **Resolution:** Manually configured port forwarding on router (not automated).
 
 **Lesson Learned:** Documentation should include:
+
 - Router port forwarding checklist
 - How to verify port accessibility: `curl http://<public-ip>/`
 - Alternative: document UPnP port mapping if router supports it
@@ -109,6 +117,7 @@ sudo certbot certonly --standalone -d yourdomain.com
 **Impact:** Extended troubleshooting time (spent 45+ minutes trying incremental fixes). **Would have been resolved in 5 minutes with a system reboot.**
 
 **Troubleshooting Attempts That Failed:**
+
 - `sudo systemctl restart docker` → still failed
 - `docker rm -f <container>` → permission denied
 - Re-running `usermod -aG docker` → no effect
@@ -117,12 +126,14 @@ sudo certbot certonly --standalone -d yourdomain.com
 **Actual Resolution:** Full system reboot solved everything immediately.
 
 **Lesson Learned:**
+
 - **When Docker gets into permission/state issues, do a full system reboot FIRST, not last**
 - Don't spend time on incremental Docker daemon restarts — they often don't clear kernel state
 - User group membership changes require a full login session or reboot to take effect
 - The 45 minutes spent troubleshooting could have been 5 minutes with a reboot
 
 **Recommendation for server-setup.sh:**
+
 ```bash
 # After Docker installation and user group changes
 echo "System reboot recommended to apply Docker group membership..."
@@ -142,6 +153,7 @@ fi
 **Root Cause:** Part of the same Docker state issue (Issue #5). Not actually a database timing problem.
 
 **What We Tried:**
+
 - Added `sleep 15` waiting for postgres ❌ (didn't help)
 - Added health check retries ❌ (didn't help)
 - Increased timeouts ❌ (didn't help)
@@ -149,6 +161,7 @@ fi
 **Actual Resolution:** Full system reboot (which also fixed the Docker permission issues).
 
 **Lesson Learned:**
+
 - **Don't add delays and retries hoping they'll fix database issues** — if the backend can't connect after postgres is healthy, it's usually a Docker/OS state problem, not timing
 - The symptom looked like a timing issue but wasn't
 - System reboot fixes the underlying issue immediately, no delays needed
@@ -180,6 +193,7 @@ Lessons from the snap → Docker CE migration carried out on 2026-05-11.
 **Root Cause:** systemd socket activation — `docker.socket` had not been started, so the socket file was never created even though the service unit appeared active.
 
 **Resolution:**
+
 ```bash
 sudo systemctl stop docker docker.socket
 sudo systemctl start docker.socket
@@ -197,11 +211,13 @@ sudo systemctl start docker
 **Symptom:** Every `apt update` after the migration printed warnings about a duplicate apt source for `download.docker.com`.
 
 **Root Cause:** The migration script added a new apt source list entry, but a file created by a previous manual Docker CE install attempt was still present:
-```
+
+```text
 /etc/apt/sources.list.d/archive_uri-https_download_docker_com_linux_ubuntu-noble.list
 ```
 
 **Resolution:**
+
 ```bash
 sudo rm /etc/apt/sources.list.d/archive_uri-https_download_docker_com_linux_ubuntu-noble.list
 sudo apt update
@@ -216,6 +232,7 @@ sudo apt update
 **Symptom:** N/A — this went right tonight, but is worth making explicit.
 
 **Lesson Learned:** `sudo snap remove --purge docker` should only be run **after**:
+
 1. Both the dev and prod stacks are confirmed healthy under Docker CE (`docker compose ps`, `curl /health`)
 2. You are satisfied there is no rollback needed
 
@@ -226,10 +243,12 @@ Do not include snap removal in the automated migration flow. Keep it as a manual
 #### 8d. Health check response interpretation — 301 and empty body are healthy
 
 **Symptom:** Post-migration health checks returned responses that looked like failures:
+
 - **Prod** `curl https://andykeys.me/health` → `301 Moved Permanently`
 - **Dev** `curl http://192.168.68.81:3001/health` → security headers with no response body
 
 **Root Cause:** These are correct, expected responses:
+
 - The prod 301 is the HTTP → HTTPS redirect working as intended; `curl -L` or a direct HTTPS request shows the real health response
 - The dev empty body is nginx returning security headers for a request it can proxy correctly; the backend is reachable
 
@@ -245,41 +264,58 @@ Before running `server-setup.sh`, verify:
 
 - [ ] Fresh Ubuntu Server LTS (22.04+) with minimal packages
 - [ ] No conflicting web servers installed:
+
   ```bash
   dpkg -l | grep -E 'apache2|nginx|httpd'  # Should return nothing
   ```
+
 - [ ] No pre-installed snaps interfering:
+
   ```bash
   snap list | grep -E 'nextcloud|apache|nginx'  # Should return nothing
   ```
+
 - [ ] Ports 80 and 443 are free:
+
   ```bash
   sudo netstat -tlnp | grep -E ':80|:443'  # Should return nothing
   lsof -i :80 -i :443 2>/dev/null         # Alternative check
   ```
+
 - [ ] No systemd services using those ports:
+
   ```bash
   systemctl list-units --type=service | grep -E 'apache|httpd|nginx|nextcloud'
   ```
+
 - [ ] Port 80/443 accessible from internet (after router config):
+
   ```bash
   curl --connect-timeout 5 http://yourserver-ip/ || echo "NOT accessible"
   ```
+
 - [ ] Domain resolves correctly:
+
   ```bash
   nslookup yourdomain.com  # Should show server IP
   ```
+
 - [ ] Router port forwarding configured (80→server, 443→server)
 - [ ] Sufficient disk space:
+
   ```bash
   df -h /  # Should have 10GB+ free
   ```
+
 - [ ] Internet connectivity:
+
   ```bash
   ping -c 1 8.8.8.8
   ```
+
 - [ ] SSH access working and no known_hosts errors
 - [ ] Time synchronized:
+
   ```bash
   timedatectl status  # Should show "System clock synchronized"
   ```
@@ -291,6 +327,7 @@ Before running `server-setup.sh`, verify:
 Instead of attempting everything at once, deploy incrementally:
 
 ### Phase 1: Core Infrastructure (HTTP only)
+
 1. Run server-setup.sh (modified to skip SSL)
 2. Bring up docker compose with HTTP-only nginx
 3. Verify backend health: `curl http://localhost/health`
@@ -298,11 +335,13 @@ Instead of attempting everything at once, deploy incrementally:
 5. Test basic API: `curl http://localhost/api/posts`
 
 ### Phase 2: Verify DNS & Accessibility
+
 1. Verify domain points to server: `nslookup yourdomain.com`
 2. Test external access: `curl http://yourdomain.com/health` from another machine
 3. Verify port forwarding: `nmap -p 80 yourdomain.com` (should show open)
 
 ### Phase 3: SSL Certificates
+
 1. Run certbot: `sudo certbot certonly --standalone -d yourdomain.com`
 2. Verify files exist: `ls /etc/letsencrypt/live/yourdomain.com/`
 3. Create helpers if needed: `options-ssl-nginx.conf`, `ssl-dhparams.pem`
@@ -311,6 +350,7 @@ Instead of attempting everything at once, deploy incrementally:
 6. Verify HTTPS: `curl https://yourdomain.com/health`
 
 ### Phase 4: Final Verification
+
 1. Test all endpoints:
    - `/health` (system health)
    - `/api/posts` (public content)
@@ -326,6 +366,7 @@ Instead of attempting everything at once, deploy incrementally:
 ### server-setup.sh Enhancements
 
 1. **Pre-flight Checks — Installed Programs:**
+
    ```bash
    # Check for conflicting packages
    if dpkg -l | grep -qE 'apache2|nginx|httpd'; then
@@ -344,6 +385,7 @@ Instead of attempting everything at once, deploy incrementally:
    ```
 
 2. **Pre-flight Checks — Port Usage:**
+
    ```bash
    # Verify ports 80 and 443 are free
    check_port() {
@@ -369,6 +411,7 @@ Instead of attempting everything at once, deploy incrementally:
    ```
 
 3. **Pre-flight Checks — Disk Space:**
+
    ```bash
    # Verify sufficient disk space
    AVAILABLE=$(df / | awk 'NR==2 {print $4}')  # In 1K blocks
@@ -383,6 +426,7 @@ Instead of attempting everything at once, deploy incrementally:
    ```
 
 4. **Pre-flight Checks — Network:**
+
    ```bash
    # Verify internet connectivity
    if ! ping -c 1 8.8.8.8 >/dev/null 2>&1; then
@@ -398,14 +442,16 @@ Instead of attempting everything at once, deploy incrementally:
    fi
    ```
 
-2. **Port Forwarding Validation:**
+5. **Port Forwarding Validation:**
+
    ```bash
    # After setup, test external accessibility
    curl --connect-timeout 5 http://$DOMAIN/ || \
      echo "WARNING: Port 80 not accessible from internet"
    ```
 
-3. **Certbot Helper File Creation:**
+6. **Certbot Helper File Creation:**
+
    ```bash
    # Create missing files if not present
    [ -f /etc/letsencrypt/options-ssl-nginx.conf ] || \
@@ -415,13 +461,14 @@ Instead of attempting everything at once, deploy incrementally:
      openssl dhparam -out /etc/letsencrypt/ssl-dhparams.pem 2048
    ```
 
-4. **Don't add excessive waiting/retries for database issues**
+7. **Don't add excessive waiting/retries for database issues**
    - If postgres is healthy but backend can't connect, it's a Docker state issue
    - Extra delays and retries won't fix underlying state problems
    - A system reboot fixes the issue immediately
    - Focus on preventing Docker state issues instead (see Issue #5)
 
-5. **Better Error Reporting:**
+8. **Better Error Reporting:**
+
    ```bash
    # Capture detailed errors for troubleshooting
    docker compose logs > /var/log/portfolio-setup-$(date +%s).log
@@ -456,6 +503,7 @@ If Docker gets into a bad state during setup:
 1. **First attempt:** `docker compose down && docker system prune -f`
 2. **Second attempt:** `sudo systemctl restart docker`
 3. **If still failing:** Don't spend more than 5 minutes trying fixes — **just reboot**
+
    ```bash
    sudo reboot
    ```
@@ -467,6 +515,7 @@ If Docker gets into a bad state during setup:
 ## Environment & Infrastructure Notes
 
 ### Server Configuration
+
 - **OS:** Ubuntu Server 22.04 LTS (fresh installation recommended)
 - **Architecture:** Moved from Raspberry Pi (initial Pi setup) to Ubuntu Server (production deployment)
 - **Docker:** Single docker-compose.yml for both local dev and production
@@ -474,12 +523,14 @@ If Docker gets into a bad state during setup:
 - **Reverse Proxy:** Nginx in Docker container (production) or direct backend (local dev)
 
 ### Environment Variables Handling
+
 - **Critical:** JWT_SECRET and DB_PASSWORD must be set before `docker compose up`
 - **File:** `.env.prod` contains production values; not checked into git
 - **Timing:** Environment vars needed at docker-compose startup, not during setup script runtime
 - **Secrets:** Keep passwords in `.env.prod` and `~/.env` files, never in docker-compose.yml
 
 ### Docker Compose Differences
+
 - **Local Dev:** docker-compose.yml with explicit bind mounts
 - **Production:** Same compose file with `.env.prod` overrides (BACKEND_HOST=127.0.0.1 instead of 'backend')
 - **Volume Mounts:** Use explicit `type: bind` for Windows path compatibility (MSYS translation issues)
@@ -535,6 +586,7 @@ ls -la /etc/letsencrypt/live/yourdomain.com/
 ```
 
 ### What Did NOT Help
+
 - ❌ Adding `sleep` delays to database checks — timing was not the issue
 - ❌ Restarting Docker daemon incrementally — kernel state issues require reboot
 - ❌ Manually creating certbot helper files — should have re-run certbot instead
@@ -542,6 +594,7 @@ ls -la /etc/letsencrypt/live/yourdomain.com/
 - ❌ Incremental docker-compose down/up cycles — didn't clear stale containers
 
 ### What Solved Problems
+
 - ✅ Full system reboot — immediately cleared Docker state issues
 - ✅ Checking port availability BEFORE anything else — prevented cascading failures
 - ✅ Re-running certbot after fixing port forwarding — created missing SSL files automatically
@@ -645,6 +698,7 @@ After implementing improvements, test the revised setup script:
 **Estimated time with improvements:** ~30-45 minutes
 
 **Risk mitigation:**
+
 - Phase-by-phase validation catches issues early
 - Pre-flight checks prevent common mistakes
 - Better error messages reduce troubleshooting time

--- a/docs/DEV_ENVIRONMENT.md
+++ b/docs/DEV_ENVIRONMENT.md
@@ -52,7 +52,7 @@ bash ~/MyPortfolioSite-dev/scripts/deploy/deploy.sh --env dev
 
 The script checks for a `.env` file. If one doesn't exist it copies `.env.dev-server.example` into place and stops with instructions:
 
-```
+```text
 [WARN]  .env created but not yet configured.
 [WARN]  Edit ~/MyPortfolioSite-dev/.env and set these values:
 [WARN]    LAN_IP           — your server LAN IP (ip -4 addr show)
@@ -66,6 +66,7 @@ The script checks for a `.env` file. If one doesn't exist it copies `.env.dev-se
 Edit `~/MyPortfolioSite-dev/.env`, fill in the values above, then re-run the deploy script. Everything else in the file can stay as defaulted.
 
 Generate secrets with:
+
 ```bash
 openssl rand -base64 32
 ```
@@ -74,7 +75,7 @@ openssl rand -base64 32
 
 The script validates `.env`, builds the containers, and polls the health endpoint. On success:
 
-```
+```text
 ╔══════════════════════════════════════════╗
 ║           Dev deploy complete ✓          ║
 ╚══════════════════════════════════════════╝
@@ -124,6 +125,7 @@ docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml -p portfolio_dev rest
 **Health check fails after deploy**
 
 The deploy script automatically dumps container logs on failure. To investigate manually:
+
 ```bash
 docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml -p portfolio_dev logs --tail=50 backend
 docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml -p portfolio_dev logs --tail=20 postgres
@@ -138,12 +140,14 @@ Fix: navigate directly to `https://dev.andykeys.me:3001/resources/js/nav.js` in 
 Permanent fix: import the cert into Firefox's certificate store — Preferences → Privacy & Security → Certificates → View Certificates → Import → select `scripts/config/certs/dev-server.crt`.
 
 **Port 3001 not reachable from other LAN devices**
+
 ```bash
 sudo ufw status        # confirm the allow rule is present
 sudo lsof -i :3001     # confirm nginx is listening
 ```
 
 **WebAuthn / passkey errors on the dev site**
+
 - Confirm `WEBAUTHN_RP_ID` in `.env` is the bare IP (no `http://`, no port)
 - Confirm `WEBAUTHN_ORIGIN` is exactly `http://<LAN_IP>:3001`
 - Passkeys registered on prod will not work on dev (different origin — expected)

--- a/docs/DOCKER_MIGRATION.md
+++ b/docs/DOCKER_MIGRATION.md
@@ -3,6 +3,7 @@
 This document describes how to migrate the MyPortfolioSite dev/prod servers from Docker installed via **snap** to Docker CE installed via **apt**, using the helper scripts under `scripts/setup/`.
 
 The goals are:
+
 - Eliminate snap/AppArmor-related `permission denied` issues when stopping containers.
 - Standardise on Docker CE using `/var/lib/docker`.
 - Preserve dev and prod environment configuration files (`.env`).
@@ -168,7 +169,7 @@ The following were encountered during the first live migration run and are docum
 
 After Docker CE is installed and `systemctl status docker` looks healthy, all `docker` commands may still fail with:
 
-```
+```text
 Cannot connect to the Docker daemon at unix:///run/docker.sock
 ```
 

--- a/docs/INCIDENTS.md
+++ b/docs/INCIDENTS.md
@@ -17,6 +17,7 @@ One or two sentences describing what broke and when.
 Who was affected (you only, public visitors), and how (downtime, errors, data issue).
 
 **Timeline**  
+
 - `HH:MM` — Issue noticed
 - `HH:MM` — First mitigation
 - `HH:MM` — Root cause identified
@@ -30,6 +31,7 @@ What you changed to restore service.
 
 **Follow-ups**  
 Links to:
+
 - Code changes (PRs, commits)
 - Documentation updates (e.g. RUNBOOK, BACKUP, INFRASTRUCTURE)
 - Any new monitoring or alerts added
@@ -47,6 +49,7 @@ Dev deployments started serving old backend code despite successful deploy scrip
 Only affected dev environment; prod not impacted.
 
 **Timeline**  
+
 - `21:05` — Noticed new API route 404ing on dev after deploy
 - `21:15` — Confirmed new code was on disk but container was old image
 - `21:30` — Manually removed orphan container and re-ran deploy
@@ -59,6 +62,7 @@ Old container with the same name was not being removed; deploy script updated im
 Updated deploy script to use `docker compose up -d --force-recreate` and added explicit container removal step.
 
 **Follow-ups**  
+
 - Linked script change in `scripts/deploy/dev-deploy.sh`
 - Added note to **docs/DEPLOYMENT_LESSONS_LEARNED.md** and referenced this incident
 - Added a check to regression tests to hit the new route explicitly

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -47,6 +47,7 @@ dlog()       # Raw log lines — auto-redacted
 ```
 
 **Example:**
+
 ```bash
 # Input
 dinfo "Backend running at https://192.168.68.81:3001 on host $(hostname)"
@@ -153,6 +154,7 @@ dlog "JWT_SECRET: ******* ($(echo -n "$JWT_SECRET" | wc -c) chars)"
 The log file (`/home/[USER]/dev-deploy.log` or similar) is **local to the server**. Sensitive information is redacted before writing.
 
 **Before sharing logs:**
+
 1. Run through `_redact_sensitive()` again to verify
 2. Check for missed IP addresses, usernames, paths
 3. Use `grep -v` to filter if needed

--- a/docs/PRE_DEPLOYMENT_CHECKLIST.md
+++ b/docs/PRE_DEPLOYMENT_CHECKLIST.md
@@ -7,6 +7,7 @@ Complete this checklist **before** running `server-setup.sh`. Each section must 
 ## 1. Network & Router Configuration
 
 ### Domain Setup
+
 - [ ] Domain registered and you have access to DNS settings
 - [ ] **DDNS provider configured** (for dynamic IP addresses):
   - [ ] Provider chosen (Namecheap, No-IP, DuckDNS, etc.)
@@ -14,6 +15,7 @@ Complete this checklist **before** running `server-setup.sh`. Each section must 
   - [ ] DDNS client installed and configured on server (if not using docker-compose)
   - Example: Namecheap DDNS password saved for server-setup.sh
 - [ ] Domain configured to point to your server's public IP
+
   ```bash
   # Verify: Run this on any machine
   nslookup yourdomain.com
@@ -21,9 +23,10 @@ Complete this checklist **before** running `server-setup.sh`. Each section must 
   ```
 
 ### Router Port Forwarding
+
 **This is critical — Let's Encrypt will fail without this!**
 
-- [ ] Log into your router's admin panel (usually http://192.168.1.1 or http://192.168.0.1)
+- [ ] Log into your router's admin panel (usually <http://192.168.1.1> or <http://192.168.0.1>)
 - [ ] Find Port Forwarding settings (usually under "Advanced" or "NAT")
 - [ ] Create forwarding rule:
   - **External Port:** 80
@@ -38,7 +41,9 @@ Complete this checklist **before** running `server-setup.sh`. Each section must 
 - [ ] Save and reboot router if prompted
 
 ### Verify Port Forwarding Works
+
 Run these commands from a **different machine** (not the server):
+
 ```bash
 # Test HTTP port
 curl --connect-timeout 5 http://yourdomain.com/
@@ -54,18 +59,22 @@ curl -I http://yourdomain.com:80/  # Should connect (even if 404)
 ## 2. Server Prerequisites
 
 ### Fresh Ubuntu Server
+
 - [ ] Ubuntu Server LTS 22.04 or later
 - [ ] **Fresh installation (minimal packages only) — strongly recommended**
   - Avoid reusing servers that had previous hobby projects
   - Pre-installed services can conflict with deployment
 - [ ] Root or sudo access
 - [ ] Internet connection working
+
   ```bash
   ping -c 1 8.8.8.8  # Should succeed
   ```
 
 ### No Conflicting Software Installed
+
 Run on the server:
+
 ```bash
 # Check for web servers
 dpkg -l | grep -E 'apache2|nginx|httpd'
@@ -75,46 +84,59 @@ dpkg -l | grep -E 'apache2|nginx|httpd'
 snap list | grep -E 'nextcloud|apache|nginx'
 # Should return NOTHING
 ```
+
 - [ ] No Apache, Nginx, or Nextcloud installed
 - [ ] If found, remove them:
+
   ```bash
   sudo apt remove apache2 nginx httpd
   sudo snap remove nextcloud
   ```
 
 ### Ports Available
+
 Run on the server:
+
 ```bash
 # Check if ports 80 and 443 are free
 sudo lsof -i :80 -i :443
 # Should return NOTHING
 ```
+
 - [ ] Ports 80 and 443 are not in use
 - [ ] If in use, identify and stop the service:
+
   ```bash
   sudo systemctl stop <service-name>
   sudo systemctl disable <service-name>
   ```
 
 ### Disk Space
+
 Run on the server:
+
 ```bash
 df -h /
 # Look at "Available" column
 ```
+
 - [ ] At least 10GB free disk space
 - [ ] If less than 5GB, clean up before continuing:
+
   ```bash
   sudo apt clean
   sudo apt autoremove
   ```
 
 ### Time Synchronized
+
 Run on the server:
+
 ```bash
 timedatectl status
 # Should show "System clock synchronized: yes"
 ```
+
 - [ ] System time is synchronized (critical for SSL certificates)
 
 ---
@@ -122,6 +144,7 @@ timedatectl status
 ## 3. SSH & Access
 
 ### SSH Access
+
 - [ ] Can SSH into server: `ssh user@server-ip`
 - [ ] Can run sudo commands without password prompt (ideally)
 - [ ] SSH key-based auth working (if using keys)
@@ -133,6 +156,7 @@ timedatectl status
 **⚠️ Have these ready BEFORE starting deployment — the setup script will ask for them:**
 
 ### Domain & DDNS
+
 - [ ] **Domain name:** `andykeys.me` (or your domain)
 - [ ] **DDNS provider configured** (if using dynamic IP):
   - [ ] Provider chosen and account created (Namecheap, No-IP, DuckDNS, etc.)
@@ -141,26 +165,32 @@ timedatectl status
   - Keep these safe — server-setup.sh will need them
 
 ### Application Secrets
+
 Generate these strong random strings before starting:
 
 - [ ] **Database password** — Generate with:
+
   ```bash
   openssl rand -base64 32
   ```
+
   Save as: `DB_PASSWORD=`________________
 
 - [ ] **JWT secret** — Generate with:
+
   ```bash
   openssl rand -base64 32
   ```
+
   Save as: `JWT_SECRET=`________________
 
 ### Email Configuration (Optional)
+
 Can be configured later if needed:
 
 - [ ] SMTP Host: `smtp-mail.outlook.com` (or your provider)
 - [ ] SMTP Port: `587`
-- [ ] SMTP Username: your-email@outlook.com
+- [ ] SMTP Username: <your-email@outlook.com>
 - [ ] SMTP App-Specific Password (not your regular password)
 - [ ] Admin Email Address
 
@@ -169,21 +199,27 @@ Can be configured later if needed:
 ## 5. Docker & Git
 
 ### Docker Installation
+
 Run on the server:
+
 ```bash
 docker --version
 # Should show: Docker version X.X.X
 ```
+
 - [ ] Docker is installed and working
 - [ ] If not: the setup script will install it
 
 ### Git Access
+
 Run on the server:
+
 ```bash
 git clone https://github.com/AndyRKeys/MyPortfolioSite.git /tmp/test
 # Should succeed
 rm -rf /tmp/test
 ```
+
 - [ ] Can clone the repository
 - [ ] GitHub is accessible from server
 
@@ -192,6 +228,7 @@ rm -rf /tmp/test
 ## 6. Final Verification
 
 ### Automated Server Readiness Check (Recommended)
+
 Run this script to automatically verify all prerequisites:
 
 ```bash
@@ -200,6 +237,7 @@ bash scripts/deploy/check-server-ready.sh yourdomain.com
 ```
 
 This checks:
+
 - OS version and system clock
 - Disk space (10GB+ free)
 - Ports 80 & 443 available
@@ -212,6 +250,7 @@ This checks:
 Expected output: `✓ Server is ready for deployment`
 
 ### Alternative: Manual Verification
+
 If you prefer to check items manually or the script encounters issues:
 
 ```bash
@@ -221,13 +260,14 @@ bash scripts/deploy/server-setup.sh yourdomain.com --check-only
 ```
 
 ### Backup Current Server State (if migrating)
+
 - [ ] Database backed up (if migrating from old server)
 - [ ] Any custom data backed up
 - [ ] Have rollback plan if needed
 
 ---
 
-## 7. Ready to Deploy!
+## 7. Ready to Deploy
 
 Once all items are checked:
 
@@ -243,18 +283,21 @@ bash scripts/deploy/server-setup.sh yourdomain.com
 ## Troubleshooting Common Issues
 
 ### "Port 80/443 Not Accessible"
+
 - [ ] Verify router port forwarding is saved
 - [ ] Check router is not blocking those ports
 - [ ] Try from a different network (mobile hotspot)
 - [ ] Verify public IP hasn't changed
 
 ### "Domain Doesn't Resolve"
+
 - [ ] Wait 5-10 minutes for DNS propagation
 - [ ] Check DNS settings in your registrar
 - [ ] Verify public IP is correct: `curl ifconfig.me`
 - [ ] Flush DNS cache: `ipconfig /flushdns` (Windows) or `sudo dscacheutil -flushcache` (Mac)
 
 ### "Certbot Fails"
+
 - [ ] **First, identify the root cause:**
   - Port forwarding must be working (test with curl above)
   - Domain must resolve to your IP
@@ -262,9 +305,11 @@ bash scripts/deploy/server-setup.sh yourdomain.com
   - Check firewall isn't blocking outbound connections
 
 - [ ] **Fix the root cause, then re-run certbot**
+
   ```bash
   sudo certbot certonly --standalone -d yourdomain.com
   ```
+
   Don't manually create SSL files — certbot creates them automatically
 
 - [ ] **Certbot creates these automatically:**
@@ -275,16 +320,20 @@ bash scripts/deploy/server-setup.sh yourdomain.com
 - [ ] Only if certbot repeatedly fails: check `/var/log/letsencrypt/letsencrypt.log` for details
 
 ### "Docker Permission Denied"
+
 - [ ] User must be in docker group: `groups $USER`
 - [ ] If not: `sudo usermod -aG docker $USER`
 - [ ] **Logout/login or reboot** (group membership requires new shell session)
 - [ ] If still failing: **Do a full system reboot**
+
   ```bash
   sudo reboot
   ```
+
   This is faster than trying incremental Docker daemon restarts
 
 ### "Database Connection Failed"
+
 - [ ] Wait 30 seconds for postgres to initialize
 - [ ] Check Docker is running: `docker ps`
 - [ ] Check logs: `docker compose logs postgres`

--- a/docs/PROJECT_ASSESSMENT.md
+++ b/docs/PROJECT_ASSESSMENT.md
@@ -154,6 +154,7 @@ This is an unusual section for a project assessment, but it is directly relevant
 These are ordered by impact-to-effort ratio, considering both operational risk and agent friction.
 
 **Resolved (no longer blocking):**
+
 1. ✅ **Done — `docs/INFRASTRUCTURE.md` written** (Compose service names, Nginx config paths, cert locations, ddclient config and other server-specific facts). Now complemented by `docs/TERMINOLOGY.md`. Keep both current.
 2. ✅ **Done — production containerised** (migrated off the Raspberry Pi to Ubuntu Server, Docker Compose; #165/#171/#179). Dev and prod environments are now aligned.
 3. ✅ **Done — `/health` endpoint** (internal-only; #279, Release 2026-05-18).

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -66,18 +66,21 @@ Frontend modernisation, admin UX, auth hardening, and deploy reliability release
 ### Features
 
 **Admin sub-pages with responsive subnav (#378)**
+
 - Monolithic `admin/index.html` replaced with a dashboard and six dedicated sub-pages (posts, travel, deploy, CV, stats, notes/auth/passkeys)
 - `admin-subnav.js` injects a shared responsive horizontal navigation bar across all admin pages
 - Each page loads only its own JS module entry point — no unrelated code runs on load
 - E2E test updated to navigate sub-pages; JS runtime check extended to cover all admin pages
 
 **Puppeteer JS runtime check for all public pages (#390)**
+
 - `test-public-pages.js` added to the deploy pipeline: loads `/`, `/blog/`, `/travel/`, `/login/`, `/setup/`, and dynamically discovered blog/travel post pages after every deploy
 - Fails the deploy (warn-only) on any unhandled JS exception on public pages
 - `test-admin-e2e.js` extended with `pageerror` tracking during CRUD interactions
 - All Puppeteer API calls use browser-page fetch so `--ignore-certificate-errors` covers self-signed dev certs without Node-level overrides
 
 **Travel coordinate privacy (#244)**
+
 - Public endpoints `GET /travel` and `GET /travel/:id` now return coordinates rounded to 2 decimal places (~1km precision)
 - Admin endpoints (`GET /travel/all`, `GET /travel/admin/:id`) retain full 6-decimal precision for editing
 - Query-layer only via `TRAVEL_COLS_PUBLIC` constant — no schema changes
@@ -85,12 +88,14 @@ Frontend modernisation, admin UX, auth hardening, and deploy reliability release
 ### Changed
 
 **jQuery removed from all public pages (#385)**
+
 - `script.js`, `blog.js`, `travel.js`, `travel-post.js`, and `utils/dom.js` migrated to vanilla DOM APIs
 - `jquery-3.5.1.min.js` (87KB) removed from all public pages — no external JS dependency on the public site
 - Net: −1,575 lines; no behaviour change
 - Also adds hover lift to timeline cards and improves error logging in blog/travel catch handlers
 
 **Auth setup endpoint retired (#282, #283)**
+
 - `POST /auth/setup` returns 410 Gone; account creation now happens automatically on the first magic-link send via the existing upsert in `POST /api/auth/email/send`
 - `setup/index.html` replaces the account-creation form with a redirect to `/login/`
 - Deleting the last passkey now shows a warning that magic-link sign-in remains available
@@ -123,21 +128,25 @@ Admin panel refactoring release. Deconstructs the 1,173-line `admin.js` monolith
 ### Changed
 
 **Admin JS modularised (#175)**
+
 - 1,173-line `admin.js` split into per-feature ES modules under `resources/js/admin/`: `posts.js`, `travel.js`, `deploy.js`, `cv.js`, `auth.js`, `passkeys.js`, `stats.js`, `notes.js`
 - `admin.js` is now a thin entry point (~20 lines) that imports and initialises each module
 - Agents and maintainers can now target individual modules rather than reasoning about the full monolith
 
 **jQuery removed from admin panel (#176)**
+
 - All admin JS migrated to vanilla DOM APIs and `fetch`
 - No behaviour change; eliminates the jQuery/vanilla ambiguity in the admin codebase
 
 **Travel date field unified (#132)**
+
 - `visit_date`/`visitDate` alias removed from `TRAVEL_COLS`
 - Field is now consistently `post_date` throughout: backend routes, middleware schemas, frontend JS, utils, and tests
 
 ### Added
 
 **Admin CRUD E2E test suite (#175)**
+
 - `test-admin-e2e.js` — Puppeteer script covering authenticated blog create/delete, travel create/delete, and deploy panel smoke
 - Wired into `deploy.sh` as a hard-fail phase (triggers rollback on assertion failure)
 - Test records prefixed `[E2E]` cleaned up at start and end of each run
@@ -158,30 +167,37 @@ Observability and deploy-hardening release. Adds a frontend error logger with al
 ### Features
 
 **Frontend error logger (#333, #334, #336)**
+
 - feat(#333): `error-logger.js` captures uncaught JS errors, resource-load failures, unhandled promise rejections, CSP violations, and `console.error`/`console.warn` calls; reports to `POST /api/debug/errors`, persisted to `client_errors` table, surfaced in admin stats panel
 - feat(#333): admin alert email when 20+ frontend errors arrive within 15 minutes (`ERROR_ALERT_THRESHOLD` / `ERROR_ALERT_WINDOW_MS`); in-memory cooldown prevents repeated emails during sustained storms
 - feat(#334): failed error sends buffered in `localStorage` and flushed on next page load — delivery resilient across page navigations
 - feat(#336): request-ID correlation — `X-Request-Id` links every frontend error report to the exact backend log line for the same page view
 
 **Backend startup env validation (#357)**
+
 - feat(#357): `backend/utils/validateEnv.js` asserts every required env var at startup via `validateEnvOrExit()`; logs each missing var and exits 1, triggering deploy rollback instead of serving traffic with broken config
 - feat(#357): CORS smoke check added to regression suite — `GET /api/health` with `Origin: https://<SITE_HOST>` must succeed; catches the case where `SITE_HOST` is absent in the container
 
 **CSP scanning on every deploy (#341, #342)**
+
 - feat(#341): `test-csp-violations.js` loads all served pages (`/`, `/blog/`, `/travel/`, `/login/`, `/admin/`, `/setup/`) in Puppeteer after each deploy, flags any `securitypolicyviolation` event; warn-only with machine-parseable `[csp-violations]` summary line in the deploy report
 - feat(#342): `test-admin-e2e-csp.js` mints a JWT, injects it into `localStorage.adminToken`, loads `/admin/`, and drives Nominatim geocode interactions — catches auth-path CSP breaks like the original #330 incident
 
 **Dev hostname redirect (#358)**
+
 - feat(#358): `dev.andykeys.me:443` now redirects to `dev.andykeys.me:3001` via a prod-nginx `server` block, eliminating the port-confusion support burden
 
 **Vitest coverage (#335)**
+
 - feat(#335): upload, cv, and debug route test coverage — auth gating, MIME filtering, size limits, private-info scan warnings, error ingestion/persistence, pagination, sanitisation; posts tests extended with INSERT (201), PUT 404, and DELETE flows
 - fix(#335): `cv.js` `MulterError` now correctly returns 400 (was 500) via multer callback pattern
 
 **Unified deploy scripts (#300)**
+
 - feat(#300): `dev-deploy.sh` and `prod-deploy.sh` merged into `deploy.sh --env dev|prod`; env-specific behaviour gated by feature flags; PowerShell wrappers updated to match
 
 **Project structure reorg (#307)**
+
 - feat(#307): HTML pages moved into feature subfolders (`blog/`, `travel/`, `admin/`, `login/`, `setup/`) for clean URLs; `resources/java/` renamed to `resources/js/`; all internal links and magic-link email URL updated; Nginx `try_files` handles directory routing with no config changes
 
 ### Bug Fixes
@@ -202,6 +218,7 @@ Observability and deploy-hardening release. Adds a frontend error logger with al
 ### Deploy Test Reporting (#366)
 
 All five deploy test phases now emit consistent `suite= tests= passed= failed=` counts in the deploy report:
+
 - **vitest** — counts read from json reporter output file (immune to text-summary format drift)
 - **error-logger** — Puppeteer page-load checks for `[error-logger] Initializing`
 - **error-logger-contracts** — API contract checks for `POST /api/debug/errors` and `GET /api/debug/errors`
@@ -287,6 +304,7 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 ### Features
 
 **Dev environment on Ubuntu Server — LAN-only, port 3001 (PR #201)**
+
 - feat(#159): `docker-compose.dev-server.yml` — separate Docker stack running the `dev` branch alongside production; services: `postgres-dev` (`portfolio_dev` DB), `backend-dev` (port 8081 internal), `nginx-dev` (port 3001, LAN-only)
 - feat(#159): `scripts/config/nginx-dev-server.conf.template` — HTTP-only nginx on port 3001 with full security headers (CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy)
 - feat(#159): `.env.dev-server.example` — env template documenting `LAN_IP`, separate DB and JWT secrets, and WebAuthn origin pointing at `http://<LAN_IP>:3001`
@@ -313,6 +331,7 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 ### Bug Fixes
 
 **Content Security Policy fix (PR #198)**
+
 - fix(#197): extract inline scripts to external modules to satisfy CSP (`admin-init.js`, `login-init.js`)
 - fix(#197): add `cdn.jsdelivr.net` to CSP `script-src` (Leaflet maps dependency)
 - fix(#197): update `API_BASE` handling and add CSP policy headers
@@ -372,12 +391,14 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 ### Features & Improvements
 
 **Infrastructure Quick Wins (PR #177)**
+
 - feat(#163): `/api/health` endpoint returns status + DB connectivity + uptime + version
 - security: MIME sniffing prevention, clickjacking protection, Referrer-Policy, Permissions-Policy headers
 - docs(#167): `docs/INFRASTRUCTURE.md` — server layout, service architecture, operational procedures, troubleshooting, Dropbear remote decryption workflow
 - docs(#168): `docs/ARCHITECTURE.md` — system diagram, request flows, file structure, data flow examples
 
 **Docker Compose Production Migration (PR #179)**
+
 - feat(#165): `docker-compose.prod.yml` — production-grade containerization with postgres, backend (prod target), nginx, named volumes, SSL cert mounting
 - feat(#165): Production architecture now entirely containerized: postgres 16, Node.js backend, nginx reverse proxy
 - feat(#171): `scripts/deploy/server-setup.sh` — one-shot Ubuntu Server LTS initialization script
@@ -397,6 +418,7 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 ### Breaking Changes / Deployment Notes
 
 **⚠️ MAJOR: Docker Compose production deployment**
+
 - Production now runs entirely via Docker Compose instead of PM2 on host
 - No more system-level PostgreSQL, Nginx, or Node.js services
 - Requires fresh server setup via `scripts/deploy/server-setup.sh` on Ubuntu Server LTS 22.04+
@@ -422,10 +444,12 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 **PR:** #144
 
 ### Bug Fixes
+
 - fix(#144): remove duplicate `initDeploySection()` declaration in `admin.js` — caused a fatal `SyntaxError` in ES module strict mode, breaking every admin panel section on page load
 - Root cause: bad merge conflict resolution in `release/2026-05-05-2` kept both the old and new versions of the function
 
 ### Breaking Changes / Deployment Notes
+
 - None — frontend-only fix; no backend restart or DB changes required
 
 ---
@@ -437,9 +461,11 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 **PR:** #140
 
 ### Bug Fixes
+
 - fix(#140): restore missing deployment section HTML in `admin.html` — the deployment panel tab content was absent after the `release/2026-05-05-2` merge, making the deploy console inaccessible
 
 ### Breaking Changes / Deployment Notes
+
 - None — frontend-only fix; no backend restart or DB changes required
 
 ---
@@ -451,6 +477,7 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 **PR:** #126
 
 ### Features
+
 - feat(#129): git fetch button in deployment panel — retrieves latest commits from remote before deploying
 - feat(#129): `POST /api/deploy/fetch` endpoint with SSE streaming output
 - feat(#100): contact form dev stub — returns `{ success: true }` in local dev when SMTP not configured; returns 503 in production
@@ -460,6 +487,7 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 - chore(#130): all root-level docs consolidated under `docs/`
 
 ### Bug Fixes
+
 - fix(#123): deploy script uses `git reset --hard` instead of `git pull` to prevent local change conflicts
 - fix(#94): blog and travel admin clear buttons now show confirmation prompt before resetting
 - fix(#93, #95): date slicing — travel and blog edit forms now correctly populate date fields
@@ -467,6 +495,7 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 - fix: `$Host` reserved variable error in `prod-deploy.ps1` — renamed to `$Hostname`
 
 ### Breaking Changes / Deployment Notes
+
 - None — `npm install` runs automatically in the deploy script if `package.json` changed
 
 ---
@@ -478,6 +507,7 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 **PR:** #113
 
 ### Features
+
 - feat(#98, #117): admin deployment panel with live status, deploy history, and rollback capability
 - feat(#98): `POST /api/deploy/` — SSE-streaming deploy endpoint
 - feat(#98): `POST /api/deploy/rollback` — rollback to a previous commit
@@ -486,10 +516,12 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 - chore: `backend/utils/shell.js` — shared spawn utilities for streaming child processes
 
 ### Bug Fixes
+
 - fix(#118): unhandled `spawn` error (`ENOENT`) when git not available in dev — backend no longer crashes
 - fix(#118): deploy endpoints gracefully degrade when git unavailable rather than returning 500
 
 ### Breaking Changes / Deployment Notes
+
 - None — deploy script handles `npm install` automatically
 
 ---
@@ -501,25 +533,30 @@ On 2026-05-11, `ak-home-server` was migrated from snap Docker to Docker CE:
 **PR:** #114
 
 ### Features
+
 - feat(#97): automated testing — Vitest + Supertest integration suite wired into the backend container (`npm test`)
 - feat(#101): CV management — `GET /api/cv/exists`, `GET /api/cv`, `POST /api/cv`, `DELETE /api/cv`; multer PDF-only upload (5 MB cap); pdf-parse private-content scan with warnings modal in admin UI
 - feat(#110): CV download button on `index.html` — hidden when no CV present, fetched via blob URL, updates reactively on `visibilitychange` without a page reload
 
 ### Bug Fixes
+
 - fix(#93): travel edit form — `visit_date` sliced to `YYYY-MM-DD` before populating the date input
 - fix(#95): blog edit form — `loadPostForEdit` converted to `async/await` so `post_date` and `body_markdown` always populate before user interaction; new post defaults date to today
 
 ### Process / Docs
+
 - docs(AI.md): documentation hygiene rule — stale paths and added/removed files must be updated in the same commit
 - docs(STYLE_GUIDE.md): section-header comment convention (`// ── Label`); stale test script paths corrected
 - docs(README.md): AI onboarding prompt section added
 - test(Test-PR107.ps1): idempotent CV cleanup step before empty-CV 404 assertion to prevent false failures on repeat runs
 
 ### Breaking Changes / Deployment Notes
+
 - `pdf-parse` npm dependency added — run `npm install` inside the backend container after deploy
 - CV uploads are stored at `uploads/cv.pdf` on the server — ensure the `uploads/` directory exists and is writable by the Node process
 
 ### Known Issues
+
 - #100: contact form returns 500 in dev — SMTP credentials not configured; fails open, no data lost
 - #111: CV private-content scanner does not detect phone numbers or home addresses — manual redaction required until resolved
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,6 +43,7 @@ The goals for the project are:
 ### 3.1 ✅ Dual-environment hosting — SHIPPED (~Release 2026-05-18)
 
 Both environments run on `ak-home-server`:
+
 - Production on `main` — public, port 443, Let's Encrypt TLS.
 - Dev/staging on `dev` branch — LAN-only, `dev.andykeys.me:3001`, self-signed TLS.
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -30,6 +30,7 @@ curl.exe -s https://andykeys.me/api/health
 ```
 
 Expected:
+
 - HTML for the homepage in the first call
 - A small JSON health payload or 200 OK for `/api/health`
 
@@ -106,6 +107,7 @@ From Windows:
 ```
 
 This will:
+
 - SSH into `ak-home-server`
 - Pull the latest `main`
 - Rebuild images
@@ -148,6 +150,7 @@ For a specific PR, run its PowerShell smoke test from Windows against dev (see *
 ### 6. Renew the Outlook OAuth2 refresh token
 
 **When:** Magic link emails stop arriving. Backend logs show `invalid_grant` or `AADSTS70000`. This happens because:
+
 - Microsoft invalidates refresh tokens after **90 days of inactivity**
 - Refresh tokens are also invalidated immediately if the **client secret is rotated** in Azure
 
@@ -168,7 +171,7 @@ node scripts/generate-outlook-refresh-token.js
 
 You'll be prompted for your Azure app's CLIENT_ID, CLIENT_SECRET (the _value_, not the ID), and your Outlook email. The script opens a browser, you authorise, and it prints the new values:
 
-```
+```text
 OUTLOOK_CLIENT_ID=...
 OUTLOOK_CLIENT_SECRET=...
 OUTLOOK_REFRESH_TOKEN=...
@@ -202,6 +205,7 @@ docker compose logs -f backend | grep -i "auth/email"
 ### 1. Narrow it down
 
 Ask three questions:
+
 - Is it **frontend only** (layout/JS), **API only** (HTTP errors), or **everything** (site down)?
 - Does it reproduce on both **dev** and **prod**, or just one?
 - Did a deploy just happen?
@@ -225,6 +229,7 @@ docker compose logs --tail=100 backend
 ```
 
 Common fixes:
+
 - Fix any config error reported in logs (env var, port conflict, bad nginx config)
 - Re-run `docker compose up -d --build`
 
@@ -240,6 +245,7 @@ docker compose logs -f backend
 ```
 
 Look for:
+
 - Stack traces or structured error logs around the failing endpoint
 - Database connection errors
 - Auth errors (JWT / WebAuthn)

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -391,7 +391,7 @@ See **[docs/TESTING.md](docs/TESTING.md)** for the full guide, including the smo
 
 Test files mirror the source tree under `backend/tests/`:
 
-```
+```text
 backend/tests/
   middleware/validate.test.js
   middleware/errorHandler.test.js
@@ -435,7 +435,7 @@ Every PR that touches backend code must include a `scripts/tests/Test-PRN.ps1` (
 
 Follow the imperative style documented in [docs/AI.md](docs/AI.md) → Commit Conventions:
 
-```
+```text
 feat(#78): add travel post detail page
 fix(#81): use /api as API_BASE in blog-post.js
 refactor: extract formatDate to shared utils

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -11,6 +11,7 @@ The dev server at `http://<LAN_IP>:3001` is the canonical test environment. Depl
 ### Workflow
 
 1. **Deploy your branch** to the dev server:
+
    ```powershell
    git checkout fix/your-issue
    .\scripts\deploy\dev-deploy.ps1
@@ -22,6 +23,7 @@ The dev server at `http://<LAN_IP>:3001` is the canonical test environment. Depl
    - Check for regressions in related features
 
 3. **View server logs** if something fails:
+
    ```bash
    docker compose -f ~/MyPortfolioSite-dev/docker-compose.yml logs -f backend
    ```
@@ -120,7 +122,8 @@ Uses Puppeteer request interception to capture POSTs to `/api/debug/errors` and 
 | 5 | No browser hang when five errors fire against a failing backend | #331 |
 
 It prints a machine-parseable summary line collected into the deploy report:
-```
+
+```text
 [error-logger-browser] status=OK passed=8 failed=0
 ```
 
@@ -144,7 +147,8 @@ docker compose -f docker-compose.yml -p portfolio_dev exec -T backend \
 Loads every served page (`/`, `/blog/`, `/travel/`, `/login/`, `/admin/`, `/setup/`) in a real browser and listens for `securitypolicyviolation` events (#341). Reports any blocked resource with the directive, source, and remediation instruction. ISP-injected inline-script noise is expected; maintainers can record known-noise patterns in the `KNOWN_NOISE` array inside the script to suppress specific entries.
 
 Machine-parseable summary:
-```
+
+```text
 [csp-violations] status=OK pages=6 violations=0
 ```
 
@@ -161,7 +165,8 @@ Loads `/admin/` as an authenticated session (JWT minted from `JWT_SECRET` and in
 Any `securitypolicyviolation` event during these interactions fails the check. This is the Nominatim `connect-src` path that was the root cause of the original #330 breakage.
 
 Machine-parseable summary:
-```
+
+```text
 [admin-e2e-csp] status=OK interactions=3 violations=0
 ```
 
@@ -182,11 +187,13 @@ Test records are prefixed `[E2E]` and cleaned up at the start and end of each ru
 **Failure policy: hard-fail.** An assertion failure rolls the deploy back (same as Vitest). If Puppeteer fails to launch (e.g. missing Chromium), the test is skipped with a warning and the deploy proceeds.
 
 Machine-parseable summary:
-```
+
+```text
 [admin-e2e] status=OK tests=5 passed=5 failed=0
 ```
 
 Run manually:
+
 ```bash
 cd ~/MyPortfolioSite-dev
 docker compose -f docker-compose.yml exec -T \
@@ -200,6 +207,7 @@ docker compose -f docker-compose.yml exec -T \
 - Manually after any change to `resources/js/error-logger.js` or `backend/routes/debug.js`
 - Manually after adding or moving any external resource (script, style, font, image, API origin) — verifies the CSP allowlist update is correct
 - Run the admin E2E scan after any change to the admin travel form or any new external fetch:
+
   ```bash
   cd ~/MyPortfolioSite-dev
   docker compose -f docker-compose.yml exec -T \
@@ -256,7 +264,7 @@ bash ~/MyPortfolioSite-dev/scripts/tests/test-regression.sh \
 
 Every deploy ends with a structured report block that collects all `[deploy:*]` checkpoint lines. The three test suites report in a consistent shape — each tagged with `suite=backend|frontend|regression` and normalised `tests/passed/failed` counts (CSP scans keep their native `pages`/`interactions`/`violations` metrics, since a violation isn't a 1:1 test):
 
-```
+```text
 ╔════════════════════════════════════════════════════════════════════════════╗
 ║  Deploy Report — dev — 2026-05-17 13:30:00                                 ║
 ╠════════════════════════════════════════════════════════════════════════════╣
@@ -316,6 +324,7 @@ The regression baseline is now handled server-side by `test-regression.sh` as pa
 ### Script template — Test-PR\<N\>.ps1
 
 When creating a `Test-PR<N>.ps1` script for a new PR, place it in `scripts/tests/` and use this as the starting point. The key requirements are:
+
 1. **`Start-Transcript` / `Stop-Transcript`** — output always captured without the caller needing flags
 2. **Auto-generate JWT** from the container — no hardcoded secrets, no manual token passing
 3. **`$PSScriptRoot '../..' 'test-results'`** path — resolves correctly from `scripts/tests/`
@@ -423,7 +432,7 @@ Name the script `scripts/tests/Test-PR<N>.ps1` and replace the two `<N>` placeho
 
 All test files live under `backend/tests/`, mirroring the source structure.
 
-```
+```text
 backend/
 └── tests/
     ├── middleware/
@@ -444,6 +453,7 @@ New test files should follow the same path convention: `tests/<layer>/<source-fi
 ### Priority 1 — Validation middleware (`validate.test.js`)
 
 Unit tests for every Zod schema exported from `middleware/validate.js`. Each schema is tested with:
+
 - A valid input that should pass through with `next()` called
 - Invalid inputs that should return `400 { error }` with a meaningful message
 - Coercion and default behaviour (e.g. lat/lng string → number, `body_markdown` defaulting to `''`)
@@ -451,6 +461,7 @@ Unit tests for every Zod schema exported from `middleware/validate.js`. Each sch
 ### Priority 2 — Route integration tests
 
 Mounts each router against the full Express app via Supertest with the `pg` pool mocked. Verifies:
+
 - `401` is returned for missing or invalid JWT on all protected routes
 - `400` is returned with the correct `{ error }` shape when required fields are missing
 - The DB query spy is **not** called when validation rejects a request (proves validation fires before DB)

--- a/docs/UNTRACKED_FILES.md
+++ b/docs/UNTRACKED_FILES.md
@@ -5,16 +5,19 @@ This document lists files and directories that are **not tracked in git** but ar
 ## Critical Files (Must Exist)
 
 ### `.env` — Environment Configuration
+
 **Location:** `~/.env` (dev server) or `$(git rev-parse --show-toplevel)/.env` (local testing)
 
 **Purpose:** Secrets, credentials, and environment-specific settings that must never be committed.
 
 **How it's created:**
+
 - Deployment script copies from `.env.dev-server.example` template
 - Or manually: `cp .env.dev-server.example .env`
 - Then edit with real values (LAN_IP, passwords, API keys, etc.)
 
 **What goes in it:**
+
 ```bash
 # Network & WebAuthn
 LAN_IP=192.168.x.x
@@ -35,37 +38,45 @@ ADMIN_EMAIL=you@example.com
 ```
 
 **How Docker uses it:**
+
 - Docker Compose reads `.env` automatically from the working directory
 - Variables are injected into container environments
 - Nginx templates use `${VARIABLE}` syntax (envsubst substitution)
 
 ### `scripts/config/certs/` — SSL Certificates (Dev Only)
+
 **Location:** `scripts/config/certs/`
 
 **Files:**
+
 - `dev-server.crt` — Self-signed certificate (generated for dev HTTPS)
 - `dev-server.key` — Private key (generated for dev HTTPS)
 
 **How they're created:**
+
 - Automatically by deployment: `bash scripts/setup/generate-dev-certs.sh $LAN_IP`
 - Or manually: `bash scripts/setup/generate-dev-certs.sh 192.168.68.81`
 
 **Why it's untracked:**
+
 - Private key should never be committed
 - Certificate is specific to server IP/hostname
 - Regenerated when LAN_IP changes
 
 ### `uploads/` — User-Uploaded Files
+
 **Location:** `uploads/` (repository root)
 
 **Purpose:** Stores user uploads (PDFs, images) from the admin console.
 
 **How it's managed:**
+
 - Created automatically by deployment: `mkdir -p uploads/`
 - Persisted in Docker volume: `uploads_dev_data:/app/uploads`
 - Never committed (`.gitignore`)
 
 **Why it's untracked:**
+
 - Contains user data
 - Can be large
 - Server-specific
@@ -73,13 +84,17 @@ ADMIN_EMAIL=you@example.com
 ## Important Directories That Persist
 
 ### `scripts/config/certs/` — Certificate Metadata
+
 Stores:
+
 - `dev-server.crt` — SSL certificate
 - `dev-server.key` — SSL key
 - (Previously) `dev-server.lan_ip` — IP used when cert was generated (deprecated, now checks cert CN/SAN)
 
 ### Volumes (Docker Data)
+
 **Not directly in repo, but critical:**
+
 - `postgres_dev_data` — Database files
 - `uploads_dev_data` — Uploaded files
 - Database is initialized from `backend/db/schema.sql` (tracked in repo)
@@ -88,6 +103,7 @@ Stores:
 ## Deployment Script Checklist
 
 The deployment script (`scripts/deploy/deploy.sh --env dev`) automatically:
+
 1. ✅ Clones repo (if needed)
 2. ✅ Creates `.env` from template if missing
 3. ✅ Validates `.env` (required variables, no placeholders)
@@ -97,13 +113,15 @@ The deployment script (`scripts/deploy/deploy.sh --env dev`) automatically:
 7. ✅ Starts containers with Docker Compose
 
 **What the script does NOT do** (requires manual setup):
+
 - UFW firewall rules (optional, prompted after deploy)
 - Systemd autostart service (optional, prompted after deploy)
 - Email configuration (set in `.env`, tested in admin console)
 
 ## Restoring After Disaster
 
-### Rebuild everything from scratch:
+### Rebuild everything from scratch
+
 ```bash
 # On dev server:
 rm -rf ~/MyPortfolioSite-dev
@@ -114,19 +132,22 @@ bash ~/MyPortfolioSite-dev/scripts/deploy/deploy.sh --env dev dev
 ```
 
 This will:
+
 1. Clone the repo
 2. Create `.env` (you configure it)
 3. Generate certificates
 4. Initialize database
 5. Start containers
 
-### Recover database only (keep existing data):
+### Recover database only (keep existing data)
+
 ```bash
 # Docker volumes persist, so data isn't lost
 docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml up -d
 ```
 
-### Recover uploads only:
+### Recover uploads only
+
 ```bash
 # If uploads/ was accidentally deleted:
 mkdir -p ~/MyPortfolioSite-dev/uploads
@@ -136,6 +157,7 @@ docker compose -f ~/MyPortfolioSite-dev/docker-compose.dev-server.yml up -d
 ## Local Development Checklist
 
 When cloning locally for testing:
+
 ```bash
 git clone https://github.com/AndyRKeys/MyPortfolioSite.git
 cd MyPortfolioSite
@@ -154,13 +176,15 @@ docker compose -f docker-compose.dev-server.yml up -d --build
 ## Security Notes
 
 **Never commit:**
+
 - `.env` (secrets, passwords, API keys)
 - `scripts/config/certs/dev-server.key` (private key)
 - `uploads/` (user data)
 
 **Always use .gitignore:**
 These are in `.gitignore`:
-```
+
+```text
 .env
 scripts/config/certs/
 uploads/
@@ -176,7 +200,7 @@ Verify with: `git check-ignore .env`
 
 ## Reference: How Variables Flow
 
-```
+```text
 .env file (secrets)
     ↓
 docker-compose.yml reads .env automatically
@@ -191,7 +215,8 @@ Backend app reads env vars directly (process.env.JWT_SECRET, etc.)
 ```
 
 Example: WEBAUTHN_ORIGIN flow:
-```
+
+```text
 .env: WEBAUTHN_ORIGIN=https://192.168.68.81:3001
   ↓
 docker-compose.yml backend environment: WEBAUTHN_ORIGIN: ${WEBAUTHN_ORIGIN}

--- a/docs/archive/es-module-migration-plan.md
+++ b/docs/archive/es-module-migration-plan.md
@@ -39,7 +39,7 @@ Convert all frontend JavaScript from `var` globals / plain `<script>` tags to na
 
 **Key cross-file dependencies to resolve:**
 
-```
+```text
 script.js  ──exports──▶  window.buildTimelineItem  ◀──consumes──  blog.js
 script.js  ──exports──▶  window.buildPostCard      ◀──consumes──  blog.js
 script.js  ──exports──▶  window.isAdminSession     ◀──consumes──  script.js (self)
@@ -52,7 +52,7 @@ config.js  ──exports──▶  API, isAdminSession       ◀──consumes�
 
 After migration, the module graph will be:
 
-```
+```text
 resources/java/
 ├── config.js            (already module)  export: API_BASE, isAdminSession
 ├── utils/
@@ -70,7 +70,7 @@ resources/java/
 ```
 
 > **Note on jQuery:** jQuery (loaded from a local file via `<script>`) is not an ES module. It sets `window.$`. All converted modules that use jQuery will access it as the global `$` — this is normal and correct when jQuery is loaded before the module entry point. No change to jQuery loading is needed.
-
+>
 > **Note on Leaflet:** Same pattern. `L` stays as a CDN global.
 
 ---
@@ -84,6 +84,7 @@ Migration is done **page by page**, from simplest to most complex, so each step 
 Create three new files. Nothing breaks because no HTML loads them yet.
 
 **`resources/java/utils/html.js`**
+
 ```js
 export function escapeHtml(str) {
     return String(str || '')
@@ -99,6 +100,7 @@ Extract `formatVisitDate`, `formatRelativeDate`, `formatPostDate` from `script.j
 Extract `buildTimelineItem`, `buildPostCard`, `buildPublicTravelCard`, `buildRepoCard` from `script.js`.
 
 Also update `config.js` to export `API_BASE` (it currently exports `API` — rename for consistency):
+
 ```js
 export const API_BASE = '/api';
 export function isAdminSession() { ... }
@@ -109,6 +111,7 @@ export function isAdminSession() { ... }
 Simplest page: one JS file, no cross-file dependencies, no jQuery.
 
 Changes:
+
 - `blog-post.js`: add `import { API_BASE } from './config.js';`, remove `var API_BASE` shim, convert to module
 - `blog-post.html`: change `<script src="...">` to `<script type="module" src="...">`
 - Remove `<script src="jquery-3.5.1.min.js">` if not used (verify first)
@@ -118,6 +121,7 @@ Changes:
 One JS file, uses jQuery and `API_BASE`.
 
 Changes:
+
 - `travel-post.js`: `import { API_BASE } from './config.js';`, `import { escapeHtml } from './utils/html.js';`, convert to module
 - `travel-post.html`: `<script type="module">`
 - jQuery `<script>` tag stays as plain script (loaded before the module)
@@ -127,6 +131,7 @@ Changes:
 `blog.html` loads both `script.js` and `blog.js`. `blog.js` currently calls `window.buildTimelineItem` and `window.buildPostCard` (set by `script.js`).
 
 Changes:
+
 - `blog.js`: `import { buildTimelineItem, buildPostCard } from './utils/dom.js';`, `import { API_BASE } from './config.js';`, remove `window.*` references, convert to module
 - `script.js`: convert to module, remove `window.buildTimelineItem = ...` and `window.buildPostCard = ...` exports, `import` from `utils/*`
 - `blog.html`: both script tags get `type="module"`
@@ -166,11 +171,13 @@ Verify these pages load no custom JS that needs converting (currently they appea
 ## 6. Files Changed Summary
 
 ### New files
+
 - `resources/java/utils/html.js`
 - `resources/java/utils/date.js`
 - `resources/java/utils/dom.js`
 
 ### Modified JS files
+
 - `resources/java/config.js` — rename `API` → `API_BASE`
 - `resources/java/script.js` — convert to module, remove `window.*` exports, import from utils
 - `resources/java/blog.js` — convert to module, import from utils, remove `window.*` calls
@@ -181,6 +188,7 @@ Verify these pages load no custom JS that needs converting (currently they appea
 - `resources/java/nav.js` — add `export {}` or keep as plain script (TBD)
 
 ### Modified HTML files (script tag changes only)
+
 - `blog-post.html`
 - `travel-post.html`
 - `blog.html`
@@ -338,7 +346,7 @@ Run through every manual test below and note the current pass/fail state. Any pr
 
 Each phase = one commit, named:
 
-```
+```text
 refactor(modules): phase 1 — create utils/html, utils/date, utils/dom
 refactor(modules): phase 2 — convert blog-post.js and blog-post.html
 refactor(modules): phase 3 — convert travel-post.js and travel-post.html

--- a/docs/archive/tech-debt-3-plan.md
+++ b/docs/archive/tech-debt-3-plan.md
@@ -35,6 +35,7 @@ This branch completes the remaining items from issue #79 after PRs #85 and #86:
 - [ ] `backend/routes/upload.js`
 
 **Search command:**
+
 ```bash
 grep -rn '{ message:' backend/routes/
 ```
@@ -46,11 +47,13 @@ grep -rn '{ message:' backend/routes/
 **Goal:** Replace per-route `if (!field) return res.status(400)...` manual checks with a shared Zod middleware.
 
 ### Step 1 — Install Zod
+
 ```bash
 cd backend && npm install zod
 ```
 
 ### Step 2 — Implement `backend/middleware/validate.js`
+
 ```js
 const { z } = require('zod');
 
@@ -87,6 +90,7 @@ Define schemas at the top of each route file, or in a new `backend/schemas/` dir
 ### Step 4 — Wire middleware into routes
 
 Replace manual field checks with `validate(Schema)` in the route definition:
+
 ```js
 // Before
 router.post('/', authenticate, async (req, res) => {
@@ -109,6 +113,7 @@ router.post('/', authenticate, validate(CreatePostSchema), async (req, res) => {
 **Goal:** Unhandled errors thrown in async route handlers return `{ error }` rather than crashing or returning HTML stack traces.
 
 ### Step 1 — Implement `backend/middleware/errorHandler.js`
+
 ```js
 function errorHandler(err, req, res, next) {
     if (res.headersSent) return next(err);
@@ -122,6 +127,7 @@ module.exports = { errorHandler };
 ```
 
 ### Step 2 — Register in `backend/server.js`
+
 ```js
 const { errorHandler } = require('./middleware/errorHandler');
 // ... all route registrations ...
@@ -129,10 +135,13 @@ app.use(errorHandler); // must be last
 ```
 
 ### Step 3 — Wrap async routes (optional but recommended)
+
 Async route handlers that throw will not be caught by Express 4 unless wrapped:
+
 ```js
 const asyncHandler = fn => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
 ```
+
 Apply to all `async (req, res)` route handlers, or upgrade to Express 5 which handles this natively.
 
 ---
@@ -147,7 +156,7 @@ Apply to all `async (req, res)` route handlers, or upgrade to Express 5 which ha
 
 ## Commit Strategy
 
-```
+```text
 refactor(errors): standardise all route error responses to { error } shape
 feat(validation): implement Zod validate() middleware
 refactor(routes): replace manual field checks with validate() middleware

--- a/scripts/tests/BACKEND_TROUBLESHOOTING.md
+++ b/scripts/tests/BACKEND_TROUBLESHOOTING.md
@@ -22,6 +22,7 @@ docker compose ps
 ```
 
 You should see:
+
 - `backend` — running on port 8080
 - `postgres` — running on port 5432
 
@@ -40,6 +41,7 @@ docker compose logs backend --tail 100
 ```
 
 Look for:
+
 - `ECONNREFUSED` — postgres not ready yet (wait a few seconds and retry)
 - `Error: ENOENT: no such file or directory, open '/app/backend/.env'` — .env file missing
 - `git: command not found` — git isn't installed in the container (expected in some dev setups; /deploy endpoints degrade gracefully)
@@ -126,6 +128,7 @@ curl http://localhost:8080/api/health
 ```
 
 If problems persist, check that:
+
 - `.env` exists in `backend/` with `JWT_SECRET` set
 - Docker has enough disk space (`docker system df`)
 - No firewall rules blocking localhost:8080


### PR DESCRIPTION
## Summary

Fixes all markdownlint warnings across the repository's `.md` files. Adds a `.markdownlint.json` config to establish consistent linting going forward, with four rules suppressed where suppression is the correct call rather than a shortcut.

Closes #199

## Changes

- **`.markdownlint.json`** — new config file suppressing MD013 (line-length), MD024 (duplicate headings), MD036 (emphasis-as-heading), MD041 (first-line-heading), MD060 (table-column-style); see commit message for rationale on each
- **Auto-fixed across 26 files** — blanks around headings (MD022), fences (MD031), and lists (MD032) via `markdownlint --fix`
- **MD040** — added `text` language specifier to 35 bare code fences (diagrams, trees, templates, log output) across README, AI.md, ARCHITECTURE.md, TESTING.md, STYLE_GUIDE.md, and others
- **MD056** — fixed missing Impact column in ARCHITECTURE.md critical-paths table
- **MD028** — merged split blockquote in `docs/archive/es-module-migration-plan.md`

## Test plan

```bash
# Verify zero markdownlint warnings
docker run --rm -v $(pwd):/repo node:22-alpine sh -c \
  "npm install -g markdownlint-cli -q 2>/dev/null && \
   markdownlint --config /repo/.markdownlint.json \
     /repo/docs /repo/README.md /repo/CLAUDE.md \
     /repo/scripts/tests/BACKEND_TROUBLESHOOTING.md \
     --dot /repo/.github"
# Expected: no output (zero warnings)
```

- [ ] Smoke tests: N/A — docs-only change, no backend code touched
- [ ] Documentation: N/A — this PR IS the documentation change