### PR TITLE
feat(#248): normalise location field to City, Country on geocode

### DIFF
--- a/resources/js/admin/travel.js
+++ b/resources/js/admin/travel.js
@@ -272,6 +272,20 @@ function hasValidGps(lat, lng) {
     return Number.isFinite(lat) && Number.isFinite(lng) && !(lat === 0 && lng === 0);
 }
 
+// Build canonical "City, Country" from a Nominatim address object.
+// Falls back to the first two comma-separated parts of display_name if address
+// lacks city-level data (e.g. remote areas that only resolve to a state).
+function normaliseLocation(address, displayName) {
+    if (address) {
+        const city    = address.city || address.town || address.village || address.hamlet || address.county || address.state_district || address.state || '';
+        const country = address.country || '';
+        const result  = [city, country].filter(Boolean).join(', ');
+        if (result) return result;
+    }
+    const parts = displayName ? displayName.split(',').map(p => p.trim()).filter(Boolean) : [];
+    return parts.slice(0, 2).join(', ') || null;
+}
+
 // Reverse geocode lat/lng to a human-readable location string using Nominatim.
 // Only populates the Location field if it is currently empty.
 async function reverseGeocodeToLocation(lat, lng) {
@@ -281,11 +295,7 @@ async function reverseGeocodeToLocation(lat, lng) {
         const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
         if (!res.ok) return;
         const data = await res.json();
-        if (!data.address) return;
-        const a = data.address;
-        const city    = a.city || a.town || a.village || a.hamlet || a.county || a.state_district || a.state || '';
-        const country = a.country || '';
-        const locationStr = [city, country].filter(Boolean).join(', ');
+        const locationStr = normaliseLocation(data.address, data.display_name);
         if (locationStr) document.getElementById('travel-location').value = locationStr;
     } catch {
         // Reverse geocode failure is non-fatal — silently ignore
@@ -360,15 +370,25 @@ async function geocodeLocation() {
     btn.textContent = 'Looking up…';
     setMessage('');
     try {
-        const url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + encodeURIComponent(q);
+        const url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&addressdetails=1&q=' + encodeURIComponent(q);
         const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
         const results = await res.json();
         if (!results.length) { setMessage('Location not found — try a more specific name.', true); return; }
-        const { lat, lon, display_name } = results[0];
+        const { lat, lon, display_name, address } = results[0];
         const parsedLat = parseFloat(lat);
         const parsedLng = parseFloat(lon);
         document.getElementById('travel-lat').value = parsedLat.toFixed(6);
         document.getElementById('travel-lng').value = parsedLng.toFixed(6);
+
+        // Normalise location field to canonical City, Country format
+        const normalised = normaliseLocation(address, display_name);
+        if (normalised) {
+            const locationInput = document.getElementById('travel-location');
+            locationInput.value = normalised;
+            locationInput.style.outline = '2px solid var(--color-success)';
+            setTimeout(() => { locationInput.style.outline = ''; }, 1500);
+        }
+
         setMessage(`Coordinates set — confirm pin location on the map below (matched: ${display_name.split(',').slice(0, 3).join(',')}).`, false, true);
         updateGeoconfirmMap(parsedLat, parsedLng);
     } catch {

--- a/resources/js/admin/travel.js
+++ b/resources/js/admin/travel.js
@@ -273,14 +273,16 @@ function hasValidGps(lat, lng) {
 }
 
 // Build canonical "City, Country" from a Nominatim address object.
-// Falls back to the first two comma-separated parts of display_name if address
-// lacks city-level data (e.g. remote areas that only resolve to a state).
+// Falls back to the first two comma-separated parts of display_name when the
+// address object lacks a city-level field (e.g. Tokyo returns addresstype
+// "province", not "city", so address.province must be checked explicitly).
 function normaliseLocation(address, displayName) {
     if (address) {
-        const city    = address.city || address.town || address.village || address.hamlet || address.county || address.state_district || address.state || '';
+        const city    = address.city || address.town || address.village || address.hamlet ||
+                        address.municipality || address.province ||
+                        address.county || address.state_district || address.state || '';
         const country = address.country || '';
-        const result  = [city, country].filter(Boolean).join(', ');
-        if (result) return result;
+        if (city && country) return `${city}, ${country}`;
     }
     const parts = displayName ? displayName.split(',').map(p => p.trim()).filter(Boolean) : [];
     return parts.slice(0, 2).join(', ') || null;


### PR DESCRIPTION
## Summary

After a successful geocode, rewrites the location input with a canonical \`City, Country\` string derived from Nominatim's \`address\` object. The field flashes a green outline for 1.5 s so the user notices the update. On geocode failure the field is left unchanged.

Closes #248

## Changes

- **\`resources/js/admin/travel.js\`**
  - Adds \`normaliseLocation(address, displayName)\` — shared helper that builds \`City, Country\` from a Nominatim address object, falling back to the first two parts of \`display_name\` for areas without city-level data
  - Refactors \`reverseGeocodeToLocation()\` to use the new helper (removes duplicated city/country logic)
  - Adds \`&addressdetails=1\` to the geocode search URL so the address object is returned without an extra round-trip
  - After a successful geocode: normalises the location field and flashes a \`--color-success\` outline for 1.5 s

## Test plan

Deploy to dev server and open the admin travel panel at \`https://<SITE_HOST>:3001/admin/\`.

```bash
# 1. Confirm normalisation for well-known cities
# Type "tokyo" in the location field and press Geocode
# Expected: field updates to "Tokyo, Japan", green outline flashes briefly

# 2. Mixed-case / abbreviated input
# Type "AMSTERDAM" → expected: "Amsterdam, Netherlands"
# Type "paris france" → expected: "Paris, France"

# 3. Smaller place (exercises county/state fallback)
# Type "st peter port guernsey" → expected: "St Peter Port, Guernsey"

# 4. Unresolvable input — field unchanged
# Type "zzzznotaplace" → expected: "Location not found" error, field left as typed

# 5. Regression — coordinates still set correctly after normalisation
# Geocode "london" → check lat/lng fields are populated and map pin appears

# 6. Regression — EXIF reverse geocode (location autofill from photo GPS)
# Upload a photo with GPS EXIF data with the location field empty
# Expected: field populates with City, Country as before (uses same normaliseLocation helper)
```

- [ ] Smoke tests: N/A — frontend-only change, no backend routes touched; no Test-PR script required
- [ ] Documentation: N/A — no operator workflow or API surface changed