### PR TITLE
fix(#424): remove broken isAdminSession() from config.js

### DIFF
--- a/resources/js/config.js
+++ b/resources/js/config.js
@@ -10,7 +10,3 @@ export const API_BASE = '/api';
 
 // Deprecated alias remains:
 export const API = API_BASE;
-
-export function isAdminSession() {
-  return !!sessionStorage.getItem('adminToken');
-}


### PR DESCRIPTION
## Summary

Removes the dead, broken `isAdminSession()` export from `config.js`. The function read from `sessionStorage` but every token writer and all real callers use `localStorage` — so it always returned `false`. No module ever imported `isAdminSession` from `config.js`; the correct implementation (localStorage + JWT expiry check) lives in `auth-utils.js` and is what `script.js` and `login.js` actually use.

Closes #424

## Changes

- `resources/js/config.js` — remove unused `isAdminSession()` (4 lines deleted)

## Test Plan

### Happy path

1. Load the public homepage (`https://localhost` or `https://dev.andykeys.me`) while logged in as admin.
2. Confirm visit counter still does **not** increment (admin-session guard in `script.js:148` calls `isAdminSession()` from `auth-utils.js` — should still work correctly).
3. Load the homepage while **not** logged in; visit counter should increment normally.

### Edge cases

- [ ] Log in via `/login/` — confirm redirect to `/admin/` still works (`login.js` imports `isAdminSession` from `auth-utils.js`, unchanged).
- [ ] Visit any public page while not logged in — confirm no JS errors in console.

### Regression checks

- [ ] `script.js` visit-counter admin guard still honours the admin session (imports from `auth-utils.js` — not affected).
- [ ] `login.js` already-logged-in redirect still works (imports from `auth-utils.js` — not affected).

### Setup required before testing

- None

## Smoke Test

- [x] N/A — no backend changes in this PR

## Documentation

- [x] N/A — behaviour and operator docs already match the change (no updates needed); this is a dead-code removal

## Risk / Impact

Zero runtime risk — no module imported the removed function. The correct implementation in `auth-utils.js` is untouched.

## Squash Commit Message

```text
fix(#424): remove broken isAdminSession() from config.js

The function read from sessionStorage but every token writer
and all real callers use localStorage — always returned false.
No module imported it from config.js; auth-utils.js holds the
correct implementation. Removing the dead duplicate.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

This is a 4-line deletion of dead code. The authoritative `isAdminSession()` in `auth-utils.js` (localStorage + JWT expiry check) is unchanged — it is the only import site for this function.