### PR TITLE
fix(#426): align CV download filename to Andy_Keys_CV.pdf

### DIFF
--- a/resources/js/cv-download.js
+++ b/resources/js/cv-download.js
@@ -36,7 +36,7 @@
                 var url = URL.createObjectURL(blob);
                 var a = document.createElement('a');
                 a.href = url;
-                a.download = 'Andrew_Keys_CV.pdf';
+                a.download = 'Andy_Keys_CV.pdf';
                 document.body.appendChild(a);
                 a.click();
                 document.body.removeChild(a);


### PR DESCRIPTION
## Summary

The CV download had a filename mismatch: the backend's `res.download()` sets `Content-Disposition: attachment; filename="Andy_Keys_CV.pdf"`, but the frontend blob-download flow saved the file as `Andrew_Keys_CV.pdf`. Since the blob fetch path ignores the server's `Content-Disposition` header, the saved filename was always `Andrew_Keys_CV.pdf` regardless of what the backend sent. Aligned the frontend to match the backend.

Closes #426

## Changes

- `resources/js/cv-download.js:39` — `a.download = 'Andrew_Keys_CV.pdf'` → `'Andy_Keys_CV.pdf'`

## Test Plan

### Happy path

1. Navigate to the homepage (`https://dev.andykeys.me` or `https://localhost`).
2. Click **Download CV**.
3. Confirm the saved file is named **`Andy_Keys_CV.pdf`** (not `Andrew_Keys_CV.pdf`).

### Edge cases

- [ ] Direct browser navigation to `https://dev.andykeys.me:3001/api/cv` — confirm the browser prompts to save as `Andy_Keys_CV.pdf` (backend `res.download` unchanged).
- [ ] No CV uploaded — button is hidden; no download occurs.

### Regression checks

- [ ] CV download still works end-to-end (button visible when CV exists, downloads a valid PDF, button re-enables after).

### Setup required before testing

- A CV must be uploaded via the admin panel before testing.

## Smoke Test

- [x] N/A — no backend changes in this PR

## Documentation

- [x] N/A — behaviour and operator docs already match the change (no updates needed)

## Risk / Impact

Frontend-only, one-line change. Zero backend impact. Users who previously downloaded the CV will have a file named `Andrew_Keys_CV.pdf`; future downloads will be `Andy_Keys_CV.pdf`.

## Squash Commit Message

```text
fix(#426): align CV download filename to Andy_Keys_CV.pdf

Frontend blob-download path ignored the server's Content-Disposition
header and saved as Andrew_Keys_CV.pdf. Aligned a.download attribute
to match the backend filename.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

I aligned to `Andy_Keys_CV.pdf` (what the backend already sends) since the backend is the authoritative source for the filename. If you prefer `Andrew_Keys_CV.pdf` as a more formal CV name, the fix is to update `cv.js:77` instead — one-line either way.