### PR TITLE
fix(#427): replace hand-rolled HTML sanitizer with DOMPurify

### DIFF
--- a/blog/post/index.html
+++ b/blog/post/index.html
@@ -73,6 +73,11 @@
     <script src="/resources/js/nav.js"></script>
     <!-- Pinned to v9 for stable synchronous marked.parse() API -->
     <script src="https://cdn.jsdelivr.net/npm/marked@9/marked.min.js"></script>
+    <!-- SRI hash must match the exact version in blog-post.js import. Recompute on upgrade:
+         curl -sL https://cdn.jsdelivr.net/npm/dompurify@NEW/dist/purify.es.mjs | openssl dgst -sha384 -binary | openssl base64 -A -->
+    <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/dompurify@3.4.7/dist/purify.es.mjs"
+          integrity="sha384-iwQ63xeXeCJmVOwihV+YG1ZTZSe+pL+1X9OgiZQikgf+juy+bYFkn3HvaRqFVVyO"
+          crossorigin="anonymous">
     <script type="module" src="/resources/js/blog-post.js"></script>
 </body>
 </html>

--- a/resources/js/blog-post.js
+++ b/resources/js/blog-post.js
@@ -1,5 +1,5 @@
 import { API_BASE } from './config.js';
-import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.es.mjs';
+import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.4.7/dist/purify.es.mjs';
 
 function getSlug() {
     var params = new URLSearchParams(window.location.search);

--- a/resources/js/blog-post.js
+++ b/resources/js/blog-post.js
@@ -1,16 +1,5 @@
 import { API_BASE } from './config.js';
-
-function sanitizeHtml(html) {
-    var temp = document.createElement('div');
-    temp.innerHTML = html;
-    var remove = temp.querySelectorAll('script, iframe, object, embed, [onclick], [onload], [onerror]');
-    remove.forEach(function (el) { el.remove(); });
-    temp.querySelectorAll('[href*="javascript:"], [src*="javascript:"]').forEach(function (el) {
-        el.removeAttribute('href');
-        el.removeAttribute('src');
-    });
-    return temp.innerHTML;
-}
+import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.es.mjs';
 
 function getSlug() {
     var params = new URLSearchParams(window.location.search);
@@ -46,7 +35,7 @@ function loadPost() {
             var md = post.body_markdown || '';
             var result = marked.parse(md);
             Promise.resolve(result).then(function (html) {
-                document.getElementById('post-markdown').innerHTML = sanitizeHtml(html);
+                document.getElementById('post-markdown').innerHTML = DOMPurify.sanitize(html);
             });
 
             document.getElementById('post-loading').classList.add('hidden');

--- a/scripts/config/nginx-security-headers.conf
+++ b/scripts/config/nginx-security-headers.conf
@@ -5,7 +5,7 @@
 # Content Security Policy — whitelist external resources
 # Sources:
 #   - unpkg.com: SimpleWebAuthn library (@simplewebauthn/browser)
-#   - cdn.jsdelivr.net: GitHub repos widget, Leaflet map library
+#   - cdn.jsdelivr.net: GitHub repos widget, Leaflet map library, DOMPurify (blog-post sanitizer)
 #   - esm.sh: ES modules CDN (used by dev server for webauthn)
 #   - fonts.googleapis.com / fonts.gstatic.com: Google Fonts
 #   - *.tile.openstreetmap.org: OpenStreetMap tiles (travel map)


### PR DESCRIPTION
## Summary

Replaces the regex-based `sanitizeHtml()` function in `blog-post.js` with [DOMPurify](https://github.com/cure53/DOMPurify), a battle-tested library maintained by cure53. The old sanitizer missed `<svg onload=...>` and mutation XSS vectors. DOMPurify handles these correctly and is the community standard for client-side HTML sanitisation.

`cdn.jsdelivr.net` is already in the CSP `script-src` allowlist (used by Leaflet and the GitHub widget) — no policy change required. The CSP comment is updated to note the new consumer.

Closes #427

## Changes

- `resources/js/blog-post.js` — remove 11-line hand-rolled `sanitizeHtml()`, import DOMPurify 3.4.7 from jsDelivr CDN (exact version pinned for SRI), use `DOMPurify.sanitize(html)` in place of `sanitizeHtml(html)`
- `blog/post/index.html` — add `<link rel="modulepreload">` with `sha384` SRI integrity hash; href must match the import URL exactly for the browser to enforce the check. Upgrade comment included with recompute command.
- `scripts/config/nginx-security-headers.conf` — update comment to list DOMPurify as a `cdn.jsdelivr.net` consumer (no directive change)

## Test Plan

### Happy path

1. Open a blog post in the browser (e.g. `https://dev.andykeys.me/blog-post/?slug=<any-slug>`).
2. Confirm the post renders correctly — headings, paragraphs, code blocks, links all visible.
3. Open browser DevTools → Network tab → confirm `purify.es.mjs` loaded with HTTP 200 from `cdn.jsdelivr.net`.

### Edge cases

- [ ] A blog post with a `<script>` tag in the Markdown body — confirm the script is stripped by DOMPurify and does not execute.
- [ ] A blog post with an `<img onerror=...>` attribute — confirm the attribute is stripped.
- [ ] No blog posts exist — confirm the error state still renders correctly (DOMPurify is never called in the error path).

### Regression checks

- [ ] Normal blog post text, headings, links, and code blocks render without change.
- [ ] No CSP violations appear in the browser console (check DevTools → Console).
- [ ] DevTools → Console shows no SRI integrity errors on page load.

### Setup required before testing

- At least one blog post must exist in the dev DB.

## Smoke Test

- [x] N/A — no backend changes in this PR

## Documentation

- [x] `scripts/config/nginx-security-headers.conf` comment updated to note DOMPurify as a `cdn.jsdelivr.net` consumer
- [x] Upgrade instructions embedded in `blog/post/index.html` comment (recompute command for new SRI hash)
- [x] N/A — behaviour and operator docs already match the change (no updates needed)

## Risk / Impact

**Security improvement.** DOMPurify's default configuration allows all safe HTML elements (headings, paragraphs, links, code, blockquotes, etc.) and strips dangerous ones (`<script>`, `<svg onload=...>`, `javascript:` hrefs, and mutation XSS vectors). Behaviour for clean Markdown-generated HTML is identical to before; the difference is in handling of adversarially crafted input.

SRI is enforced via `<link rel="modulepreload" integrity="sha384-...">` — if the CDN serves a tampered build, the browser rejects it before `blog-post.js` runs. The version is pinned to `3.4.7`; upgrading requires bumping the version in both the import and the `href`, then recomputing the hash.

Possible regression: DOMPurify also strips `<iframe>` by default (consistent with old sanitizer). If any blog post relied on iframes, those would already have been stripped before this change.

## Squash Commit Message

```text
fix(#427): replace hand-rolled sanitizer with DOMPurify + SRI

The regex-based sanitizeHtml() missed <svg onload=...> and mutation
XSS vectors. DOMPurify 3.4.7 handles these correctly. SRI enforced
via modulepreload integrity hash in blog/post/index.html.
cdn.jsdelivr.net is already in script-src — no CSP change needed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```