### PR TITLE
refactor(#431): extract createMessenger factory for admin modules

### DIFF
--- a/resources/js/admin/cv.js
+++ b/resources/js/admin/cv.js
@@ -1,12 +1,8 @@
 import { authFetch, getToken } from './auth.js';
 import { API_BASE } from '../config.js';
+import { createMessenger } from '../utils/messenger.js';
 
-function setMessage(msg, isError = false) {
-    const el = document.getElementById('cv-message');
-    if (!el) return;
-    el.textContent = msg;
-    el.style.color = isError ? 'var(--color-error)' : 'var(--color-success)';
-}
+const setMessage = createMessenger('cv-message');
 
 function updateStatusBadge(exists) {
     const badge = document.getElementById('cv-status-badge');

--- a/resources/js/admin/deploy.js
+++ b/resources/js/admin/deploy.js
@@ -1,5 +1,6 @@
 import { authFetch } from './auth.js';
 import { escapeHtml } from '../utils/html.js';
+import { createMessenger } from '../utils/messenger.js';
 
 export function initDeploy() {
     let deployEnv = 'prod'; // fallback until status loads
@@ -16,10 +17,7 @@ export function initDeploy() {
     const statusRow       = document.getElementById('deploy-status-row');
     const logList         = document.getElementById('deploy-log-list');
 
-    function setMessage(msg, isError = false) {
-        message.textContent = msg;
-        message.style.color = isError ? 'var(--color-error)' : 'var(--color-success)';
-    }
+    const setMessage = createMessenger('deploy-message');
 
     function setBusy(busy) {
         fetchBtn.disabled        = busy;

--- a/resources/js/admin/passkeys.js
+++ b/resources/js/admin/passkeys.js
@@ -1,13 +1,9 @@
 import { startRegistration } from 'https://esm.sh/@simplewebauthn/browser@7';
 import { authFetch } from './auth.js';
 import { escapeHtml } from '../utils/html.js';
+import { createMessenger } from '../utils/messenger.js';
 
-function setMessage(msg, isError = false) {
-    const el = document.getElementById('passkey-message');
-    if (!el) return;
-    el.textContent = msg;
-    el.style.color = isError ? 'var(--color-error)' : 'var(--color-success)';
-}
+const setMessage = createMessenger('passkey-message');
 
 async function loadPasskeys() {
     const container = document.getElementById('passkey-list');

--- a/resources/js/admin/posts.js
+++ b/resources/js/admin/posts.js
@@ -1,5 +1,6 @@
 import { authFetch, todayIso } from './auth.js';
 import { escapeHtml } from '../utils/html.js';
+import { createMessenger } from '../utils/messenger.js';
 
 // ── Post body template ────────────────────────────────────────────────────────
 
@@ -31,12 +32,7 @@ End with a takeaway, a question, or a link to what\'s next.
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function setMessage(msg, isError = false) {
-    const el = document.getElementById('post-message');
-    if (!el) return;
-    el.textContent = msg;
-    el.style.color = isError ? 'var(--color-error)' : 'var(--color-success)';
-}
+const setMessage = createMessenger('post-message');
 
 function clearForm() {
     document.getElementById('post-edit-id').value = '';

--- a/resources/js/admin/travel.js
+++ b/resources/js/admin/travel.js
@@ -1,6 +1,7 @@
 import exifr from 'https://esm.sh/exifr@7.1.3';
 import { authFetch, authFetchMultipart, todayIso } from './auth.js';
 import { escapeHtml } from '../utils/html.js';
+import { createMessenger } from '../utils/messenger.js';
 
 // ── Module state ──────────────────────────────────────────────────────────────
 
@@ -12,12 +13,7 @@ let geoconfirmMarker = null;
 
 // ── Messaging ─────────────────────────────────────────────────────────────────
 
-function setMessage(msg, isError = false, isHint = false) {
-    const el = document.getElementById('travel-message');
-    if (!el) return;
-    el.textContent = msg;
-    el.style.color = isError ? 'var(--color-error)' : isHint ? 'var(--color-text-muted)' : 'var(--color-success)';
-}
+const setMessage = createMessenger('travel-message');
 
 // ── Media list ────────────────────────────────────────────────────────────────
 

--- a/resources/js/utils/messenger.js
+++ b/resources/js/utils/messenger.js
@@ -1,0 +1,20 @@
+/**
+ * createMessenger(elementId) → setMessage(msg, isError, isHint)
+ *
+ * Returns a function that writes a status message to the named element.
+ * isError  → --color-error (red)
+ * isHint   → --color-text-muted (grey)
+ * default  → --color-success (green)
+ */
+export function createMessenger(elementId) {
+    return function setMessage(msg, isError = false, isHint = false) {
+        const el = document.getElementById(elementId);
+        if (!el) return;
+        el.textContent = msg;
+        el.style.color = isError
+            ? 'var(--color-error)'
+            : isHint
+            ? 'var(--color-text-muted)'
+            : 'var(--color-success)';
+    };
+}


### PR DESCRIPTION
## Summary

Five admin modules (`cv.js`, `posts.js`, `passkeys.js`, `deploy.js`, `travel.js`) each defined their own `setMessage(msg, isError)` function pointing at a different element ID. Any change to the colour logic — for example, switching from a hardcoded hex to a CSS variable, or adding a new state — had to be applied five times and had already diverged (`admin/travel.js` had an extra `isHint` parameter the others lacked).

Extracted to `resources/js/utils/messenger.js` as `createMessenger(elementId)` → returns `setMessage(msg, isError, isHint)`. The factory handles all three colour states; callers that don't pass `isHint` get the existing two-state behaviour unchanged.

Closes #431

## Changes

- `resources/js/utils/messenger.js` — new factory utility (18 LOC)
- `resources/js/admin/cv.js` — remove inline `setMessage`, add `createMessenger('cv-message')` call
- `resources/js/admin/posts.js` — same for `'post-message'`
- `resources/js/admin/passkeys.js` — same for `'passkey-message'`
- `resources/js/admin/deploy.js` — replace inner `setMessage` in `initDeploy()` with `createMessenger('deploy-message')`
- `resources/js/admin/travel.js` — replace inline `setMessage` (including its `isHint` param) with `createMessenger('travel-message')`

## Test Plan

### Happy path

1. Log in to the admin panel (`https://dev.andykeys.me/admin/`).
2. **Posts tab:** Create a post → confirm green success message appears. Attempt to save with empty title → confirm red error message appears.
3. **Travel tab:** Geocode a location → confirm the hint-coloured (grey) "Coordinates set…" message appears. Save → confirm green success message.
4. **CV tab:** Upload a PDF → confirm "Uploading…" then success message in green. Delete → confirm success.
5. **Passkeys tab:** Remove a passkey → confirm success/warning message appears.
6. **Deploy tab:** Click Fetch → confirm status message updates.

### Edge cases

- [ ] Admin panel loads with no JS errors in the browser console.
- [ ] `setMessage('')` (clear) works — element text is cleared, no colour artifact.

### Regression checks

- [ ] All five admin sections still show status messages correctly on success and error.
- [ ] `isHint` grey colour still appears in travel module for geocode hint messages.

### Setup required before testing

- Logged-in admin session required.

## Smoke Test

- [x] N/A — no backend changes in this PR

## Documentation

- [x] N/A — behaviour and operator docs already match the change (no updates needed)

## Risk / Impact

Frontend-only refactor. Behaviour is identical for all callers — the factory returns a function with the same signature. The `isHint` path (grey colour for informational messages) is now available to all five modules but was previously only used in `admin/travel.js`.

## Squash Commit Message

```text
refactor(#431): extract createMessenger factory for admin modules

Five admin modules each defined setMessage() pointing at a different
element ID — colour-logic changes had to be applied five times and
had already diverged (isHint missing from four of them). Extracted
to utils/messenger.js as createMessenger(elementId).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

`deploy.js`'s `setMessage` was an inner function inside `initDeploy()` that used a captured `message` DOM reference. The factory approach replaces it with `createMessenger('deploy-message')` which calls `getElementById` on each invocation — functionally equivalent since the element is stable for the lifetime of the page.