### PR TITLE
fix(#445): isolate rate limit counters per endpoint via key_type

### DIFF
--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -146,10 +146,25 @@ WHERE post_type = 'travel'
 -- DB-backed rate limiting for contact form (#79)
 -- One row per IP; window_start resets when the window expires.
 CREATE TABLE IF NOT EXISTS rate_limits (
-  ip VARCHAR(45) PRIMARY KEY,
+  ip VARCHAR(45) NOT NULL,
+  key_type VARCHAR(64) NOT NULL,
   count INTEGER NOT NULL DEFAULT 1,
-  window_start TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  window_start TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (ip, key_type)
 );
+
+-- Idempotent migration: add key_type to existing single-column PK installs (#445)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'rate_limits' AND column_name = 'key_type'
+  ) THEN
+    ALTER TABLE rate_limits ADD COLUMN key_type VARCHAR(64) NOT NULL DEFAULT 'legacy';
+    ALTER TABLE rate_limits DROP CONSTRAINT rate_limits_pkey;
+    ALTER TABLE rate_limits ADD PRIMARY KEY (ip, key_type);
+  END IF;
+END $$;
 
 -- ── Indexes on hot query columns (#79) ───────────────────────────────────────
 -- slug is already covered by the UNIQUE constraint (implicit index).

--- a/backend/middleware/rateLimit.js
+++ b/backend/middleware/rateLimit.js
@@ -5,6 +5,7 @@ export function createRateLimiter(options = {}) {
   const {
     limit = 10,
     windowMs = 60 * 1000, // 1 minute
+    keyType = 'default',
     keyGenerator = (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
     message = 'Too many requests. Please try again later.',
     skip = () => false,
@@ -23,20 +24,20 @@ export function createRateLimiter(options = {}) {
       const windowStart = new Date(now.getTime() - windowMs);
 
       const result = await pool.query(
-        `INSERT INTO rate_limits (ip, count, window_start)
-         VALUES ($1, 1, $2)
-         ON CONFLICT (ip) DO UPDATE
+        `INSERT INTO rate_limits (ip, key_type, count, window_start)
+         VALUES ($1, $2, 1, $3)
+         ON CONFLICT (ip, key_type) DO UPDATE
            SET
              count = CASE
-               WHEN rate_limits.window_start < $3 THEN 1
+               WHEN rate_limits.window_start < $4 THEN 1
                ELSE rate_limits.count + 1
              END,
              window_start = CASE
-               WHEN rate_limits.window_start < $3 THEN $2
+               WHEN rate_limits.window_start < $4 THEN $3
                ELSE rate_limits.window_start
              END
          RETURNING count`,
-        [key, now, windowStart]
+        [key, keyType, now, windowStart]
       );
 
       const count = result.rows[0].count;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -31,6 +31,7 @@ const JWT_EXPIRY = '24h';
 const emailRateLimit = createRateLimiter({
   limit: 5,
   windowMs: 60 * 60 * 1000, // 5 per hour
+  keyType: 'email',
   message: 'Too many login attempts. Please try again later.',
   skip: exemptIfServiceAccount,
 });
@@ -38,6 +39,7 @@ const emailRateLimit = createRateLimiter({
 const passkeyRateLimit = createRateLimiter({
   limit: 10,
   windowMs: 60 * 60 * 1000, // 10 per hour
+  keyType: 'passkey',
   message: 'Too many authentication attempts. Please try again later.',
   skip: exemptIfServiceAccount,
 });

--- a/backend/routes/contact.js
+++ b/backend/routes/contact.js
@@ -11,6 +11,7 @@ const router = Router();
 const contactRateLimit = createRateLimiter({
   limit: 3,
   windowMs: 60 * 60 * 1000, // 1 hour
+  keyType: 'contact',
   message: 'Too many requests. Please try again later.',
   skip: exemptIfTrusted,
 });

--- a/backend/routes/debug.js
+++ b/backend/routes/debug.js
@@ -16,6 +16,7 @@ const IS_DEV = process.env.NODE_ENV !== 'production';
 const debugRateLimit = createRateLimiter({
   limit: 50,
   windowMs: 60 * 1000,
+  keyType: 'debug',
   message: 'Rate limited',
   skip: exemptIfTrusted,
 });


### PR DESCRIPTION
## Summary

All \`createRateLimiter\` instances shared a single \`rate_limits\` row keyed on \`ip\` alone. Contact form submissions, passkey attempts, and debug calls all incremented the same counter as magic link requests — meaning the email limiter's 5/hr cap could be exhausted by unrelated traffic from the same IP.

Closes #445

## Changes

- \`backend/db/schema.sql\` — add \`key_type VARCHAR(64)\` column, change primary key to \`(ip, key_type)\`. Idempotent DO block migrates existing single-column-PK installs without data loss.
- \`backend/middleware/rateLimit.js\` — add \`keyType\` option; SQL now uses \`(ip, key_type)\` as the composite conflict target.
- \`backend/routes/auth.js\` — \`emailRateLimit\` gets \`keyType: 'email'\`, \`passkeyRateLimit\` gets \`keyType: 'passkey'\`
- \`backend/routes/contact.js\` — \`contactRateLimit\` gets \`keyType: 'contact'\`
- \`backend/routes/debug.js\` — \`debugRateLimit\` gets \`keyType: 'debug'\`

Note: \`test-regression.sh\`'s \`reset_rate_limits\` deletes by \`ip\` only — this still clears all \`key_type\` rows for those IPs, so no change needed there.

## Test Plan

### Happy path

```bash
# Verify email counter is isolated from contact counter
# On dev server — hit the contact endpoint 3 times (its full quota)
curl -s -X POST https://localhost:3001/api/contact \
  -H "Content-Type: application/json" \
  -d '{"name":"Test","email":"test@example.com","message":"hello world test"}' -k
# Repeat 2 more times (total 3 — contact is now at limit)

# Then request a magic link — should succeed (email counter is separate)
curl -s -X POST https://localhost:3001/api/auth/email/send \
  -H "Content-Type: application/json" \
  -d '{"email":"<ADMIN_EMAIL>"}' -k
# Expected: {"sent":true} — not 429
```

### Schema migration (existing DB)

```bash
# Confirm key_type column exists and PK is composite after boot
docker compose exec postgres psql -U portfolio_user -d portfolio_dev \
  -c "\d rate_limits"
# Expected: ip + key_type columns, PRIMARY KEY (ip, key_type)
```

### Edge cases

- [ ] Hit email endpoint 5 times — confirm 429 on the 6th email request only, not on contact or passkey.
- [ ] Hit contact endpoint 3 times — confirm 429 on contact only; email and passkey still respond normally.

### Regression checks

- [ ] \`docker compose exec backend npm test\` — full Vitest suite passes (mocked pool.query shape unchanged).
- [ ] \`scripts/tests/test-regression.sh\` run and passing — \`reset_rate_limits\` still clears rows correctly.

## Smoke Test

- [ ] Magic link login succeeds after contact form traffic from same IP.

## Documentation

- [x] N/A — internal middleware change; no operator-facing behaviour change beyond the bug fix.

## Risk / Impact

Schema migration runs at boot via the idempotent DO block. On a fresh DB the \`CREATE TABLE\` defines the correct schema directly. On an existing install the DO block detects the missing column, adds it, drops the old single-column PK, and adds the composite PK — existing rows are preserved with \`key_type = 'legacy'\`.

## Squash Commit Message

```text
fix(#445): isolate rate limit counters per endpoint via key_type

All createRateLimiter instances shared a single row per IP in
rate_limits, so contact/passkey/debug hits could exhaust the
email limiter's 5/hr quota. Add key_type column with composite
PK (ip, key_type); each limiter passes its own keyType string.
Schema migration is idempotent via DO block for existing installs.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```