### PR TITLE
fix(#447): tighten backup-schedule check to prevent false positives

### DIFF
--- a/scripts/backup/db-backup.sh
+++ b/scripts/backup/db-backup.sh
@@ -5,14 +5,14 @@
 set -e
 
 REPO_DIR="$HOME/MyPortfolioSite"
-BACKUP_DIR="${BACKUP_DIR:-$HOME/backups/prod}"
-TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-
-mkdir -p "$BACKUP_DIR"
 cd "$REPO_DIR"
 
-# Load .env for DB credentials
+# Load .env first so BACKUP_DIR and DB credentials are available before use
 set -a; source .env 2>/dev/null || true; set +a
+
+BACKUP_DIR="${BACKUP_DIR:-$HOME/backups/prod}"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+mkdir -p "$BACKUP_DIR"
 
 echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Starting backup..."
 

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -2006,7 +2006,11 @@ run_regression_tests() {
 check_backup_health() {
   dsection "Backup health check"
   local ok=1
-  local backup_dir="${BACKUP_DIR:-${HOME}/backups}"
+  # Scan the parent ~/backups tree rather than BACKUP_DIR from the deploy env.
+  # The cron job always runs from ~/MyPortfolioSite and resolves its own BACKUP_DIR
+  # from the prod .env — which may differ from the dev deploy env. Scanning the
+  # parent with maxdepth 2 finds files under prod/, dev/, or a flat layout.
+  local backup_dir="${HOME}/backups"
   local max_age_days=2
 
   # ── Check 1: cron/systemd timer configured ───────────────────────────────

--- a/scripts/deploy/deploy-lib.sh
+++ b/scripts/deploy/deploy-lib.sh
@@ -2011,9 +2011,9 @@ check_backup_health() {
 
   # ── Check 1: cron/systemd timer configured ───────────────────────────────
   local cron_found=0
-  if crontab -l 2>/dev/null | grep -qi "backup"; then
+  if crontab -l 2>/dev/null | grep -q "db-backup"; then
     cron_found=1
-  elif systemctl list-timers --all 2>/dev/null | grep -qi "backup"; then
+  elif systemctl list-timers --all 2>/dev/null | grep -q "db-backup"; then
     cron_found=1
   fi
 
@@ -2034,8 +2034,15 @@ check_backup_health() {
 
     if [ "$install_cron" = "1" ]; then
       (crontab -l 2>/dev/null; echo "$cron_entry") | crontab -
-      dstatus backup-schedule status=installed
-      dok "Installed backup cron: ${cron_entry}"
+      if crontab -l 2>/dev/null | grep -q "db-backup"; then
+        dstatus backup-schedule status=installed
+        dok "Installed backup cron: ${cron_entry}"
+      else
+        dstatus backup-schedule status=warn
+        dwarn "Cron install attempted but could not be verified — add manually: crontab -e"
+        dwarn "  ${cron_entry}"
+        ok=0
+      fi
     else
       dstatus backup-schedule status=warn
       dwarn "No backup cron job found — add manually: crontab -e"


### PR DESCRIPTION
## Summary

Three related backup health check bugs, all in the same area:

1. **False positive on schedule check** — \`grep -qi \"backup\"\` matched any system timer (Timeshift, snaps, etc.), and the auto-install path reported \`status=installed\` without verifying the crontab write succeeded.
2. **\`BACKUP_DIR\` ignored in backup script** — \`db-backup.sh\` set \`BACKUP_DIR\` before sourcing \`.env\`, so the env value was always overridden by the hardcoded default.
3. **Health check scanned wrong path on dev deploys** — the health check used \`BACKUP_DIR\` from the deploy environment (dev \`.env\` on a dev deploy), which may differ from where the prod cron job actually writes its files.

Closes #447

## Changes

- \`scripts/deploy/deploy-lib.sh\`
  - \`grep -qi \"backup\"\` → \`grep -q \"db-backup\"\` on both crontab and systemd checks
  - Auto-install now re-reads \`crontab -l\` after writing; falls through to \`status=warn\` if the entry cannot be verified
  - Health check always scans \`~/backups\` (maxdepth 2) rather than the deploy env's \`BACKUP_DIR\`, so it finds files under \`prod/\`, \`dev/\`, or a flat layout regardless of which env is active
- \`scripts/backup/db-backup.sh\`
  - Reordered: source \`.env\` first, then apply \`BACKUP_DIR\` default and run \`mkdir -p\`

## Test Plan

```bash
# 1. Confirm schedule check warns when cron is absent
crontab -l | grep -v db-backup | crontab -
# Deploy or call check_backup_health directly — expect status=warn, not status=ok

# 2. Confirm backup script uses BACKUP_DIR from .env
# Add BACKUP_DIR=/tmp/test-backup to ~/MyPortfolioSite/.env
# Run db-backup.sh manually — expect files in /tmp/test-backup/, not ~/backups/prod/
~/MyPortfolioSite/scripts/backup/db-backup.sh
ls /tmp/test-backup/

# 3. Confirm health check finds prod backups from a dev deploy
# Deploy this branch to dev — expect backup-files status to reflect ~/backups/prod/ contents
```

## Smoke Test

- [x] N/A — deploy script and backup script changes only; no backend or frontend behaviour affected

## Documentation

- [x] N/A — internal script fixes; no operator docs change needed

## Risk / Impact

Low. All three changes make behaviour match the documented intent. The \`db-backup.sh\` reorder is safe — \`.env\` is sourced before any path is used. The health check scan-path change is broader (finds backups anywhere under \`~/backups\`) which is strictly more correct for a single-server setup.

## Squash Commit Message

```text
fix(#447): fix backup schedule false positive and BACKUP_DIR bugs

Three fixes: grep for "db-backup" not "backup" to avoid matching
unrelated system timers; verify crontab write before reporting
status=installed; reorder db-backup.sh to source .env before
applying BACKUP_DIR default; health check scans ~/backups tree
rather than the deploy env's BACKUP_DIR to avoid dev/prod mismatch.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```