### PR TITLE
fix(#450): document docker.sock privilege escalation risk

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,12 @@ services:
     volumes:
       - uploads_data:/app/uploads
       - .:/repo  # repo root — needed by deploy route for git commands and deploy script
-      - /var/run/docker.sock:/var/run/docker.sock  # allows deploy route to run docker compose on the host daemon
+      # SECURITY: docker.sock grants the backend full control over the host Docker daemon.
+      # Required by the deploy route (backend/routes/deploy.js) to run docker compose
+      # commands from the admin panel. Trade-off accepted for a self-hosted hobby project,
+      # but represents a significant privilege escalation surface — any RCE in the backend
+      # container could escape to the host. Revisit with a dedicated deploy agent: #450.
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Adds a comment block to the \`docker.sock\` volume mount in \`docker-compose.yml\` making the trade-off explicit. The mount is load-bearing for the admin panel deploy route but represents a significant privilege escalation surface with no prior documentation.

Closes #450. Part of tech debt audit #379.

## Changes

- \`docker-compose.yml\` — replace one-line inline comment on the \`docker.sock\` mount with a 5-line block explaining why it exists, the risk, and the issue number to revisit

## Test Plan

### Smoke Test

- [x] N/A — comment-only change; no behaviour affected

## Documentation

- [x] N/A — the comment itself is the documentation change

## Risk / Impact

None — comment only.

## Squash Commit Message

\`\`\`text
fix(#450): document docker.sock privilege escalation risk

The socket mount is load-bearing for the deploy route but gives
the backend full host Docker daemon access. Add a comment block
making the trade-off explicit for future operators.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
\`\`\`