### PR TITLE
fix(#432): extract recordVisit() utility with admin-session guard

### DIFF
--- a/resources/js/blog.js
+++ b/resources/js/blog.js
@@ -1,6 +1,7 @@
 import { API_BASE } from './config.js';
 import { formatPostDate } from './utils/date.js';
 import { buildPostCard, buildTimelineItem } from './utils/dom.js';
+import { recordVisit } from './utils/stats.js';
 
 function truncate(str, len) {
     if (!str) return '';
@@ -96,7 +97,6 @@ function loadPosts() {
 
 // ── Bootstrap ─────────────────────────────────────────────────────────────────
 
-// Fire-and-forget visit counter — swallow errors so stats never break the page
-fetch(API_BASE + '/stats/visit?page=blog', { method: 'POST' }).catch(function () {});
+recordVisit('blog');
 
 loadPosts();

--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -1,6 +1,7 @@
 import { API_BASE } from './config.js';
-import { isAdminSession, getToken } from './auth-utils.js';
+import { getToken } from './auth-utils.js';
 import { buildRepoCard } from './utils/dom.js';
+import { recordVisit as _recordVisit } from './utils/stats.js';
 
 // ── Horizontal scroll carousel ────────────────────────────────────────────────
 
@@ -145,21 +146,18 @@ function initContactForm() {
 // ── Visit counter ─────────────────────────────────────────────────────────────
 
 function recordVisit(page) {
-    if (isAdminSession()) return;
-
     var counterLine = document.getElementById('visit-counter-line');
     var countEl = document.getElementById('visit-count');
     if (!counterLine || !countEl) return;
-
-    fetch(API_BASE + '/stats/visit?page=' + encodeURIComponent(page), { method: 'POST' })
-        .then(function (res) { return res.json(); })
-        .then(function (data) {
-            if (data.count) {
-                countEl.textContent = data.count.toLocaleString();
-                counterLine.style.display = '';
-            }
-        })
-        .catch(function () {});
+    var p = _recordVisit(page);
+    if (!p) return;
+    p.then(function (res) { return res ? res.json() : null; })
+     .then(function (data) {
+         if (data && data.count) {
+             countEl.textContent = data.count.toLocaleString();
+             counterLine.style.display = '';
+         }
+     });
 }
 
 // ── Bootstrap ─────────────────────────────────────────────────────────────────

--- a/resources/js/travel-post.js
+++ b/resources/js/travel-post.js
@@ -1,5 +1,6 @@
 import { API_BASE } from './config.js';
 import { openLightbox, initLightbox } from './utils/lightbox.js';
+import { recordVisit } from './utils/stats.js';
 
 // ── Page loader ───────────────────────────────────────────────────────────────
 
@@ -29,8 +30,7 @@ function loadTravelPost() {
         })
         .then(function (travel) {
             renderTravelPost(travel);
-            // Fire-and-forget visit counter — only on a successful post load.
-            fetch(API_BASE + '/stats/visit?page=travel', { method: 'POST' }).catch(function () {});
+            recordVisit('travel');
         })
         .catch(function () { showError(); });
 }

--- a/resources/js/travel.js
+++ b/resources/js/travel.js
@@ -3,6 +3,7 @@ import { escapeHtml } from './utils/html.js';
 import { formatVisitDate } from './utils/date.js';
 import { buildTimelineItem, buildPublicTravelCard } from './utils/dom.js';
 import { initLightbox } from './utils/lightbox.js';
+import { recordVisit } from './utils/stats.js';
 
 // ── Travel map (Leaflet) ──────────────────────────────────────────────────────
 
@@ -181,6 +182,6 @@ function loadPublicTravelPosts() {
 
 // ── Bootstrap ─────────────────────────────────────────────────────────────────
 
-fetch(API_BASE + '/stats/visit?page=travel', { method: 'POST' }).catch(function () {});
+recordVisit('travel');
 loadPublicTravelPosts();
 initLightbox();

--- a/resources/js/utils/stats.js
+++ b/resources/js/utils/stats.js
@@ -1,0 +1,10 @@
+import { API_BASE } from '../config.js';
+import { isAdminSession } from '../auth-utils.js';
+
+// Returns the fetch Promise (so callers can chain .then for response data),
+// or undefined when the session is admin (visit should not be counted).
+export function recordVisit(page) {
+    if (isAdminSession()) return;
+    return fetch(API_BASE + '/stats/visit?page=' + encodeURIComponent(page), { method: 'POST' })
+        .catch(function () {});
+}


### PR DESCRIPTION
## Summary

- Extracts a shared `recordVisit(page)` utility to `resources/js/utils/stats.js`
- The utility applies the `isAdminSession()` guard centrally, fixing a bug where admin page views were being counted on the blog and travel listing pages
- Replaces 4 separate inline `fetch('/stats/visit?...')` calls; `script.js` wraps the shared utility to retain its DOM counter display

## Changes

| File | Change |
|------|--------|
| `resources/js/utils/stats.js` | New shared utility — `recordVisit(page)` with admin guard |
| `resources/js/blog.js` | Import + call `recordVisit('blog')` |
| `resources/js/travel.js` | Import + call `recordVisit('travel')` |
| `resources/js/travel-post.js` | Import + call `recordVisit('travel')` |
| `resources/js/script.js` | Delegate to shared utility; retain DOM counter update |

## Test plan

```bash
# 1. Verify blog page does NOT count admin visits
# Log in as admin, open the blog listing page, check visit stats in admin panel — count should not increment

# 2. Verify travel page does NOT count admin visits
# Same as above for the travel listing page and a travel detail page

# 3. Verify visit counter still shows on the home page for non-admin visitors
# Open the homepage in a private/incognito window, confirm the visit count
# line appears and increments

# 4. Verify no JS errors on any page
# Open browser devtools → Console tab — no errors on blog, travel, travel-post, or home
```

## Smoke tests

```bash
# No backend changes — API endpoints unchanged. Frontend-only.
# Manual: load /blog, /travel, a travel post, and / in browser; confirm no JS console errors.
```

## Documentation checklist

- [x] No behaviour-visible change for non-admin visitors — N/A for docs
- [x] No API changes — N/A for API docs

Closes #432

---

**Squash commit message:**
```
fix(#432): extract recordVisit() utility with admin-session guard

Admin page views were inflating blog/travel visit stats because the
isAdminSession() guard was missing from 3 of the 4 call sites. Extracts
recordVisit(page) to utils/stats.js with the guard built in.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```