### PR TITLE
fix(#371): persist error alert cooldown across container restarts

### DIFF
--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -211,3 +211,15 @@ CREATE TABLE IF NOT EXISTS client_errors (
 
 CREATE INDEX IF NOT EXISTS idx_client_errors_received_at
   ON client_errors (received_at DESC);
+
+-- ── App settings (#371) ──────────────────────────────────────────────────────
+-- Persistent key/value store for small pieces of runtime state that must
+-- survive container restarts. First user: `last_error_alert_at` — the
+-- timestamp of the most recent /debug/errors alert email, so the cooldown
+-- in routes/debug.js is honoured across deploys. Values are stored as TEXT;
+-- callers parse to the type they need. Not for secrets.
+CREATE TABLE IF NOT EXISTS app_settings (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/backend/routes/debug.js
+++ b/backend/routes/debug.js
@@ -28,10 +28,41 @@ const debugRateLimit = rateLimit({
 // ── Alert threshold ───────────────────────────────────────────────────────────
 // Fire an email when this many errors arrive within the window. Cooldown
 // prevents repeated alerts for sustained storms — one email per window max.
-const ALERT_THRESHOLD = parseInt(process.env.ERROR_ALERT_THRESHOLD || '20');
-const ALERT_WINDOW_MS = parseInt(process.env.ERROR_ALERT_WINDOW_MS  || String(15 * 60 * 1000));
-const ALERT_WINDOW_MIN = Math.round(ALERT_WINDOW_MS / 60_000);
+// The cooldown timestamp is persisted to the `app_settings` table (#371) so
+// that a container restart inside the window does not re-fire an alert that
+// was already sent before the restart.
+const ALERT_THRESHOLD        = parseInt(process.env.ERROR_ALERT_THRESHOLD || '20');
+const ALERT_WINDOW_MS        = parseInt(process.env.ERROR_ALERT_WINDOW_MS  || String(15 * 60 * 1000));
+const ALERT_WINDOW_MIN       = Math.round(ALERT_WINDOW_MS / 60_000);
+const LAST_ALERT_SETTING_KEY = 'last_error_alert_at';
 let _lastAlertAt = 0;
+
+// Restore the cooldown timestamp from the DB on module load. Fire-and-forget:
+// if the DB is not yet ready (boot ordering) or the row doesn't exist, log a
+// warning and leave _lastAlertAt at 0 — at worst we may send one extra alert
+// on the first request after startup, never one less.
+(async () => {
+  try {
+    const result = await pool.query(
+      'SELECT value FROM app_settings WHERE key = $1',
+      [LAST_ALERT_SETTING_KEY]
+    );
+    if (result.rows.length === 0) return;
+    const parsed = parseInt(result.rows[0].value, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      _lastAlertAt = parsed;
+      logger.info(
+        { lastAlertAt: new Date(parsed).toISOString() },
+        '[debug/errors] Restored alert cooldown timestamp from app_settings'
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      { err: err.message },
+      '[debug/errors] Could not restore alert cooldown from app_settings — starting from 0'
+    );
+  }
+})();
 
 async function maybeAlert() {
   if (!isEmailConfigured()) return;
@@ -60,7 +91,25 @@ async function maybeAlert() {
     [windowStart]
   );
 
-  _lastAlertAt = Date.now();
+  const now = Date.now();
+  _lastAlertAt = now;
+  // Persist the new cooldown timestamp so a container restart in the next
+  // ALERT_WINDOW_MS does not re-fire (#371). Failure here must not block the
+  // email — the in-memory cooldown still holds until the next restart.
+  try {
+    await pool.query(
+      `INSERT INTO app_settings (key, value, updated_at)
+            VALUES ($1, $2, NOW())
+       ON CONFLICT (key) DO UPDATE
+            SET value = EXCLUDED.value, updated_at = NOW()`,
+      [LAST_ALERT_SETTING_KEY, String(now)]
+    );
+  } catch (err) {
+    logger.error(
+      { err: err.message },
+      '[debug/errors] Failed to persist alert cooldown to app_settings — will reset on restart'
+    );
+  }
   logger.warn({ count, windowMin: ALERT_WINDOW_MIN }, '[debug/errors] Alert threshold reached — sending email');
   await sendErrorAlertEmail({ count, windowMinutes: ALERT_WINDOW_MIN, topErrors: top.rows, adminEmail });
 }


### PR DESCRIPTION
## Summary

Fixes a false-alert bug: `_lastAlertAt` in `debug.js` was in-memory and reset to `0` on every container restart (every deploy). If 20+ errors had accumulated before the restart, the first request after startup would immediately trigger an alert email — even if one had just been sent.

**Fix:** adds an `app_settings` table (a persistent key/value store) and reads/writes `last_error_alert_at` through it so the cooldown survives restarts.

## Changes

| File | Change |
|------|--------|
| `backend/db/schema.sql` | New `app_settings` table (`key TEXT PK`, `value TEXT`, `updated_at`) — idempotent `CREATE TABLE IF NOT EXISTS` |
| `backend/routes/debug.js` | On module load: async IIFE restores `_lastAlertAt` from DB (fail-safe: logs warning, keeps 0). On alert: persists timestamp via `INSERT…ON CONFLICT UPDATE` (failure logs error, does not block email) |

## Test plan

```bash
# 1. Verify the new schema table is created idempotently
docker compose exec postgres psql -U postgres -d portfolio_dev \
  -c "\d app_settings"
# Expected: table with columns key, value, updated_at

# 2. Run the full test suite — no regressions
docker compose exec backend npm test
# Expected: 121 passed

# 3. Manually verify cooldown restores on restart
# a) Trigger an alert (or manually insert a row):
docker compose exec postgres psql -U postgres -d portfolio_dev \
  -c "INSERT INTO app_settings (key, value) VALUES ('last_error_alert_at', ((EXTRACT(EPOCH FROM NOW())::bigint * 1000)::text)) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW();"
# b) Restart the backend container:
docker compose restart backend
# c) Check logs for the restore message:
docker compose logs backend --tail=20 | grep "Restored alert cooldown"
# Expected: log line with lastAlertAt timestamp

# 4. Verify cooldown is honoured after restart
# With the row inserted in step 3a (timestamp = now), posting to /api/debug/errors
# should NOT trigger an alert because the cooldown window hasn't elapsed.
```

## Smoke tests

```bash
# Backend starts without error after schema change
docker compose logs backend --tail=10 | grep -v "ERROR"
# Expected: no ERROR lines; info line about cooldown restore (or nothing if table was empty)
```

## Documentation checklist

- [x] `backend/db/schema.sql` updated with new `app_settings` table — schema self-documents
- [x] No API surface changes — N/A for API docs
- [x] No deployment workflow changes — N/A for ops docs

Closes #371

---

**Squash commit message:**
```
fix(#371): persist error alert cooldown across container restarts

_lastAlertAt reset on every deploy, causing false alert emails post-restart.
Adds app_settings table and reads/writes last_error_alert_at through it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```