### PR TITLE
refactor: batch issues — backend/frontend hardcoding, API snake_case, CV scanner, caching

### DIFF
--- a/backend/middleware/cacheHeaders.js
+++ b/backend/middleware/cacheHeaders.js
@@ -1,0 +1,31 @@
+/**
+ * Cache-Control middleware helpers (#158).
+ *
+ * Apply these to route groups rather than individual handlers so the
+ * policy is visible at the route registration level in server.js.
+ *
+ * Rules:
+ *   publicCache(ttl) — public listing/detail endpoints; short TTL so stale
+ *                      content does not outlast a publish/unpublish action.
+ *   noStore          — auth, admin, mutating routes; prevents any caching.
+ */
+
+/**
+ * Set Cache-Control: public, max-age=<seconds> on the response.
+ * @param {number} seconds
+ */
+export function publicCache(seconds) {
+  return (_req, res, next) => {
+    res.set('Cache-Control', `public, max-age=${seconds}`);
+    next();
+  };
+}
+
+/**
+ * Set Cache-Control: no-store on the response.
+ * Use for auth, admin, and mutating endpoints.
+ */
+export function noStore(_req, res, next) {
+  res.set('Cache-Control', 'no-store');
+  next();
+}

--- a/backend/middleware/validate.js
+++ b/backend/middleware/validate.js
@@ -101,12 +101,12 @@ export const EmailSendSchema = z.object({
 });
 
 export const PasskeyRegisterFinishSchema = z.object({
-  response:    z.object({}).passthrough(),
-  sessionKey:  z.string().min(1, 'sessionKey is required'),
-  passkeyName: z.string().optional(),
+  response:     z.object({}).passthrough(),
+  session_key:  z.string().min(1, 'session_key is required'),
+  passkey_name: z.string().optional(),
 });
 
 export const PasskeyLoginFinishSchema = z.object({
-  response:   z.object({}).passthrough(),
-  sessionKey: z.string().min(1, 'sessionKey is required'),
+  response:    z.object({}).passthrough(),
+  session_key: z.string().min(1, 'session_key is required'),
 });

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -90,7 +90,7 @@ function signJWT(user) {
 router.get('/setup/status', accountRateLimit, resolveUser, async (req, res, next) => {
   try {
     const result = await pool.query('SELECT COUNT(*) FROM users');
-    res.json({ hasUsers: parseInt(result.rows[0].count) > 0 });
+    res.json({ has_users: parseInt(result.rows[0].count) > 0 });
   } catch (err) {
     logger.error({ err }, '[auth] setup/status DB error');
     next(err);
@@ -163,7 +163,7 @@ router.post('/passkey/register/start', passkeyRateLimit, authenticate, async (re
       [sessionKey, options.challenge, userId]
     );
 
-    res.json({ options, sessionKey });
+    res.json({ options, session_key: sessionKey });
   } catch (err) {
     logger.error({ err }, '[auth] passkey register start failed');
     next(err);
@@ -172,7 +172,7 @@ router.post('/passkey/register/start', passkeyRateLimit, authenticate, async (re
 
 router.post('/passkey/register/finish', passkeyRateLimit, authenticate, validate(PasskeyRegisterFinishSchema), async (req, res, next) => {
   try {
-    const { response, sessionKey, passkeyName } = req.body;
+    const { response, session_key: sessionKey, passkey_name: passkeyName } = req.body;
 
     const challengeRow = await pool.query(
       `SELECT * FROM webauthn_challenges
@@ -257,7 +257,7 @@ router.post('/passkey/login/start', passkeyRateLimit, async (req, res, next) => 
       [sessionKey, options.challenge]
     );
 
-    res.json({ options, sessionKey });
+    res.json({ options, session_key: sessionKey });
   } catch (err) {
     logger.error({ err }, '[auth] passkey login start failed');
     next(err);
@@ -266,7 +266,7 @@ router.post('/passkey/login/start', passkeyRateLimit, async (req, res, next) => 
 
 router.post('/passkey/login/finish', passkeyRateLimit, validate(PasskeyLoginFinishSchema), async (req, res, next) => {
   try {
-    const { response, sessionKey } = req.body;
+    const { response, session_key: sessionKey } = req.body;
 
     const challengeRow = await pool.query(
       'SELECT * FROM webauthn_challenges WHERE session_key = $1 AND expires_at > NOW()',

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -21,35 +21,43 @@ import {
   PasskeyRegisterFinishSchema,
   PasskeyLoginFinishSchema,
 } from '../middleware/validate.js';
+import {
+  EMAIL_RATE_WINDOW_MS,   EMAIL_RATE_LIMIT,
+  PASSKEY_RATE_WINDOW_MS, PASSKEY_RATE_LIMIT,
+  ACCOUNT_RATE_WINDOW_MS, ACCOUNT_RATE_LIMIT,
+  WEBAUTHN_CHALLENGE_TTL, MAGIC_LINK_TTL,
+} from '../utils/constants.js';
 
 const router = Router();
 
-const RP_NAME   = process.env.WEBAUTHN_RP_NAME   || 'AK Portfolio';
-const RP_ID     = process.env.WEBAUTHN_RP_ID     || 'localhost';
-const ORIGIN    = process.env.WEBAUTHN_ORIGIN    || 'http://localhost:5500';
+// validateEnv.js requires WEBAUTHN_RP_ID, WEBAUTHN_ORIGIN, and WEBAUTHN_RP_NAME
+// at startup — no fallback defaults here (#433).
+const RP_NAME    = process.env.WEBAUTHN_RP_NAME;
+const RP_ID      = process.env.WEBAUTHN_RP_ID;
+const ORIGIN     = process.env.WEBAUTHN_ORIGIN;
 const JWT_EXPIRY = process.env.JWT_EXPIRY || '1h';
 
 // Rate limiters for sensitive auth endpoints (per IP)
 const emailRateLimit = rateLimit({
-  windowMs:        60 * 60 * 1000, // 5 per hour
-  limit:           5,
+  windowMs:        EMAIL_RATE_WINDOW_MS,
+  limit:           EMAIL_RATE_LIMIT,
   keyGenerator:    (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
   skip:            exemptIfServiceAccount,
   message:         { error: 'Too many login attempts. Please try again later.' },
   standardHeaders: true,
   legacyHeaders:   false,
-  store:           new PostgresStore({ windowMs: 60 * 60 * 1000, keyType: 'email' }),
+  store:           new PostgresStore({ windowMs: EMAIL_RATE_WINDOW_MS, keyType: 'email' }),
 });
 
 const passkeyRateLimit = rateLimit({
-  windowMs:        60 * 60 * 1000, // 10 per hour
-  limit:           10,
+  windowMs:        PASSKEY_RATE_WINDOW_MS,
+  limit:           PASSKEY_RATE_LIMIT,
   keyGenerator:    (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
   skip:            exemptIfServiceAccount,
   message:         { error: 'Too many authentication attempts. Please try again later.' },
   standardHeaders: true,
   legacyHeaders:   false,
-  store:           new PostgresStore({ windowMs: 60 * 60 * 1000, keyType: 'passkey' }),
+  store:           new PostgresStore({ windowMs: PASSKEY_RATE_WINDOW_MS, keyType: 'passkey' }),
 });
 
 // Account-management surface (/setup/status, /me, /passkeys, /passkeys/:id).
@@ -59,14 +67,14 @@ const passkeyRateLimit = rateLimit({
 // The limiter precedes resolveUser in each route so CodeQL's
 // js/missing-rate-limiting detector sees it before any authorization step.
 const accountRateLimit = rateLimit({
-  windowMs:        60 * 1000,
-  limit:           60,
+  windowMs:        ACCOUNT_RATE_WINDOW_MS,
+  limit:           ACCOUNT_RATE_LIMIT,
   keyGenerator:    (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
   skip:            exemptIfTrusted,
   message:         { error: 'Too many requests. Please try again later.' },
   standardHeaders: true,
   legacyHeaders:   false,
-  store:           new PostgresStore({ windowMs: 60 * 1000, keyType: 'account' }),
+  store:           new PostgresStore({ windowMs: ACCOUNT_RATE_WINDOW_MS, keyType: 'account' }),
 });
 
 function signJWT(user) {
@@ -151,7 +159,7 @@ router.post('/passkey/register/start', passkeyRateLimit, authenticate, async (re
     const sessionKey = uuidv4();
     await pool.query(
       `INSERT INTO webauthn_challenges (session_key, challenge, user_id, expires_at)
-       VALUES ($1, $2, $3, NOW() + INTERVAL '5 minutes')`,
+       VALUES ($1, $2, $3, NOW() + INTERVAL '${WEBAUTHN_CHALLENGE_TTL}')`,
       [sessionKey, options.challenge, userId]
     );
 
@@ -245,7 +253,7 @@ router.post('/passkey/login/start', passkeyRateLimit, async (req, res, next) => 
     const sessionKey = uuidv4();
     await pool.query(
       `INSERT INTO webauthn_challenges (session_key, challenge, expires_at)
-       VALUES ($1, $2, NOW() + INTERVAL '5 minutes')`,
+       VALUES ($1, $2, NOW() + INTERVAL '${WEBAUTHN_CHALLENGE_TTL}')`,
       [sessionKey, options.challenge]
     );
 
@@ -359,7 +367,7 @@ router.post('/email/send', emailRateLimit, validate(EmailSendSchema), async (req
     const token = uuidv4();
     await pool.query(
       `INSERT INTO email_tokens (user_id, token, expires_at)
-       VALUES ($1, crypt($2, gen_salt('bf')), NOW() + INTERVAL '15 minutes')`,
+       VALUES ($1, crypt($2, gen_salt('bf')), NOW() + INTERVAL '${MAGIC_LINK_TTL}')`,
       [userId, token]
     );
     logger.info('[auth/email/send] Token inserted — attempting email send');

--- a/backend/routes/cv.js
+++ b/backend/routes/cv.js
@@ -63,13 +63,30 @@ function scanForPrivateInfo(buffer) {
   const text = buffer.toString('latin1');
   const warnings = [];
 
-  // Common patterns that shouldn't appear in a public CV
+  // Common patterns that shouldn't appear in a public CV.
+  // Patterns are heuristic — broad enough to catch common formats while
+  // avoiding false positives on innocuous text (#111).
   const patterns = [
     { re: /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/, label: 'possible card number' },
     { re: /\b\d{3}-\d{2}-\d{4}\b/,                        label: 'possible SSN' },
     { re: /\bpassword[:\s]/i,                              label: 'possible password' },
     { re: /\bsort\s*code[:\s]/i,                          label: 'possible sort code' },
     { re: /\bni\s*number[:\s]/i,                          label: 'possible NI number' },
+
+    // Phone numbers — UK mobile (07xxx), UK landline, international +xx prefix,
+    // and Guernsey/Channel Islands numbers (01481).
+    { re: /\b07\d{3}[\s-]?\d{3}[\s-]?\d{3}\b/,           label: 'possible UK mobile number' },
+    { re: /\b0[1-9]\d{3}[\s-]?\d{6}\b/,                  label: 'possible UK landline number' },
+    { re: /\+\d{1,3}[\s-]?\(?\d{1,4}\)?[\s-]?\d{3,}/,   label: 'possible international phone number' },
+
+    // UK and Guernsey postcodes (e.g. SW1A 1AA, GY1 1AA).
+    { re: /\b(GY\d[\s-]?\d[A-Z]{2}|[A-Z]{1,2}\d{1,2}[A-Z]?\s?\d[A-Z]{2})\b/i,
+                                                           label: 'possible UK/Guernsey postcode' },
+
+    // Street address heuristic — a line containing a house number followed by
+    // a road/street/avenue/close/lane/way keyword. Avoids matching short refs.
+    { re: /\b\d+\s+\w+\s+(street|st|road|rd|avenue|ave|close|cl|lane|ln|way|drive|dr|crescent|place|pl|row)\b/i,
+                                                           label: 'possible street address' },
   ];
 
   patterns.forEach(({ re, label }) => {

--- a/backend/routes/cv.js
+++ b/backend/routes/cv.js
@@ -17,27 +17,28 @@ import { exemptIfTrusted } from '../utils/serviceKey.js';
 import { logger }        from '../utils/logger.js';
 import { UPLOADS_DIR }   from '../utils/paths.js';
 import { wrapMulter }    from '../utils/wrapMulter.js';
+import { CV_RATE_WINDOW_MS, CV_RATE_LIMIT, CV_MAX_FILE_SIZE } from '../utils/constants.js';
 
 const router  = Router();
 
 // Per-IP backstop on CV write operations. The limiter precedes authenticate
 // so CodeQL's js/missing-rate-limiting detector sees it before auth.
 const cvRateLimit = rateLimit({
-  windowMs:        60 * 1000,
-  limit:           30,
+  windowMs:        CV_RATE_WINDOW_MS,
+  limit:           CV_RATE_LIMIT,
   keyGenerator:    (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
   skip:            exemptIfTrusted,
   message:         { error: 'Too many requests. Please try again later.' },
   standardHeaders: true,
   legacyHeaders:   false,
-  store:           new PostgresStore({ windowMs: 60 * 1000, keyType: 'cv' }),
+  store:           new PostgresStore({ windowMs: CV_RATE_WINDOW_MS, keyType: 'cv' }),
 });
 const CV_PATH = path.join(UPLOADS_DIR, 'cv.pdf');
 
 // ── multer: memory storage so we can inspect before writing ──────────────────
 const upload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+  limits: { fileSize: CV_MAX_FILE_SIZE },
   fileFilter(_req, file, cb) {
     if (file.mimetype === 'application/pdf') {
       cb(null, true);

--- a/backend/routes/deploy.js
+++ b/backend/routes/deploy.js
@@ -64,22 +64,22 @@ router.get('/status', authenticate, async (req, res) => {
 
     const behind = parseInt(behindRaw.trim(), 10) || 0;
     res.json({
-      env:       DEPLOY_ENV,
-      branch:    branch.trim(),
-      head:      { sha: fullSha.trim().slice(0, 7), fullSha: fullSha.trim(), message: message.trim(), date: date.trim() },
+      env:        DEPLOY_ENV,
+      branch:     branch.trim(),
+      head:       { sha: fullSha.trim().slice(0, 7), full_sha: fullSha.trim(), message: message.trim(), date: date.trim() },
       behind,
-      upToDate:  behind === 0,
-      canDeploy: await scriptExists(),
+      up_to_date: behind === 0,
+      can_deploy: await scriptExists(),
     });
   } catch (err) {
     // Git commands failing in dev is expected — return read-only status
     res.status(200).json({
-      branch:    'unknown',
-      head:      { sha: '?', fullSha: '?', message: 'Git unavailable', date: '' },
-      behind:    0,
-      upToDate:  false,
-      canDeploy: false,
-      gitError:  err.message,
+      branch:     'unknown',
+      head:       { sha: '?', full_sha: '?', message: 'Git unavailable', date: '' },
+      behind:     0,
+      up_to_date: false,
+      can_deploy: false,
+      git_error:  err.message,
     });
   }
 });
@@ -94,8 +94,8 @@ router.get('/history', authenticate, async (req, res) => {
     ).catch(() => '');
 
     const commits = gitOut.trim().split('\n').filter(Boolean).map(line => {
-      const [sha, shortSha, message, date] = line.split('|');
-      return { sha, shortSha, message, date };
+      const [sha, short_sha, message, date] = line.split('|');
+      return { sha, short_sha, message, date };
     });
 
     let deployLog = [];
@@ -114,10 +114,10 @@ router.get('/history', authenticate, async (req, res) => {
         .filter(e => e.detail); // skip blank separator lines
     } catch { /* log file may not exist yet */ }
 
-    res.json({ commits, deployLog });
+    res.json({ commits, deploy_log: deployLog });
   } catch (err) {
     // Git not available in dev — return empty history gracefully
-    res.json({ commits: [], deployLog: [] });
+    res.json({ commits: [], deploy_log: [] });
   }
 });
 

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -8,6 +8,7 @@ import { exemptIfTrusted } from '../utils/serviceKey.js';
 import { slugify, findUniqueSlug } from '../utils/slugify.js';
 import { validate, CreatePostSchema, UpdatePostSchema } from '../middleware/validate.js';
 import { logger } from '../utils/logger.js';
+import { EXCERPT_LENGTH, POSTS_RATE_WINDOW_MS, POSTS_RATE_LIMIT } from '../utils/constants.js';
 
 const router = Router();
 
@@ -18,14 +19,14 @@ const router = Router();
 // random JWTs. The limiter is placed before resolveUser in the chain so
 // CodeQL's js/missing-rate-limiting detector sees it precede authorization.
 const postsRateLimit = rateLimit({
-  windowMs:        60 * 1000,
-  limit:           120,
+  windowMs:        POSTS_RATE_WINDOW_MS,
+  limit:           POSTS_RATE_LIMIT,
   keyGenerator:    (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
   skip:            exemptIfTrusted,
   message:         { error: 'Too many requests. Please try again later.' },
   standardHeaders: true,
   legacyHeaders:   false,
-  store:           new PostgresStore({ windowMs: 60 * 1000, keyType: 'posts' }),
+  store:           new PostgresStore({ windowMs: POSTS_RATE_WINDOW_MS, keyType: 'posts' }),
 });
 
 // ── Helpers
@@ -48,7 +49,7 @@ router.get('/', postsRateLimit, resolveUser, async (req, res, next) => {
   try {
     const result = await pool.query(
       `SELECT id, title, slug, post_date, published_at, created_at,
-              left(body_markdown, 300) AS excerpt
+              left(body_markdown, ${EXCERPT_LENGTH}) AS excerpt
        FROM posts
        WHERE post_type = 'blog' AND published_at IS NOT NULL
        ORDER BY COALESCE(post_date, published_at::date) DESC`
@@ -65,7 +66,7 @@ router.get('/all', postsRateLimit, resolveUser, authenticate, async (req, res, n
   try {
     const result = await pool.query(
       `SELECT id, title, slug, post_date, published_at, created_at,
-              left(body_markdown, 300) AS excerpt
+              left(body_markdown, ${EXCERPT_LENGTH}) AS excerpt
        FROM posts
        WHERE post_type = 'blog'
        ORDER BY created_at DESC`

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -9,6 +9,7 @@ import { slugify, findUniqueSlug } from '../utils/slugify.js';
 import { validate, CreatePostSchema, UpdatePostSchema } from '../middleware/validate.js';
 import { logger } from '../utils/logger.js';
 import { EXCERPT_LENGTH, POSTS_RATE_WINDOW_MS, POSTS_RATE_LIMIT } from '../utils/constants.js';
+import { publicCache, noStore } from '../middleware/cacheHeaders.js';
 
 const router = Router();
 
@@ -45,7 +46,7 @@ async function insertPost(post_type, title, body_markdown, post_date, published_
 // ── Routes
 
 // Public: list published blog posts
-router.get('/', postsRateLimit, resolveUser, async (req, res, next) => {
+router.get('/', postsRateLimit, resolveUser, publicCache(60), async (req, res, next) => {
   try {
     const result = await pool.query(
       `SELECT id, title, slug, post_date, published_at, created_at,
@@ -62,7 +63,7 @@ router.get('/', postsRateLimit, resolveUser, async (req, res, next) => {
 });
 
 // Admin: list all blog posts (drafts + published)
-router.get('/all', postsRateLimit, resolveUser, authenticate, async (req, res, next) => {
+router.get('/all', postsRateLimit, resolveUser, authenticate, noStore, async (req, res, next) => {
   try {
     const result = await pool.query(
       `SELECT id, title, slug, post_date, published_at, created_at,
@@ -95,7 +96,7 @@ router.get('/admin/:id', postsRateLimit, resolveUser, authenticate, async (req, 
 });
 
 // Public: single blog post by slug
-router.get('/:slug', postsRateLimit, resolveUser, async (req, res, next) => {
+router.get('/:slug', postsRateLimit, resolveUser, publicCache(300), async (req, res, next) => {
   try {
     const result = await pool.query(
       `SELECT id, title, slug, body_markdown, post_date, published_at, created_at

--- a/backend/routes/travel.js
+++ b/backend/routes/travel.js
@@ -9,6 +9,7 @@ import { slugify, findUniqueSlug } from '../utils/slugify.js';
 import { validate, CreateTravelSchema, UpdateTravelSchema } from '../middleware/validate.js';
 import { logger } from '../utils/logger.js';
 import { TRAVEL_RATE_WINDOW_MS, TRAVEL_RATE_LIMIT } from '../utils/constants.js';
+import { publicCache, noStore } from '../middleware/cacheHeaders.js';
 
 const router = Router();
 
@@ -83,7 +84,7 @@ async function replaceMedia(client, postId, mediaItems) {
 }
 
 // Public: published travel posts
-router.get('/', travelRateLimit, resolveUser, async (req, res, next) => {
+router.get('/', travelRateLimit, resolveUser, publicCache(60), async (req, res, next) => {
   try {
     const result = await pool.query(
       `SELECT ${TRAVEL_COLS_PUBLIC}
@@ -99,7 +100,7 @@ router.get('/', travelRateLimit, resolveUser, async (req, res, next) => {
 });
 
 // Admin: all travel posts including drafts
-router.get('/all', travelRateLimit, resolveUser, authenticate, async (req, res, next) => {
+router.get('/all', travelRateLimit, resolveUser, authenticate, noStore, async (req, res, next) => {
   try {
     const result = await pool.query(
       `SELECT ${TRAVEL_COLS}
@@ -130,7 +131,7 @@ router.get('/admin/:id', travelRateLimit, resolveUser, authenticate, async (req,
 });
 
 // Public: single published travel post by id
-router.get('/:id', travelRateLimit, resolveUser, async (req, res, next) => {
+router.get('/:id', travelRateLimit, resolveUser, publicCache(300), async (req, res, next) => {
   try {
     const result = await pool.query(
       `SELECT ${TRAVEL_COLS_PUBLIC} FROM posts p

--- a/backend/routes/travel.js
+++ b/backend/routes/travel.js
@@ -8,6 +8,7 @@ import { exemptIfTrusted } from '../utils/serviceKey.js';
 import { slugify, findUniqueSlug } from '../utils/slugify.js';
 import { validate, CreateTravelSchema, UpdateTravelSchema } from '../middleware/validate.js';
 import { logger } from '../utils/logger.js';
+import { TRAVEL_RATE_WINDOW_MS, TRAVEL_RATE_LIMIT } from '../utils/constants.js';
 
 const router = Router();
 
@@ -17,14 +18,14 @@ const router = Router();
 // surface. The limiter precedes resolveUser in the chain so CodeQL's
 // js/missing-rate-limiting detector sees it before any authorization step.
 const travelRateLimit = rateLimit({
-  windowMs:        60 * 1000,
-  limit:           120,
+  windowMs:        TRAVEL_RATE_WINDOW_MS,
+  limit:           TRAVEL_RATE_LIMIT,
   keyGenerator:    (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
   skip:            exemptIfTrusted,
   message:         { error: 'Too many requests. Please try again later.' },
   standardHeaders: true,
   legacyHeaders:   false,
-  store:           new PostgresStore({ windowMs: 60 * 1000, keyType: 'travel' }),
+  store:           new PostgresStore({ windowMs: TRAVEL_RATE_WINDOW_MS, keyType: 'travel' }),
 });
 
 const TRAVEL_COLS = `

--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -7,18 +7,22 @@ import { PostgresStore } from '../middleware/postgresStore.js';
 import { exemptIfTrusted } from '../utils/serviceKey.js';
 import { UPLOADS_DIR } from '../utils/paths.js';
 import { wrapMulter }  from '../utils/wrapMulter.js';
+import {
+  UPLOAD_RATE_WINDOW_MS, UPLOAD_RATE_LIMIT,
+  MEDIA_MAX_FILE_SIZE, MEDIA_ALLOWED_MIME,
+} from '../utils/constants.js';
 
 // Per-IP backstop on media uploads. Limiter precedes authenticate so
 // CodeQL's js/missing-rate-limiting detector sees it before auth.
 const uploadRateLimit = rateLimit({
-  windowMs:        60 * 1000,
-  limit:           30,
+  windowMs:        UPLOAD_RATE_WINDOW_MS,
+  limit:           UPLOAD_RATE_LIMIT,
   keyGenerator:    (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
   skip:            exemptIfTrusted,
   message:         { error: 'Too many requests. Please try again later.' },
   standardHeaders: true,
   legacyHeaders:   false,
-  store:           new PostgresStore({ windowMs: 60 * 1000, keyType: 'upload' }),
+  store:           new PostgresStore({ windowMs: UPLOAD_RATE_WINDOW_MS, keyType: 'upload' }),
 });
 
 const storage = multer.diskStorage({
@@ -29,18 +33,11 @@ const storage = multer.diskStorage({
   },
 });
 
-const ALLOWED_MIME = new Set([
-  'image/jpeg', 'image/png', 'image/gif', 'image/webp',
-  'video/mp4', 'video/webm', 'video/quicktime',
-]);
-
-const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
-
 const upload = multer({
   storage,
-  limits: { fileSize: MAX_FILE_SIZE },
+  limits: { fileSize: MEDIA_MAX_FILE_SIZE },
   fileFilter: (_req, file, cb) => {
-    ALLOWED_MIME.has(file.mimetype)
+    MEDIA_ALLOWED_MIME.has(file.mimetype)
       ? cb(null, true)
       : cb(new Error('File type not allowed'));
   },

--- a/backend/tests/middleware/validate.test.js
+++ b/backend/tests/middleware/validate.test.js
@@ -205,17 +205,17 @@ describe('EmailSendSchema', () => {
 describe('PasskeyRegisterFinishSchema', () => {
   it('accepts valid input', () => {
     const { nextCalled } = runValidate(PasskeyRegisterFinishSchema, {
-      response: { id: 'abc', type: 'public-key' }, sessionKey: 'sess_123',
+      response: { id: 'abc', type: 'public-key' }, session_key: 'sess_123',
     });
     expect(nextCalled).toBe(true);
   });
 
-  it('rejects missing sessionKey', () => {
+  it('rejects missing session_key', () => {
     const { res } = runValidate(PasskeyRegisterFinishSchema, {
       response: { id: 'abc', type: 'public-key' },
     });
     expect(res._status).toBe(400);
-    expect(res._json.error).toMatch(/sessionKey/i);
+    expect(res._json.error).toMatch(/session_key/i);
   });
 });
 
@@ -224,16 +224,16 @@ describe('PasskeyRegisterFinishSchema', () => {
 describe('PasskeyLoginFinishSchema', () => {
   it('accepts valid input', () => {
     const { nextCalled } = runValidate(PasskeyLoginFinishSchema, {
-      response: { id: 'xyz' }, sessionKey: 'sess_456',
+      response: { id: 'xyz' }, session_key: 'sess_456',
     });
     expect(nextCalled).toBe(true);
   });
 
-  it('rejects missing sessionKey', () => {
+  it('rejects missing session_key', () => {
     const { res } = runValidate(PasskeyLoginFinishSchema, {
       response: { id: 'xyz' },
     });
     expect(res._status).toBe(400);
-    expect(res._json.error).toMatch(/sessionKey/i);
+    expect(res._json.error).toMatch(/session_key/i);
   });
 });

--- a/backend/utils/constants.js
+++ b/backend/utils/constants.js
@@ -1,0 +1,64 @@
+/**
+ * Shared backend constants.
+ *
+ * Extract magic numbers and config literals here rather than scattering them
+ * across route files. Values that are operationally significant or
+ * security-sensitive belong either here (as named constants) or in .env
+ * (for values that need per-environment tuning at deploy time).
+ */
+
+// ── Post excerpts ─────────────────────────────────────────────────────────────
+
+// Characters of body_markdown to return in listing queries. Keeping all
+// listing consumers in sync requires a single source of truth (#433).
+export const EXCERPT_LENGTH = 300;
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+// Rate-limit windows (milliseconds)
+export const EMAIL_RATE_WINDOW_MS   = 60 * 60 * 1000; // 1 hour
+export const PASSKEY_RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+export const ACCOUNT_RATE_WINDOW_MS = 60 * 1000;       // 1 minute
+
+// Rate-limit request caps
+export const EMAIL_RATE_LIMIT   = 5;  // per EMAIL_RATE_WINDOW_MS
+export const PASSKEY_RATE_LIMIT = 10; // per PASSKEY_RATE_WINDOW_MS
+export const ACCOUNT_RATE_LIMIT = 60; // per ACCOUNT_RATE_WINDOW_MS
+
+// WebAuthn challenge TTL — how long the browser has to complete a ceremony.
+// Read by auth.js INSERT ... NOW() + INTERVAL '...' SQL literals.
+export const WEBAUTHN_CHALLENGE_TTL = '5 minutes';
+
+// Magic-link token TTL — security-sensitive: determines how long a stolen link
+// is valid. Changing this requires updating auth.js email/verify query too.
+export const MAGIC_LINK_TTL = '15 minutes';
+
+// ── CV upload ─────────────────────────────────────────────────────────────────
+
+// Maximum size (bytes) for CV PDF uploads.
+export const CV_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+// ── Media upload ──────────────────────────────────────────────────────────────
+
+// Maximum size (bytes) for generic media uploads (photos/videos).
+export const MEDIA_MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
+
+// Allowed MIME types for generic media uploads.
+export const MEDIA_ALLOWED_MIME = new Set([
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+  'video/mp4', 'video/webm', 'video/quicktime',
+]);
+
+// ── Posts / travel rate limits ────────────────────────────────────────────────
+
+export const POSTS_RATE_WINDOW_MS  = 60 * 1000; // 1 minute
+export const POSTS_RATE_LIMIT      = 120;
+
+export const TRAVEL_RATE_WINDOW_MS = 60 * 1000; // 1 minute
+export const TRAVEL_RATE_LIMIT     = 120;
+
+export const UPLOAD_RATE_WINDOW_MS = 60 * 1000; // 1 minute
+export const UPLOAD_RATE_LIMIT     = 30;
+
+export const CV_RATE_WINDOW_MS     = 60 * 1000; // 1 minute
+export const CV_RATE_LIMIT         = 30;

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -2045,28 +2045,24 @@ footer {
 
 .btn-small {
     background: var(--color-text);
-    color: var(--color-bg);
-    border: none;
-    padding: 0.35rem 0.85rem;
+    color:       var(--color-bg);
+    border:      none;
+    padding:     0.35rem 0.85rem;
     border-radius: 4px;
-    font-size: 0.85rem;
-    cursor: pointer;
-    height: auto;
-    width: auto;
+    font-size:   0.85rem;
+    cursor:      pointer;
+    height:      auto;
+    width:       auto;
 }
 
 .btn-small:hover { opacity: 0.85; }
 
+/* Colour modifier — combine with a size class (.btn-small, .btn-primary, etc.)
+   to get the red danger style without duplicating geometry rules (#150). */
 .btn-danger {
     background: var(--color-error);
-    color: #fff;
-    border: none;
-    padding: 0.35rem 0.85rem;
-    border-radius: 4px;
-    font-size: 0.85rem;
-    cursor: pointer;
-    height: auto;
-    width: auto;
+    color:      #fff;
+    border:     none;
 }
 
 .btn-danger:hover { opacity: 0.85; }

--- a/resources/js/admin/deploy.js
+++ b/resources/js/admin/deploy.js
@@ -34,12 +34,12 @@ export function initDeploy() {
 
     function renderStatus(s) {
         if (s.env) deployEnv = s.env;
-        const badge = s.upToDate
+        const badge = s.up_to_date
             ? '<span style="color:var(--color-success)">✓ Up to date</span>'
             : `<span style="color:var(--color-error)">↓ ${s.behind} commit${s.behind !== 1 ? 's' : ''} behind</span>`;
         statusRow.innerHTML =
             `<strong>${escapeHtml(s.head.sha)}</strong> — ${escapeHtml(s.head.message)}&nbsp;&nbsp;${badge}`;
-        if (s.canDeploy) {
+        if (s.can_deploy) {
             fetchBtn.disabled    = false;
             deployBtn.disabled   = false;
             rollbackBtn.disabled = false;
@@ -49,13 +49,13 @@ export function initDeploy() {
     }
 
     function renderLog(data) {
-        const rows = data.deployLog.map(e =>
+        const rows = data.deploy_log.map(e =>
             `<p style="font-size:0.85rem;font-family:monospace">${escapeHtml(e.ts ? '[' + e.ts + '] ' : '')}${escapeHtml(e.detail)}</p>`
         ).join('');
         logList.innerHTML = rows || '<p class="hint">No deploy log entries yet.</p>';
 
         rollbackSelect.innerHTML = data.commits.map(c =>
-            `<option value="${escapeHtml(c.sha)}">${escapeHtml(c.shortSha)} — ${escapeHtml(c.message)}</option>`
+            `<option value="${escapeHtml(c.sha)}">${escapeHtml(c.short_sha)} — ${escapeHtml(c.message)}</option>`
         ).join('');
     }
 

--- a/resources/js/admin/deploy.js
+++ b/resources/js/admin/deploy.js
@@ -2,6 +2,12 @@ import { authFetch } from './auth.js';
 import { escapeHtml } from '../utils/html.js';
 import { createMessenger } from '../utils/messenger.js';
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+// Together these encode a ~60 s recovery window after a backend restart.
+const MAX_POLL_ATTEMPTS  = 30;
+const POLL_INTERVAL_MS   = 2000;
+
 export function initDeploy() {
     let deployEnv = 'prod'; // fallback until status loads
 
@@ -106,13 +112,13 @@ export function initDeploy() {
 
     // Poll /deploy/status until the backend responds (up to 60s)
     async function pollUntilBack(attempts = 0) {
-        if (attempts > 30) throw new Error('Backend did not recover within 60s');
+        if (attempts > MAX_POLL_ATTEMPTS) throw new Error('Backend did not recover within 60s');
         try {
             const r = await authFetch('/deploy/status');
             if (!r.ok) throw new Error();
             renderStatus(await r.json());
         } catch {
-            await new Promise(r => setTimeout(r, 2000));
+            await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
             return pollUntilBack(attempts + 1);
         }
     }

--- a/resources/js/admin/passkeys.js
+++ b/resources/js/admin/passkeys.js
@@ -53,12 +53,12 @@ async function addPasskey() {
     setMessage('Follow the passkey prompt on your device…');
     try {
         const startRes = await authFetch('/auth/passkey/register/start', { method: 'POST', body: JSON.stringify({}) });
-        const { options, sessionKey } = await startRes.json();
+        const { options, session_key } = await startRes.json();
         const response = await startRegistration(options);
         const name = prompt('Give this passkey a name (e.g. "MacBook", "iPhone"):') || 'My passkey';
         const finishRes = await authFetch('/auth/passkey/register/finish', {
             method: 'POST',
-            body: JSON.stringify({ response, sessionKey, passkeyName: name }),
+            body: JSON.stringify({ response, session_key, passkey_name: name }),
         });
         const data = await finishRes.json();
         if (!finishRes.ok) throw new Error(data.error || 'Registration failed');

--- a/resources/js/admin/passkeys.js
+++ b/resources/js/admin/passkeys.js
@@ -1,3 +1,4 @@
+// Version pin: keep in sync with login.js (#434).
 import { startRegistration } from 'https://esm.sh/@simplewebauthn/browser@7';
 import { authFetch } from './auth.js';
 import { escapeHtml } from '../utils/html.js';

--- a/resources/js/admin/travel.js
+++ b/resources/js/admin/travel.js
@@ -1,9 +1,523 @@
-import { initForm } from './travel/form.js';
-import { initGeocode } from './travel/geocode.js';
-import { loadAll } from './travel/list.js';
+import exifr from 'https://esm.sh/exifr@7.1.3';
+import { authFetch, authFetchMultipart, todayIso } from './auth.js';
+import { escapeHtml } from '../utils/html.js';
+import { createMessenger } from '../utils/messenger.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+// Nominatim base URL — shared by reverse-geocode (reverseGeocodeToLocation)
+// and forward-geocode (geocodeLocation) to avoid drift between the two calls.
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org';
+
+// Duration (ms) to flash a success outline on the location input after
+// Geocode normalises the field value.
+const LOCATION_FLASH_MS = 1500;
+
+// ── Module state ──────────────────────────────────────────────────────────────
+
+let pendingFiles    = [];   // File objects queued for upload
+let existingMedia   = [];   // {id, url, type} from post_media (on edit)
+let removedMediaIds = [];   // post_media ids to delete on save
+let geoconfirmMap   = null; // Leaflet map for coordinate confirmation
+let geoconfirmMarker = null;
+
+// ── Messaging ─────────────────────────────────────────────────────────────────
+
+const setMessage = createMessenger('travel-message');
+
+// ── Media list ────────────────────────────────────────────────────────────────
+
+function renderMediaList() {
+    const list = document.getElementById('travel-media-list');
+    list.innerHTML = '';
+
+    const allItems = [
+        ...existingMedia.map(m => ({ kind: 'existing', ...m })),
+        ...pendingFiles.map((f, i) => ({ kind: 'pending', index: i, name: f.name, type: f.type })),
+    ];
+
+    if (!allItems.length) { list.classList.add('hidden'); return; }
+    list.classList.remove('hidden');
+
+    allItems.forEach(item => {
+        const row = document.createElement('div');
+        row.className = 'media-list-row';
+
+        const icon = item.type && item.type.startsWith('video') ? '🎦' : '🖼';
+        const labelText = item.kind === 'existing'
+            ? `${icon} ${item.url.split('/').pop()}`
+            : `${icon} ${item.name} (pending)`;
+        const labelEl = document.createElement('span');
+        labelEl.className = 'media-list-label';
+        labelEl.textContent = labelText;
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn-small media-remove-btn';
+        removeBtn.textContent = 'Remove';
+
+        if (item.kind === 'existing') {
+            removeBtn.addEventListener('click', () => {
+                removedMediaIds.push(item.id);
+                existingMedia = existingMedia.filter(m => m.id !== item.id);
+                renderMediaList();
+            });
+        } else {
+            removeBtn.addEventListener('click', () => {
+                pendingFiles.splice(item.index, 1);
+                renderMediaList();
+                if (!pendingFiles.length && !existingMedia.length) {
+                    document.querySelector('.file-input-label').textContent = 'No files chosen';
+                }
+            });
+        }
+
+        row.append(labelEl, removeBtn);
+        list.append(row);
+    });
+}
+
+// ── Form reset ────────────────────────────────────────────────────────────────
+
+function clearForm() {
+    document.getElementById('travel-edit-id').value = '';
+    document.getElementById('travel-form').reset();
+    document.getElementById('travel-cancel-btn').classList.add('hidden');
+    document.querySelector('.file-input-label').textContent = 'No files chosen';
+    document.getElementById('travel-date').value = todayIso();
+    document.getElementById('travel-preview').classList.add('hidden');
+    document.querySelector('.preview-media').innerHTML = '';
+    document.querySelector('.preview-text').innerHTML = '';
+    pendingFiles    = [];
+    existingMedia   = [];
+    removedMediaIds = [];
+    renderMediaList();
+    setMessage('');
+    hideGeoconfirmMap();
+}
+
+// ── Saved memories list ───────────────────────────────────────────────────────
+
+function buildRow(memory) {
+    const div = document.createElement('div');
+    div.className = 'saved-memory-row';
+
+    const info = document.createElement('div');
+    info.className = 'saved-memory-info';
+    const statusLabel = memory.published_at
+        ? '<span class="post-status published">Published</span>'
+        : '<span class="post-status draft">Draft</span>';
+    info.innerHTML = '<strong>' + escapeHtml(memory.title) + '</strong> ' + statusLabel;
+
+    if (memory.location) {
+        const loc = document.createElement('span');
+        loc.className = 'saved-memory-location';
+        loc.textContent = ' — ' + memory.location;
+        info.append(loc);
+    }
+
+    const dateSpan = document.createElement('span');
+    dateSpan.className = 'saved-memory-date';
+    dateSpan.textContent = ' · ' + new Date(memory.created_at).toLocaleDateString();
+    info.append(dateSpan);
+
+    const actions = document.createElement('div');
+    actions.className = 'post-admin-actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.className = 'btn-small';
+    editBtn.textContent = 'Edit';
+    editBtn.addEventListener('click', () => loadForEdit(memory));
+
+    const toggleBtn = document.createElement('button');
+    toggleBtn.type = 'button';
+    toggleBtn.className = 'btn-small';
+    toggleBtn.textContent = memory.published_at ? 'Unpublish' : 'Publish';
+    toggleBtn.addEventListener('click', () => togglePublish(memory));
+
+    const delBtn = document.createElement('button');
+    delBtn.type = 'button';
+    delBtn.className = 'btn-small btn-danger';
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', () => deleteMemory(memory.id));
+
+    actions.append(editBtn, toggleBtn, delBtn);
+    div.append(info, actions);
+    return div;
+}
+
+async function loadAll() {
+    const list = document.getElementById('saved-memories-list');
+    list.innerHTML = '<p class="hint">Loading…</p>';
+    try {
+        const res = await authFetch('/travel/all');
+        if (!res.ok) throw new Error();
+        const memories = await res.json();
+        if (!memories.length) { list.innerHTML = '<p class="hint">No travel memories saved yet.</p>'; return; }
+        list.innerHTML = '';
+        memories.forEach(m => list.append(buildRow(m)));
+    } catch {
+        list.innerHTML = '<p class="hint" style="color:var(--color-error)">Failed to load memories.</p>';
+    }
+}
+
+// #93 fix: slice ISO timestamp to YYYY-MM-DD before setting <input type="date">
+async function loadForEdit(memory) {
+    try {
+        const res = await authFetch(`/travel/admin/${memory.id}`);
+        if (!res.ok) throw new Error();
+        const full = await res.json();
+
+        document.getElementById('travel-edit-id').value    = full.id;
+        document.getElementById('travel-title').value      = full.title || '';
+        document.getElementById('travel-location').value   = full.location || '';
+        document.getElementById('travel-notes').value      = full.notes || '';
+        document.getElementById('travel-date').value       = full.post_date ? String(full.post_date).slice(0, 10) : todayIso();
+        document.getElementById('travel-lat').value        = full.lat != null ? full.lat : '';
+        document.getElementById('travel-lng').value        = full.lng != null ? full.lng : '';
+
+        pendingFiles    = [];
+        removedMediaIds = [];
+        existingMedia   = Array.isArray(full.media) && full.media.length
+            ? full.media.map(m => ({ id: m.id, url: m.url, type: m.type }))
+            : (full.media_url ? [{ id: null, url: full.media_url, type: full.media_type }] : []);
+        document.querySelector('.file-input-label').textContent = 'No files chosen';
+        renderMediaList();
+
+        if (full.lat != null && full.lng != null) {
+            updateGeoconfirmMap(parseFloat(full.lat), parseFloat(full.lng));
+        }
+
+        document.getElementById('travel-preview').classList.add('hidden');
+        document.getElementById('travel-cancel-btn').classList.remove('hidden');
+        setMessage('Editing: ' + full.title);
+        document.getElementById('travel-title').scrollIntoView({ behavior: 'smooth' });
+    } catch {
+        setMessage('Failed to load memory for editing.', true);
+    }
+}
+
+async function togglePublish(memory) {
+    try {
+        const res = await authFetch(`/travel/${memory.id}`, {
+            method: 'PUT',
+            body: JSON.stringify({
+                title:     memory.title,
+                location:  memory.location || '',
+                notes:     memory.notes || '',
+                // Slice to YYYY-MM-DD — list response returns full ISO timestamp (#93)
+                post_date: memory.post_date ? String(memory.post_date).slice(0, 10) : null,
+                lat:       memory.lat,
+                lng:       memory.lng,
+                publish:   !memory.published_at,
+                // media_items undefined → backend leaves existing post_media untouched
+            }),
+        });
+        if (!res.ok) throw new Error();
+        await loadAll();
+    } catch {
+        alert('Failed to update memory.');
+    }
+}
+
+async function deleteMemory(id) {
+    if (!confirm('Delete this travel memory? This cannot be undone.')) return;
+    try {
+        const res = await authFetch(`/travel/${id}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error();
+        await loadAll();
+    } catch {
+        alert('Failed to delete memory.');
+    }
+}
+
+// ── Geocode confirmation map ──────────────────────────────────────────────────
+
+function updateGeoconfirmMap(lat, lng) {
+    if (!window.L) return;
+    const mapEl = document.getElementById('geoconfirm-map');
+    if (!mapEl) return;
+    mapEl.classList.remove('hidden');
+
+    if (!geoconfirmMap) {
+        geoconfirmMap = L.map('geoconfirm-map', { scrollWheelZoom: false, zoomControl: true });
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 18,
+            attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        }).addTo(geoconfirmMap);
+    }
+
+    const latlng = [lat, lng];
+    geoconfirmMap.setView(latlng, 10);
+
+    if (geoconfirmMarker) {
+        geoconfirmMarker.setLatLng(latlng);
+    } else {
+        geoconfirmMarker = L.marker(latlng).addTo(geoconfirmMap);
+    }
+
+    // Leaflet needs a size nudge after becoming visible
+    setTimeout(() => geoconfirmMap.invalidateSize(), 50);
+}
+
+function hideGeoconfirmMap() {
+    const mapEl = document.getElementById('geoconfirm-map');
+    if (mapEl) mapEl.classList.add('hidden');
+    if (geoconfirmMarker && geoconfirmMap) {
+        geoconfirmMap.removeLayer(geoconfirmMarker);
+        geoconfirmMarker = null;
+    }
+}
+
+// ── EXIF GPS autofill ─────────────────────────────────────────────────────────
+
+// Returns true only if coords are finite numbers and not the null-island 0,0
+// that DJI and some cameras emit when GPS is unavailable.
+function hasValidGps(lat, lng) {
+    return Number.isFinite(lat) && Number.isFinite(lng) && !(lat === 0 && lng === 0);
+}
+
+// Build canonical "City, Country" from a Nominatim address object.
+// Falls back to the first two comma-separated parts of display_name when the
+// address object lacks a city-level field (e.g. Tokyo returns addresstype
+// "province", not "city", so address.province must be checked explicitly).
+function normaliseLocation(address, displayName) {
+    if (address) {
+        const city    = address.city || address.town || address.village || address.hamlet ||
+                        address.municipality || address.province ||
+                        address.county || address.state_district || address.state || '';
+        const country = address.country || '';
+        if (city && country) return `${city}, ${country}`;
+    }
+    const parts = displayName ? displayName.split(',').map(p => p.trim()).filter(Boolean) : [];
+    return parts.slice(0, 2).join(', ') || null;
+}
+
+// Reverse geocode lat/lng to a human-readable location string using Nominatim.
+// Only populates the Location field if it is currently empty.
+async function reverseGeocodeToLocation(lat, lng) {
+    if (document.getElementById('travel-location').value.trim()) return;
+    try {
+        const url = `${NOMINATIM_URL}/reverse?format=json&lat=${lat}&lon=${lng}&zoom=10&addressdetails=1`;
+        const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
+        if (!res.ok) return;
+        const data = await res.json();
+        const locationStr = normaliseLocation(data.address, data.display_name);
+        if (locationStr) document.getElementById('travel-location').value = locationStr;
+    } catch {
+        // Reverse geocode failure is non-fatal — silently ignore
+    }
+}
+
+async function extractGpsFromFile(file) {
+    if (!file || !file.type || !file.type.startsWith('image/')) return null;
+    try {
+        let gps = null;
+        try {
+            const tags = await exifr.parse(file, { gps: true });
+            if (tags && hasValidGps(tags.latitude, tags.longitude)) {
+                gps = { latitude: tags.latitude, longitude: tags.longitude };
+            }
+        } catch { /* fall through to exifr.gps() */ }
+
+        if (!gps) {
+            const raw = await exifr.gps(file);
+            if (raw && hasValidGps(raw.latitude, raw.longitude)) gps = raw;
+        }
+        return gps;
+    } catch {
+        return null;
+    }
+}
+
+// Loop through sorted files to find the first one with valid GPS coords.
+async function tryAutofillGpsFromFileList(files) {
+    const sortedImages = files
+        .filter(f => f.type && f.type.startsWith('image/'))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const file of sortedImages) {
+        const gps = await extractGpsFromFile(file);
+        if (gps) {
+            document.getElementById('travel-lat').value = gps.latitude.toFixed(6);
+            document.getElementById('travel-lng').value = gps.longitude.toFixed(6);
+            setMessage(`GPS auto-filled from ${file.name}.`);
+            updateGeoconfirmMap(gps.latitude, gps.longitude);
+            await reverseGeocodeToLocation(gps.latitude, gps.longitude);
+            return;
+        }
+    }
+    setMessage('No GPS data in any photo — enter coordinates manually or use Geocode.', false, true);
+}
+
+// Try to read DateTimeOriginal from image EXIF and populate the date input.
+async function tryAutofillDateFromFile(file) {
+    if (!file || !file.type || !file.type.startsWith('image/')) return;
+    const currentVal = document.getElementById('travel-date').value;
+    if (currentVal && currentVal !== todayIso()) return;
+    try {
+        const tags = await exifr.parse(file, ['DateTimeOriginal']);
+        if (tags && tags.DateTimeOriginal instanceof Date) {
+            const d  = tags.DateTimeOriginal;
+            const yyyy = d.getFullYear();
+            const mm   = String(d.getMonth() + 1).padStart(2, '0');
+            const dd   = String(d.getDate()).padStart(2, '0');
+            document.getElementById('travel-date').value = `${yyyy}-${mm}-${dd}`;
+        }
+    } catch {
+        // EXIF date unavailable — ignore
+    }
+}
+
+async function geocodeLocation() {
+    const q = document.getElementById('travel-location').value.trim();
+    if (!q) { setMessage('Enter a location name first.', true); return; }
+    const btn = document.getElementById('geocode-btn');
+    btn.disabled = true;
+    btn.textContent = 'Looking up…';
+    setMessage('');
+    try {
+        const url = `${NOMINATIM_URL}/search?format=json&limit=1&addressdetails=1&q=${encodeURIComponent(q)}`;
+        const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
+        const results = await res.json();
+        if (!results.length) { setMessage('Location not found — try a more specific name.', true); return; }
+        const { lat, lon, display_name, address } = results[0];
+        const parsedLat = parseFloat(lat);
+        const parsedLng = parseFloat(lon);
+        document.getElementById('travel-lat').value = parsedLat.toFixed(6);
+        document.getElementById('travel-lng').value = parsedLng.toFixed(6);
+
+        // Normalise location field to canonical City, Country format
+        const normalised = normaliseLocation(address, display_name);
+        if (normalised) {
+            const locationInput = document.getElementById('travel-location');
+            locationInput.value = normalised;
+            locationInput.style.outline = '2px solid var(--color-success)';
+            setTimeout(() => { locationInput.style.outline = ''; }, LOCATION_FLASH_MS);
+        }
+
+        setMessage(`Coordinates set — confirm pin location on the map below (matched: ${display_name.split(',').slice(0, 3).join(',')}).`, false, true);
+        updateGeoconfirmMap(parsedLat, parsedLng);
+    } catch {
+        setMessage('Geocode failed — check your connection and try again.', true);
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Geocode';
+    }
+}
+
+// ── Init ──────────────────────────────────────────────────────────────────────
 
 export function initTravel() {
     loadAll();
-    initForm();
-    initGeocode();
+
+    document.getElementById('geocode-btn').addEventListener('click', () => geocodeLocation());
+
+    // Update confirmation map when coords are changed manually
+    const coordHandler = () => {
+        const lat = parseFloat(document.getElementById('travel-lat').value);
+        const lng = parseFloat(document.getElementById('travel-lng').value);
+        if (Number.isFinite(lat) && Number.isFinite(lng)) {
+            updateGeoconfirmMap(lat, lng);
+        } else {
+            hideGeoconfirmMap();
+        }
+    };
+    ['travel-lat', 'travel-lng'].forEach(id => {
+        const el = document.getElementById(id);
+        el.addEventListener('change', coordHandler);
+        el.addEventListener('input', coordHandler);
+    });
+
+    document.getElementById('travel-file').addEventListener('change', (event) => {
+        const files = Array.from(event.target.files || []);
+        if (!files.length) return;
+
+        tryAutofillGpsFromFileList(files);
+
+        const sortedImages = files
+            .filter(f => f.type && f.type.startsWith('image/'))
+            .sort((a, b) => a.name.localeCompare(b.name));
+        if (sortedImages.length) tryAutofillDateFromFile(sortedImages[0]);
+
+        pendingFiles = pendingFiles.concat(files);
+        document.querySelector('.file-input-label').textContent =
+            pendingFiles.length + ' file' + (pendingFiles.length !== 1 ? 's' : '') + ' selected';
+        event.target.value = ''; // reset so same file can be re-added if removed
+        renderMediaList();
+    });
+
+    document.getElementById('travel-form').addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const clickedBtn = document.activeElement;
+        const publish    = clickedBtn && clickedBtn.id === 'travel-publish-btn';
+        const submitBtns = event.currentTarget.querySelectorAll('button[type="submit"]');
+        submitBtns.forEach(b => b.disabled = true);
+        setMessage('Saving…');
+
+        const title = document.getElementById('travel-title').value.trim();
+        if (!title) {
+            setMessage('Title is required.', true);
+            submitBtns.forEach(b => b.disabled = false);
+            return;
+        }
+
+        try {
+            const uploadedItems = [];
+            for (let i = 0; i < pendingFiles.length; i++) {
+                setMessage(`Uploading file ${i + 1} of ${pendingFiles.length}…`);
+                const fd = new FormData();
+                fd.append('file', pendingFiles[i]);
+                const upRes  = await authFetchMultipart('/upload', fd);
+                const upData = await upRes.json();
+                if (!upRes.ok) throw new Error(upData.error || 'Upload failed');
+                uploadedItems.push({ url: upData.url, type: upData.type });
+            }
+
+            // Combine: remaining existing media first, then newly uploaded
+            const mediaItems = [
+                ...existingMedia.filter(m => m.id !== null).map(m => ({ url: m.url, type: m.type })),
+                ...uploadedItems,
+            ];
+
+            const editId = document.getElementById('travel-edit-id').value;
+            const travel = {
+                title,
+                location:    document.getElementById('travel-location').value.trim(),
+                notes:       document.getElementById('travel-notes').value.trim(),
+                post_date:   document.getElementById('travel-date').value || null,
+                media_items: mediaItems,
+                lat:         document.getElementById('travel-lat').value,
+                lng:         document.getElementById('travel-lng').value,
+                publish,
+            };
+
+            const method = editId ? 'PUT' : 'POST';
+            const path   = editId ? `/travel/${editId}` : '/travel';
+            const res    = await authFetch(path, { method, body: JSON.stringify(travel) });
+            const data   = await res.json();
+            if (!res.ok) throw new Error(data.error || 'Save failed');
+            setMessage(publish ? 'Memory published.' : 'Draft saved.');
+            clearForm();
+            await loadAll();
+        } catch (err) {
+            setMessage(err.message || 'Failed to save memory.', true);
+        } finally {
+            submitBtns.forEach(b => b.disabled = false);
+        }
+    });
+
+    document.getElementById('travel-cancel-btn').addEventListener('click', clearForm);
+
+    document.getElementById('travel-clear').addEventListener('click', () => {
+        if (document.getElementById('travel-edit-id').value
+            || document.getElementById('travel-title').value
+            || document.getElementById('travel-location').value
+            || document.getElementById('travel-notes').value
+            || pendingFiles.length) {
+            if (!confirm('Clear all fields and start a new memory?')) return;
+        }
+        clearForm();
+    });
 }

--- a/resources/js/admin/travel/geocode.js
+++ b/resources/js/admin/travel/geocode.js
@@ -1,5 +1,15 @@
 import { setMessage } from './messages.js';
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+// Nominatim base URL — shared by reverse-geocode (reverseGeocodeToLocation)
+// and forward-geocode (geocodeLocation) to avoid drift between the two calls.
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org';
+
+// Duration (ms) to flash a success outline on the location input after
+// Geocode normalises the field value.
+const LOCATION_FLASH_MS = 1500;
+
 // ── Module state ──────────────────────────────────────────────────────────────
 
 let geoconfirmMap    = null;
@@ -66,7 +76,7 @@ function normaliseLocation(address, displayName) {
 export async function reverseGeocodeToLocation(lat, lng) {
     if (document.getElementById('travel-location').value.trim()) return;
     try {
-        const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&zoom=10&addressdetails=1`;
+        const url = `${NOMINATIM_URL}/reverse?format=json&lat=${lat}&lon=${lng}&zoom=10&addressdetails=1`;
         const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
         if (!res.ok) return;
         const data = await res.json();
@@ -87,7 +97,7 @@ async function geocodeLocation() {
     btn.textContent = 'Looking up…';
     setMessage('');
     try {
-        const url = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&addressdetails=1&q=' + encodeURIComponent(q);
+        const url = `${NOMINATIM_URL}/search?format=json&limit=1&addressdetails=1&q=${encodeURIComponent(q)}`;
         const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
         const results = await res.json();
         if (!results.length) { setMessage('Location not found — try a more specific name.', true); return; }
@@ -102,7 +112,7 @@ async function geocodeLocation() {
             const locationInput = document.getElementById('travel-location');
             locationInput.value = normalised;
             locationInput.style.outline = '2px solid var(--color-success)';
-            setTimeout(() => { locationInput.style.outline = ''; }, 1500);
+            setTimeout(() => { locationInput.style.outline = ''; }, LOCATION_FLASH_MS);
         }
 
         setMessage(`Coordinates set — confirm pin location on the map below (matched: ${display_name.split(',').slice(0, 3).join(',')}).`, false, true);

--- a/resources/js/login.js
+++ b/resources/js/login.js
@@ -1,6 +1,7 @@
 // Login page authentication handler — extracted from inline script to satisfy CSP script-src.
 // Handles: passkey registration, email magic links, auto-verification from URL token.
 
+// Version pin: keep in sync with admin/passkeys.js (#434).
 import { startAuthentication } from 'https://esm.sh/@simplewebauthn/browser@7';
 import { API_BASE } from './config.js';
 import { isAdminSession } from './auth-utils.js';
@@ -8,7 +9,7 @@ import { isAdminSession } from './auth-utils.js';
 function setMessage(msg, isError = false) {
     const el = document.getElementById('login-message');
     el.textContent = msg;
-    el.style.color = isError ? '#c0392b' : '#27ae60';
+    el.style.color = isError ? 'var(--color-error)' : 'var(--color-success)';
 }
 
 if (isAdminSession()) {
@@ -32,7 +33,7 @@ if (emailToken) {
         })
         .catch(err => {
             statusEl.textContent = err.message;
-            statusEl.style.color = '#c0392b';
+            statusEl.style.color = 'var(--color-error)';
         });
 }
 

--- a/resources/js/login.js
+++ b/resources/js/login.js
@@ -50,14 +50,14 @@ document.getElementById('passkey-btn').addEventListener('click', async () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({}),
         });
-        const { options, sessionKey } = await startRes.json();
+        const { options, session_key } = await startRes.json();
 
         const response = await startAuthentication(options);
 
         const finishRes = await fetch(`${API_BASE}/auth/passkey/login/finish`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ response, sessionKey }),
+            body: JSON.stringify({ response, session_key }),
         });
         const data = await finishRes.json();
         if (!finishRes.ok) throw new Error(data.error || 'Authentication failed');

--- a/scripts/config/nginx-dev-server.conf.template
+++ b/scripts/config/nginx-dev-server.conf.template
@@ -65,6 +65,14 @@ server {
         try_files $uri =404;
     }
 
+    # CSS, fonts, and images — long-lived; cache bust via deploy version param on
+    # any URL that embeds a ?v=... query string (#158).
+    location ~* \.(css|woff2|woff|ttf|png|jpg|jpeg|webp|svg|ico)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
     # Static files — rewrite .js src attrs with version hash to bust ES module cache after deploy
     location / {
         sub_filter '.js"' '.js?v=${DEPLOY_VERSION}"';

--- a/scripts/config/nginx-local.conf.template
+++ b/scripts/config/nginx-local.conf.template
@@ -47,6 +47,14 @@ server {
         try_files $uri =404;
     }
 
+    # CSS, fonts, and images — long-lived; cache bust via deploy version param on
+    # any URL that embeds a ?v=... query string (#158).
+    location ~* \.(css|woff2|woff|ttf|png|jpg|jpeg|webp|svg|ico)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
     # Static files — rewrite .js src attrs with version hash to bust ES module cache after deploy
     location / {
         sub_filter '.js"' '.js?v=${DEPLOY_VERSION}"';

--- a/scripts/config/nginx-portfolio.conf.template
+++ b/scripts/config/nginx-portfolio.conf.template
@@ -67,6 +67,14 @@ server {
         try_files $uri =404;
     }
 
+    # CSS, fonts, and images — long-lived; cache bust via deploy version param on
+    # any URL that embeds a ?v=... query string (#158).
+    location ~* \.(css|woff2|woff|ttf|png|jpg|jpeg|webp|svg|ico)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
     # Static files — rewrite .js src attrs with version hash to bust ES module cache after deploy
     location / {
         sub_filter '.js"' '.js?v=${DEPLOY_VERSION}"';


### PR DESCRIPTION
## Summary

Addresses six open issues in a single branch (owner has approved batch PRs for this session). Covers backend and frontend hardcoding extraction, API response naming standardisation, improved CV private-content detection, and HTTP caching headers.

Closes #433
Closes #434
Closes #150
Closes #376
Closes #111
Closes #158

## Changes

**#433 — Backend hardcoding (`backend/utils/constants.js` + route files)**
- New `backend/utils/constants.js`: single source of truth for `EXCERPT_LENGTH` (300), all rate-limit windows/caps, `WEBAUTHN_CHALLENGE_TTL`, `MAGIC_LINK_TTL`, `CV_MAX_FILE_SIZE`, `MEDIA_MAX_FILE_SIZE`, `MEDIA_ALLOWED_MIME`
- `auth.js`: remove dead `RP_NAME`/`RP_ID`/`ORIGIN` fallback defaults (validateEnv.js already requires these); use constants for rate limiters and TTL literals
- `posts.js`, `travel.js`, `upload.js`, `cv.js`: all rate-limit configs and file size limits now reference constants

**#434 — Frontend hardcoding**
- `login.js`: replace `#c0392b`/`#27ae60` hardcoded hex colours with `var(--color-error)`/`var(--color-success)` CSS tokens
- `admin/travel.js`: extract `NOMINATIM_URL` constant (shared by reverse- and forward-geocode calls), `LOCATION_FLASH_MS` (1500ms)
- `admin/deploy.js`: extract `MAX_POLL_ATTEMPTS` (30) and `POLL_INTERVAL_MS` (2000) so the ~60s recovery budget is self-documenting
- `login.js` + `admin/passkeys.js`: cross-reference comments on the `@simplewebauthn/browser@7` CDN version pin

**#150 — Button variant CSS refactor**
- `styles.css`: strip duplicated geometry from `.btn-danger` — it is now a pure colour modifier (background/color/border only)
- Existing `class="btn-small btn-danger"` usages are unchanged; `.btn-small` provides the geometry

**#376 — Standardise API responses to snake_case**
- `deploy/status`: `upToDate` → `up_to_date`, `canDeploy` → `can_deploy`, `fullSha` → `full_sha`, `gitError` → `git_error`
- `deploy/history`: `deployLog` → `deploy_log`, `shortSha` → `short_sha`
- `auth/setup/status`: `hasUsers` → `has_users`
- `auth passkey start`: `sessionKey` → `session_key` in both responses and request bodies
- `auth passkey register/finish`: `passkeyName` → `passkey_name`
- Zod schemas in `validate.js` updated; all frontend callers (`admin/deploy.js`, `login.js`, `admin/passkeys.js`) updated; test fixtures in `validate.test.js` updated

**#111 — CV private-content detection**
- `cv.js`: adds phone patterns (UK mobile 07xxx, UK landline, international +xx), UK/Guernsey postcode patterns (`GY\d`, `SW1A 1AA`), and street address heuristic (house number + road keyword) to `scanForPrivateInfo()`

**#158 — HTTP caching headers**
- New `backend/middleware/cacheHeaders.js` with `publicCache(seconds)` and `noStore()` helpers
- Public post/travel listing routes: `Cache-Control: public, max-age=60`
- Public post/travel detail routes: `Cache-Control: public, max-age=300`
- Admin (authenticated) endpoints: `Cache-Control: no-store`
- All three nginx config templates: new `location ~* \.(css|woff2|...)$` block with `expires 1y; Cache-Control: public, immutable`

## Test Plan

### Happy path

1. Start dev environment:
   ```powershell
   # Start all services
   . scripts\dev\dev-local.ps1 up
   ```

2. Run full test suite — must show 121 passed, 0 failed:
   ```powershell
   # Verifies validate.test.js session_key rename, no regressions in routes
   . scripts\dev\dev-local.ps1 test
   ```

3. Verify public posts list has caching header:
   ```bash
   # Inside backend container — check Cache-Control header on public post list
   curl -si http://localhost:8080/posts | grep -i cache-control
   # Expected: Cache-Control: public, max-age=60
   ```

4. Verify admin posts list has no-store:
   ```bash
   # Requires a valid JWT — check auth'd endpoint is not cached
   TOKEN=$(curl -s -X POST http://localhost:8080/auth/email/send -H 'Content-Type: application/json' -d '{"email":"test@example.com"}')
   # (obtain JWT via login flow, then:)
   curl -si -H "Authorization: Bearer <JWT>" http://localhost:8080/posts/all | grep -i cache-control
   # Expected: Cache-Control: no-store
   ```

5. Verify deploy/status returns snake_case fields:
   ```bash
   # Inside container — check renamed fields in response
   curl -si -H "Authorization: Bearer <JWT>" http://localhost:8080/deploy/status | grep -i "up_to_date\|can_deploy"
   # Expected: JSON contains up_to_date and can_deploy keys
   ```

6. Verify passkey login/start returns session_key:
   ```bash
   curl -s -X POST http://localhost:8080/auth/passkey/login/start \
     -H 'Content-Type: application/json' -d '{}' | grep session_key
   # Expected: response JSON has "session_key" key
   ```

### Edge cases

- [x] `.btn-danger` alone on a standalone button: still renders red due to `background: var(--color-error)` rule; without a size class it inherits base button geometry — acceptable for the current codebase where it's always paired with `.btn-small`
- [x] CV upload with no private patterns: `warnings` array is empty, upload proceeds — existing behaviour unchanged
- [x] CV upload with a Guernsey postcode (`GY1 1AA`): triggers `possible UK/Guernsey postcode` warning
- [x] Rate limits for posts/travel/cv/upload: still use same numeric values, just referenced from constants — no behaviour change
- [x] Dead RP_NAME/RP_ID/ORIGIN defaults removed from auth.js: `validateEnvOrExit` already halts startup if missing, so code path was unreachable

### Regression checks

- [x] Blog and travel listing pages load correctly (public GET still works, just with caching header added)
- [x] Admin post/travel CRUD still works (middleware chain unchanged; `noStore` added at route level)
- [x] Passkey login/registration flow: `session_key` rename is symmetric across start (response) and finish (request body)
- [x] Deploy panel: `up_to_date`, `can_deploy`, `deploy_log`, `short_sha` consumed correctly by `admin/deploy.js`
- [x] CV upload with existing patterns (SSN, card number, etc.) still triggers warnings

### Setup required before testing

- None — no schema changes, no new env vars required

## Smoke Test

- [x] `scripts/tests/Test-Regression.ps1` run and passing
- [ ] `scripts/tests/Test-PRbatch.ps1` created and passing — N/A for this batch of refactors; all changes are covered by the automated Vitest suite (121 tests pass) and the regression script. No new API surfaces were added.

## Documentation

- [x] N/A — `docs/STYLE_GUIDE.md` already documents `.btn-danger` as a modifier; the CSS change aligns with documented intent. No new env vars, no new API routes, no changed deployment steps. Caching TTLs are self-evident from `cacheHeaders.js`.
- [x] CSP allowlist — N/A: no new external resources or inline scripts were added

## Risk / Impact

- `#376` (snake_case rename) is the highest-risk change — `session_key`/`passkey_name` rename touches the passkey login/registration flow on both backend and frontend. The Vitest suite includes validate middleware tests and auth route tests which pass.
- `#158` (caching) uses short TTLs (60s/300s) on public endpoints so a publish/unpublish is visible within 1–5 minutes without any cache-bust mechanism. Admin routes are `no-store`.
- `#433` (remove dead auth defaults) — `validateEnvOrExit` has required `WEBAUTHN_RP_ID`, `WEBAUTHN_ORIGIN`, `WEBAUTHN_RP_NAME` since issue #357. The removed defaults were dead code.

## Squash Commit Message

```text
refactor: batch issues #433 #434 #150 #376 #111 #158

Extract backend magic numbers to constants.js; fix frontend
hardcoding (Nominatim URL, hex colours, poll constants); separate
.btn-danger geometry from colour; standardise API responses to
snake_case (deploy, auth); extend CV scanner with phone/postcode
patterns; add HTTP caching middleware and nginx asset cache rules.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

- The six issues were batched with owner approval for this session; each has its own commit with a reference number for traceability.
- `#376`: The issue explicitly notes that `sessionKey`/`passkeyName` may be left camelCase if WebAuthn spec alignment takes priority — I renamed them since they are custom fields (not part of the WebAuthn spec itself). Revert if preferred.
- `#158` nginx changes: the new CSS/font/image location block uses `try_files $uri =404` — it will 404 rather than falling through to the catch-all `location /`, which is correct for static assets.