### PR TITLE
feat: audit log, activity dashboard, full-text search, CV history, seed script, compose dedup

### DIFF
--- a/admin/activity.html
+++ b/admin/activity.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Activity | Admin | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Admin</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" target="_blank" rel="noopener noreferrer">✏ Blog</a></li>
+            <li><a href="/travel/" target="_blank" rel="noopener noreferrer">✈ Travel</a></li>
+            <li><a href="/login/" id="logout-link">Logout</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main class="admin-page">
+        <section class="sec-cont admin-panel">
+            <div class="admin-card" id="activity-log">
+                <div class="admin-card-header" style="display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;margin-bottom:1rem">
+                    <h2 class="admin-card-title" style="margin:0">Activity log</h2>
+                    <button id="activity-refresh" type="button" class="btn-small">Refresh</button>
+                </div>
+
+                <div class="activity-filters" style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-bottom:1rem">
+                    <button type="button" class="btn-small active" data-activity-filter="all">All</button>
+                    <button type="button" class="btn-small" data-activity-filter="auth">Auth</button>
+                    <button type="button" class="btn-small" data-activity-filter="post">Posts</button>
+                    <button type="button" class="btn-small" data-activity-filter="travel">Travel</button>
+                    <button type="button" class="btn-small" data-activity-filter="cv">CV</button>
+                    <button type="button" class="btn-small" data-activity-filter="deploy">Deploy</button>
+                </div>
+
+                <div class="activity-table-wrap" style="overflow-x:auto">
+                    <table class="activity-table">
+                        <thead>
+                            <tr>
+                                <th>When</th>
+                                <th>Action</th>
+                                <th>Type</th>
+                                <th>Detail</th>
+                                <th>User</th>
+                            </tr>
+                        </thead>
+                        <tbody id="activity-tbody">
+                            <tr><td colspan="5" class="activity-empty">Loading…</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <p class="hint" style="margin-top:0.75rem">
+                    Showing last 50 actions. Auto-refreshes every 60 seconds.
+                    Hover a timestamp for the exact date and time.
+                </p>
+            </div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script src="/resources/js/admin-subnav.js"></script>
+    <script type="module" src="/resources/js/admin-activity-page.js"></script>
+</body>
+</html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -66,6 +66,11 @@
                     <span class="admin-dashboard-card-title">Settings</span>
                     <span class="admin-dashboard-card-desc">Manage passkeys and account</span>
                 </a>
+                <a href="/admin/activity.html" class="admin-dashboard-card">
+                    <span class="admin-dashboard-card-icon">📋</span>
+                    <span class="admin-dashboard-card-title">Activity</span>
+                    <span class="admin-dashboard-card-desc">Audit log — recent admin actions</span>
+                </a>
             </div>
         </section>
     </main>

--- a/admin/media.html
+++ b/admin/media.html
@@ -55,9 +55,11 @@
                 </p>
                 <div class="form-actions">
                     <button type="button" id="cv-upload-btn" class="btn-primary" disabled>Upload CV</button>
-                    <button type="button" id="cv-delete-btn" class="btn-small btn-danger" disabled>Delete CV</button>
                 </div>
                 <p id="cv-message" class="admin-message"></p>
+
+                <h3 style="font-size:0.95rem;font-weight:600;margin:1.25rem 0 0.5rem">Version history</h3>
+                <div id="cv-history"><p class="hint">Loading…</p></div>
             </div>
 
             <!-- Private notes -->

--- a/backend/app.js
+++ b/backend/app.js
@@ -22,6 +22,8 @@ import statsRoutes   from './routes/stats.js';
 import cvRoutes      from './routes/cv.js';
 import deployRoutes  from './routes/deploy.js';
 import debugRoutes   from './routes/debug.js';
+import auditRoutes   from './routes/audit.js';
+import searchRoutes  from './routes/search.js';
 import { healthRouter } from './routes/health.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
@@ -85,6 +87,8 @@ export function createApp() {
   app.use('/cv',      cvRoutes);
   app.use('/deploy',  deployRoutes);
   app.use('/debug',   debugRoutes);
+  app.use('/audit',   auditRoutes);
+  app.use('/search',  searchRoutes);
 
   // Health check — internal only (direct backend port); not proxied by nginx
   app.get('/health', healthRouter);

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -223,3 +223,56 @@ CREATE TABLE IF NOT EXISTS app_settings (
   value      TEXT NOT NULL,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- ── Audit log (#154) ─────────────────────────────────────────────────────────
+-- Records admin actions with user, timestamp, action type, and structured detail.
+-- Provides a security trail and powers the admin activity dashboard (#155).
+-- Retention: rows are never auto-pruned — low volume expected for a single-admin site.
+CREATE TABLE IF NOT EXISTS audit_log (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        REFERENCES users(id) ON DELETE SET NULL,
+  action      TEXT        NOT NULL,   -- e.g. 'post.publish', 'cv.upload', 'auth.login'
+  entity_type TEXT,                   -- e.g. 'post', 'travel', 'cv', 'deploy'
+  entity_id   TEXT,                   -- id of the affected record (if applicable)
+  detail      JSONB,                  -- structured context; NEVER include secrets/tokens
+  ip          TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS audit_log_created_at
+  ON audit_log (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS audit_log_user_id
+  ON audit_log (user_id);
+
+-- ── Full-text search (#157) ───────────────────────────────────────────────────
+-- Generated tsvector column with GIN index for fast full-text search across
+-- blog and travel posts. Weighted: title (A) > excerpt (B) > body (C).
+-- The column is STORED so search is a pure index scan — no re-computation.
+ALTER TABLE posts
+  ADD COLUMN IF NOT EXISTS search_vector tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('english', coalesce(title, '')),         'A') ||
+      setweight(to_tsvector('english', coalesce(location, '')),      'B') ||
+      setweight(to_tsvector('english', coalesce(body_markdown, '')), 'C')
+    ) STORED;
+
+CREATE INDEX IF NOT EXISTS posts_search_vector_idx
+  ON posts USING GIN (search_vector);
+
+-- ── CV version history (#109) ─────────────────────────────────────────────────
+-- Tracks every uploaded CV with a timestamp. Only one row may have is_current=TRUE
+-- at a time (enforced by the partial unique index below). The public download
+-- endpoint serves whichever file has is_current=TRUE; older versions are kept for
+-- archival. Maximum 5 versions are retained — the oldest is pruned on each upload
+-- once the limit is exceeded.
+CREATE TABLE IF NOT EXISTS cvs (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  filename    TEXT        NOT NULL,           -- stored filename, e.g. cv-20260604-120000.pdf
+  uploaded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  is_current  BOOLEAN     NOT NULL DEFAULT FALSE
+);
+
+-- Only one current CV at a time
+CREATE UNIQUE INDEX IF NOT EXISTS cvs_one_current
+  ON cvs (is_current) WHERE is_current = TRUE;

--- a/backend/routes/audit.js
+++ b/backend/routes/audit.js
@@ -15,7 +15,8 @@ const router = Router();
 router.get('/', authenticate, async (req, res, next) => {
   try {
     const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
-    const type  = req.query.type && req.query.type !== 'all' ? req.query.type : null;
+    const rawType = req.query.type && req.query.type !== 'all' ? req.query.type : null;
+    const type    = rawType && /^[a-z_]+(\.[a-z_]+)?$/.test(rawType) ? rawType : null;
 
     const result = await pool.query(
       `SELECT

--- a/backend/routes/audit.js
+++ b/backend/routes/audit.js
@@ -1,0 +1,45 @@
+/**
+ * Audit log routes (#154, #155)
+ *
+ * GET /audit?limit=50&type=all  → recent audit log entries (auth required)
+ */
+import { Router }      from 'express';
+import { pool }        from '../db/pool.js';
+import { authenticate } from '../middleware/authenticate.js';
+import { logger }      from '../utils/logger.js';
+
+const router = Router();
+
+// Admin: list recent audit log entries
+// Supports ?limit=<n> (max 200, default 50) and ?type=<action-prefix|all>
+router.get('/', authenticate, async (req, res, next) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
+    const type  = req.query.type && req.query.type !== 'all' ? req.query.type : null;
+
+    const result = await pool.query(
+      `SELECT
+         al.id,
+         al.action,
+         al.entity_type,
+         al.entity_id,
+         al.detail,
+         al.ip,
+         al.created_at,
+         u.username
+       FROM audit_log al
+       LEFT JOIN users u ON u.id = al.user_id
+       WHERE ($1::text IS NULL OR al.action LIKE ($1 || '%'))
+       ORDER BY al.created_at DESC
+       LIMIT $2`,
+      [type, limit]
+    );
+
+    res.json(result.rows);
+  } catch (err) {
+    logger.error({ err }, '[audit] GET /audit failed');
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/routes/audit.js
+++ b/backend/routes/audit.js
@@ -3,16 +3,30 @@
  *
  * GET /audit?limit=50&type=all  → recent audit log entries (auth required)
  */
-import { Router }      from 'express';
-import { pool }        from '../db/pool.js';
-import { authenticate } from '../middleware/authenticate.js';
-import { logger }      from '../utils/logger.js';
+import { Router }        from 'express';
+import { rateLimit }     from 'express-rate-limit';
+import { pool }          from '../db/pool.js';
+import { authenticate }  from '../middleware/authenticate.js';
+import { PostgresStore } from '../middleware/postgresStore.js';
+import { exemptIfTrusted } from '../utils/serviceKey.js';
+import { logger }        from '../utils/logger.js';
 
 const router = Router();
 
+const auditRateLimit = rateLimit({
+  windowMs:        60 * 1000,
+  limit:           120,
+  keyGenerator:    (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
+  skip:            exemptIfTrusted,
+  message:         { error: 'Too many requests. Please try again later.' },
+  standardHeaders: true,
+  legacyHeaders:   false,
+  store:           new PostgresStore({ windowMs: 60 * 1000, keyType: 'audit' }),
+});
+
 // Admin: list recent audit log entries
 // Supports ?limit=<n> (max 200, default 50) and ?type=<action-prefix|all>
-router.get('/', authenticate, async (req, res, next) => {
+router.get('/', auditRateLimit, authenticate, async (req, res, next) => {
   try {
     const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
     const rawType = req.query.type && req.query.type !== 'all' ? req.query.type : null;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -14,7 +14,8 @@ import { rateLimit } from 'express-rate-limit';
 import { PostgresStore } from '../middleware/postgresStore.js';
 import { exemptIfServiceAccount, exemptIfTrusted } from '../utils/serviceKey.js';
 import { sendMagicLink } from '../utils/email.js';
-import { logger } from '../utils/logger.js';
+import { logger }   from '../utils/logger.js';
+import { logAudit } from '../utils/audit.js';
 import {
   validate,
   EmailSendSchema,
@@ -314,6 +315,7 @@ router.post('/passkey/login/finish', passkeyRateLimit, validate(PasskeyLoginFini
     ]);
 
     const token = signJWT({ id: passkey.user_id, email: passkey.email, username: passkey.username });
+    await logAudit(req, 'auth.login', 'user', passkey.user_id, { method: 'passkey' });
     res.json({ token, user: { id: passkey.user_id, email: passkey.email, username: passkey.username } });
   } catch (err) {
     logger.error({ err }, '[auth] passkey login finish failed');
@@ -456,6 +458,7 @@ router.get('/email/verify', emailRateLimit, async (req, res, next) => {
     logger.info({ userId: row.user_id }, '[auth/email/verify] Match — token consumed; issuing JWT');
 
     const jwtToken = signJWT({ id: row.user_id, email: row.email, username: row.username });
+    await logAudit(req, 'auth.login', 'user', row.user_id, { method: 'email_magic_link' });
     res.json({ token: jwtToken, user: { id: row.user_id, email: row.email, username: row.username } });
   } catch (err) {
     // Log the failure reason (not the token) so crypt/DB errors are diagnosable.

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -318,7 +318,7 @@ router.post('/passkey/login/finish', passkeyRateLimit, validate(PasskeyLoginFini
     ]);
 
     const token = signJWT({ id: passkey.user_id, email: passkey.email, username: passkey.username });
-    await logAudit(req, 'auth.login', 'user', passkey.user_id, { method: 'passkey' });
+    await logAudit(req, 'auth.login', 'user', passkey.user_id, { method: 'passkey' }, { userId: passkey.user_id });
     res.json({ token, user: { id: passkey.user_id, email: passkey.email, username: passkey.username } });
   } catch (err) {
     logger.error({ err }, '[auth] passkey login finish failed');
@@ -462,7 +462,7 @@ router.get('/email/verify', emailRateLimit, async (req, res, next) => {
     logger.info({ userId: row.user_id }, '[auth/email/verify] Match — token consumed; issuing JWT');
 
     const jwtToken = signJWT({ id: row.user_id, email: row.email, username: row.username });
-    await logAudit(req, 'auth.login', 'user', row.user_id, { method: 'email_magic_link' });
+    await logAudit(req, 'auth.login', 'user', row.user_id, { method: 'email_magic_link' }, { userId: row.user_id });
     res.json({ token: jwtToken, user: { id: row.user_id, email: row.email, username: row.username } });
   } catch (err) {
     // Log the failure reason (not the token) so crypt/DB errors are diagnosable.

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -274,6 +274,7 @@ router.post('/passkey/login/finish', passkeyRateLimit, validate(PasskeyLoginFini
       [sessionKey]
     );
     if (!challengeRow.rows.length) {
+      await logAudit(req, 'auth.login_failed', null, null, { method: 'passkey', reason: 'invalid_challenge' });
       return res.status(400).json({ error: 'Invalid or expired challenge' });
     }
     await pool.query('DELETE FROM webauthn_challenges WHERE session_key = $1', [sessionKey]);
@@ -287,6 +288,7 @@ router.post('/passkey/login/finish', passkeyRateLimit, validate(PasskeyLoginFini
       [credentialId]
     );
     if (!passkeyRow.rows.length) {
+      await logAudit(req, 'auth.login_failed', null, null, { method: 'passkey', reason: 'unknown_credential' });
       return res.status(400).json({ error: 'Unknown credential' });
     }
 
@@ -306,6 +308,7 @@ router.post('/passkey/login/finish', passkeyRateLimit, validate(PasskeyLoginFini
     });
 
     if (!verification.verified) {
+      await logAudit(req, 'auth.login_failed', null, null, { method: 'passkey', reason: 'verification_failed' });
       return res.status(401).json({ error: 'Authentication failed' });
     }
 
@@ -450,6 +453,7 @@ router.get('/email/verify', emailRateLimit, async (req, res, next) => {
           '[auth/email/verify] Legacy non-bcrypt row(s) present — boot cleanup may not have run (#134)'
         );
       }
+      await logAudit(req, 'auth.login_failed', null, null, { method: 'email_magic_link', reason: 'invalid_token' });
       return res.status(400).json({ error: 'Invalid or expired link' });
     }
 

--- a/backend/routes/cv.js
+++ b/backend/routes/cv.js
@@ -29,6 +29,8 @@ import { pool }          from '../db/pool.js';
 
 const router = Router();
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // Per-IP backstop on CV write operations.
 const cvRateLimit = rateLimit({
   windowMs:        CV_RATE_WINDOW_MS,
@@ -221,6 +223,7 @@ router.post('/', cvRateLimit, authenticate, wrapMulter(upload.single('cv')), asy
 
 // Admin: set a specific version as current
 router.put('/:id/set-current', cvRateLimit, authenticate, async (req, res, next) => {
+  if (!UUID_RE.test(req.params.id)) return res.status(404).json({ error: 'CV version not found' });
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
@@ -254,6 +257,7 @@ router.put('/:id/set-current', cvRateLimit, authenticate, async (req, res, next)
 
 // Admin: confirm a staged (pending) CV version — sets it as current
 router.post('/:id/confirm', cvRateLimit, authenticate, async (req, res, next) => {
+  if (!UUID_RE.test(req.params.id)) return res.status(404).json({ error: 'CV version not found' });
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
@@ -293,6 +297,7 @@ router.post('/:id/confirm', cvRateLimit, authenticate, async (req, res, next) =>
 
 // Admin: delete a specific CV version
 router.delete('/:id', cvRateLimit, authenticate, async (req, res, next) => {
+  if (!UUID_RE.test(req.params.id)) return res.status(404).json({ error: 'CV version not found' });
   try {
     const check = await pool.query(`SELECT id, filename, is_current FROM cvs WHERE id = $1`, [req.params.id]);
     if (!check.rows.length) return res.status(404).json({ error: 'CV version not found' });

--- a/backend/routes/cv.js
+++ b/backend/routes/cv.js
@@ -160,13 +160,14 @@ router.get('/history', cvRateLimit, authenticate, async (_req, res, next) => {
   }
 });
 
-// Admin: upload a new CV version (becomes current immediately)
+// Admin: upload a new CV version — auto-publishes only when no privacy warnings
 router.post('/', cvRateLimit, authenticate, wrapMulter(upload.single('cv')), async (req, res, next) => {
   if (!req.file) return res.status(400).json({ error: 'No file provided' });
 
   const warnings  = scanForPrivateInfo(req.file.buffer);
   const filename  = timestampedFilename();
   const filePath  = cvPath(filename);
+  const isCurrent = warnings.length === 0;
 
   const client = await pool.connect();
   try {
@@ -175,34 +176,39 @@ router.post('/', cvRateLimit, authenticate, wrapMulter(upload.single('cv')), asy
 
     await client.query('BEGIN');
 
-    // Demote current version
-    await client.query(`UPDATE cvs SET is_current = FALSE WHERE is_current = TRUE`);
+    if (isCurrent) {
+      await client.query(`UPDATE cvs SET is_current = FALSE WHERE is_current = TRUE`);
+    }
 
-    // Insert new version as current
     const { rows } = await client.query(
-      `INSERT INTO cvs (filename, is_current) VALUES ($1, TRUE) RETURNING id`,
-      [filename]
+      `INSERT INTO cvs (filename, is_current) VALUES ($1, $2) RETURNING id`,
+      [filename, isCurrent]
     );
     const newId = rows[0].id;
 
-    // Prune oldest versions beyond MAX_CV_VERSIONS
-    const all = await client.query(
-      `SELECT id, filename FROM cvs ORDER BY uploaded_at DESC OFFSET $1`,
-      [MAX_CV_VERSIONS]
-    );
-    for (const old of all.rows) {
-      try { fs.unlinkSync(cvPath(old.filename)); } catch { /* already gone */ }
-      await client.query(`DELETE FROM cvs WHERE id = $1`, [old.id]);
+    if (isCurrent) {
+      const all = await client.query(
+        `SELECT id, filename FROM cvs ORDER BY uploaded_at DESC OFFSET $1`,
+        [MAX_CV_VERSIONS]
+      );
+      for (const old of all.rows) {
+        try { fs.unlinkSync(cvPath(old.filename)); } catch { /* already gone */ }
+        await client.query(`DELETE FROM cvs WHERE id = $1`, [old.id]);
+      }
     }
 
     await client.query('COMMIT');
 
-    await logAudit(req, 'cv.upload', 'cv', newId, { filename, size: req.file.size });
-    logger.info({ filename, id: newId }, '[cv] New CV version uploaded and set as current');
-    res.status(200).json({ uploaded: true, id: newId, filename, warnings });
+    await logAudit(req, 'cv.upload', 'cv', newId, { filename, size: req.file.size, pending: !isCurrent });
+    logger.info({ filename, id: newId, isCurrent }, '[cv] CV version uploaded');
+
+    if (isCurrent) {
+      res.status(200).json({ uploaded: true, id: newId, filename, warnings: [] });
+    } else {
+      res.status(200).json({ pending: true, id: newId, filename, warnings });
+    }
   } catch (err) {
     await client.query('ROLLBACK');
-    // Clean up file if DB failed
     try { fs.unlinkSync(filePath); } catch { /* ignore */ }
     logger.error({ err }, '[cv] CV upload failed');
     next(err);
@@ -238,6 +244,45 @@ router.put('/:id/set-current', cvRateLimit, authenticate, async (req, res, next)
   } catch (err) {
     await client.query('ROLLBACK');
     logger.error({ err }, '[cv] set-current failed');
+    next(err);
+  } finally {
+    client.release();
+  }
+});
+
+// Admin: confirm a staged (pending) CV version — sets it as current
+router.post('/:id/confirm', cvRateLimit, authenticate, async (req, res, next) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const check = await client.query(`SELECT id, filename FROM cvs WHERE id = $1`, [req.params.id]);
+    if (!check.rows.length) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'CV version not found' });
+    }
+    const { filename } = check.rows[0];
+
+    await client.query(`UPDATE cvs SET is_current = FALSE WHERE is_current = TRUE`);
+    await client.query(`UPDATE cvs SET is_current = TRUE WHERE id = $1`, [req.params.id]);
+
+    const all = await client.query(
+      `SELECT id, filename FROM cvs ORDER BY uploaded_at DESC OFFSET $1`,
+      [MAX_CV_VERSIONS]
+    );
+    for (const old of all.rows) {
+      try { fs.unlinkSync(cvPath(old.filename)); } catch { /* already gone */ }
+      await client.query(`DELETE FROM cvs WHERE id = $1`, [old.id]);
+    }
+
+    await client.query('COMMIT');
+
+    await logAudit(req, 'cv.confirm', 'cv', req.params.id, { filename });
+    logger.info({ id: req.params.id, filename }, '[cv] Staged CV version confirmed as current');
+    res.json({ confirmed: true, id: req.params.id, filename });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    logger.error({ err }, '[cv] CV confirm failed');
     next(err);
   } finally {
     client.release();

--- a/backend/routes/cv.js
+++ b/backend/routes/cv.js
@@ -15,6 +15,7 @@ import { Router }        from 'express';
 import multer            from 'multer';
 import path              from 'path';
 import fs                from 'fs';
+import { randomBytes }   from 'crypto';
 import { rateLimit }     from 'express-rate-limit';
 import { authenticate }  from '../middleware/authenticate.js';
 import { PostgresStore } from '../middleware/postgresStore.js';
@@ -63,11 +64,12 @@ function cvPath(filename) {
   return path.join(UPLOADS_DIR, filename);
 }
 
-/** Generate a timestamped CV filename */
+/** Generate a timestamped CV filename with a random suffix to prevent same-second collisions */
 function timestampedFilename() {
-  const now = new Date();
-  const ts  = now.toISOString().replace(/[-:T]/g, '').slice(0, 14); // YYYYMMDDHHmmss
-  return `cv-${ts}.pdf`;
+  const now  = new Date();
+  const ts   = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
+  const rand = randomBytes(3).toString('hex');
+  return `cv-${ts}-${rand}.pdf`;
 }
 
 /**

--- a/backend/routes/cv.js
+++ b/backend/routes/cv.js
@@ -1,28 +1,34 @@
 /**
- * CV management routes
+ * CV management routes (#109)
  *
- * GET  /cv/exists  → { exists: bool }          public
- * GET  /cv         → streams uploads/cv.pdf    public
- * POST /cv         → upload a new CV (PDF)     auth required
- * DELETE /cv       → remove the CV file        auth required
+ * Public (unchanged contract):
+ *   GET  /cv/exists   → { exists: bool }
+ *   GET  /cv          → streams the current CV as Andy_Keys_CV.pdf
+ *
+ * Admin (version history):
+ *   POST /cv                  → upload new version (becomes current); prunes to 5 max
+ *   GET  /cv/history          → list all stored versions (newest first)
+ *   PUT  /cv/:id/set-current  → make a previous version current
+ *   DELETE /cv/:id            → delete a specific version
  */
-import { Router }   from 'express';
-import multer       from 'multer';
-import path         from 'path';
-import fs           from 'fs';
-import { rateLimit }      from 'express-rate-limit';
+import { Router }        from 'express';
+import multer            from 'multer';
+import path              from 'path';
+import fs                from 'fs';
+import { rateLimit }     from 'express-rate-limit';
 import { authenticate }  from '../middleware/authenticate.js';
 import { PostgresStore } from '../middleware/postgresStore.js';
 import { exemptIfTrusted } from '../utils/serviceKey.js';
 import { logger }        from '../utils/logger.js';
+import { logAudit }      from '../utils/audit.js';
 import { UPLOADS_DIR }   from '../utils/paths.js';
 import { wrapMulter }    from '../utils/wrapMulter.js';
 import { CV_RATE_WINDOW_MS, CV_RATE_LIMIT, CV_MAX_FILE_SIZE } from '../utils/constants.js';
+import { pool }          from '../db/pool.js';
 
-const router  = Router();
+const router = Router();
 
-// Per-IP backstop on CV write operations. The limiter precedes authenticate
-// so CodeQL's js/missing-rate-limiting detector sees it before auth.
+// Per-IP backstop on CV write operations.
 const cvRateLimit = rateLimit({
   windowMs:        CV_RATE_WINDOW_MS,
   limit:           CV_RATE_LIMIT,
@@ -33,7 +39,9 @@ const cvRateLimit = rateLimit({
   legacyHeaders:   false,
   store:           new PostgresStore({ windowMs: CV_RATE_WINDOW_MS, keyType: 'cv' }),
 });
-const CV_PATH = path.join(UPLOADS_DIR, 'cv.pdf');
+
+// Maximum stored versions before oldest is pruned
+const MAX_CV_VERSIONS = 5;
 
 // ── multer: memory storage so we can inspect before writing ──────────────────
 const upload = multer({
@@ -50,17 +58,24 @@ const upload = multer({
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function cvExists() {
-  return fs.existsSync(CV_PATH);
+/** Build the filesystem path for a versioned CV file */
+function cvPath(filename) {
+  return path.join(UPLOADS_DIR, filename);
+}
+
+/** Generate a timestamped CV filename */
+function timestampedFilename() {
+  const now = new Date();
+  const ts  = now.toISOString().replace(/[-:T]/g, '').slice(0, 14); // YYYYMMDDHHmmss
+  return `cv-${ts}.pdf`;
 }
 
 /**
  * Lightly scan the PDF buffer for strings that look like private info.
- * We use a simple regex pass over the raw bytes — no heavy parse needed
- * for this heuristic check. Returns an array of warning strings.
+ * Returns an array of warning strings.
  */
 function scanForPrivateInfo(buffer) {
-  const text = buffer.toString('latin1');
+  const text     = buffer.toString('latin1');
   const warnings = [];
 
   // Common patterns that shouldn't appear in a public CV.
@@ -88,56 +103,167 @@ function scanForPrivateInfo(buffer) {
     { re: /\b\d+\s+\w+\s+(street|st|road|rd|avenue|ave|close|cl|lane|ln|way|drive|dr|crescent|place|pl|row)\b/i,
                                                            label: 'possible street address' },
   ];
-
   patterns.forEach(({ re, label }) => {
     if (re.test(text)) warnings.push(label);
   });
-
   return warnings;
+}
+
+/** Get the current CV row from DB, or null */
+async function currentCvRow() {
+  const res = await pool.query(
+    `SELECT id, filename, uploaded_at FROM cvs WHERE is_current = TRUE LIMIT 1`
+  );
+  return res.rows[0] || null;
 }
 
 // ── Routes ────────────────────────────────────────────────────────────────────
 
-// Public: check whether a CV is currently uploaded
-router.get('/exists', (_req, res) => {
-  res.json({ exists: cvExists() });
-});
-
-// Public: download the CV
-router.get('/', (req, res) => {
-  if (!cvExists()) return res.status(404).json({ error: 'No CV uploaded yet' });
-  res.download(CV_PATH, 'Andy_Keys_CV.pdf', (err) => {
-    if (err && !res.headersSent) {
-      res.status(500).json({ error: 'Failed to send CV' });
-    }
-  });
-});
-
-// Admin: upload / replace CV
-router.post('/', cvRateLimit, authenticate, wrapMulter(upload.single('cv')), async (req, res) => {
-  if (!req.file) return res.status(400).json({ error: 'No file provided' });
-
-  const warnings = scanForPrivateInfo(req.file.buffer);
-
+// Public: check whether a current CV exists
+router.get('/exists', async (_req, res, next) => {
   try {
-    if (!fs.existsSync(UPLOADS_DIR)) fs.mkdirSync(UPLOADS_DIR, { recursive: true });
-    fs.writeFileSync(CV_PATH, req.file.buffer);
-    res.status(200).json({ uploaded: true, warnings });
+    const row = await currentCvRow();
+    const exists = row ? fs.existsSync(cvPath(row.filename)) : false;
+    res.json({ exists });
   } catch (err) {
-    logger.error({ err }, '[cv] CV upload failed');
-    res.status(500).json({ error: 'Failed to save CV' });
+    next(err);
   }
 });
 
-// Admin: delete the CV
-router.delete('/', cvRateLimit, authenticate, (req, res) => {
-  if (!cvExists()) return res.status(404).json({ error: 'No CV to delete' });
+// Public: download the current CV
+router.get('/', async (req, res, next) => {
   try {
-    fs.unlinkSync(CV_PATH);
+    const row = await currentCvRow();
+    if (!row) return res.status(404).json({ error: 'No CV uploaded yet' });
+    const filePath = cvPath(row.filename);
+    if (!fs.existsSync(filePath)) return res.status(404).json({ error: 'No CV uploaded yet' });
+    res.download(filePath, 'Andy_Keys_CV.pdf', (err) => {
+      if (err && !res.headersSent) {
+        res.status(500).json({ error: 'Failed to send CV' });
+      }
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Admin: list all stored CV versions (newest first)
+router.get('/history', cvRateLimit, authenticate, async (_req, res, next) => {
+  try {
+    const result = await pool.query(
+      `SELECT id, filename, uploaded_at, is_current FROM cvs ORDER BY uploaded_at DESC`
+    );
+    res.json(result.rows);
+  } catch (err) {
+    logger.error({ err }, '[cv] GET /history failed');
+    next(err);
+  }
+});
+
+// Admin: upload a new CV version (becomes current immediately)
+router.post('/', cvRateLimit, authenticate, wrapMulter(upload.single('cv')), async (req, res, next) => {
+  if (!req.file) return res.status(400).json({ error: 'No file provided' });
+
+  const warnings  = scanForPrivateInfo(req.file.buffer);
+  const filename  = timestampedFilename();
+  const filePath  = cvPath(filename);
+
+  const client = await pool.connect();
+  try {
+    if (!fs.existsSync(UPLOADS_DIR)) fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+    fs.writeFileSync(filePath, req.file.buffer);
+
+    await client.query('BEGIN');
+
+    // Demote current version
+    await client.query(`UPDATE cvs SET is_current = FALSE WHERE is_current = TRUE`);
+
+    // Insert new version as current
+    const { rows } = await client.query(
+      `INSERT INTO cvs (filename, is_current) VALUES ($1, TRUE) RETURNING id`,
+      [filename]
+    );
+    const newId = rows[0].id;
+
+    // Prune oldest versions beyond MAX_CV_VERSIONS
+    const all = await client.query(
+      `SELECT id, filename FROM cvs ORDER BY uploaded_at DESC OFFSET $1`,
+      [MAX_CV_VERSIONS]
+    );
+    for (const old of all.rows) {
+      try { fs.unlinkSync(cvPath(old.filename)); } catch { /* already gone */ }
+      await client.query(`DELETE FROM cvs WHERE id = $1`, [old.id]);
+    }
+
+    await client.query('COMMIT');
+
+    await logAudit(req, 'cv.upload', 'cv', newId, { filename, size: req.file.size });
+    logger.info({ filename, id: newId }, '[cv] New CV version uploaded and set as current');
+    res.status(200).json({ uploaded: true, id: newId, filename, warnings });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    // Clean up file if DB failed
+    try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+    logger.error({ err }, '[cv] CV upload failed');
+    next(err);
+  } finally {
+    client.release();
+  }
+});
+
+// Admin: set a specific version as current
+router.put('/:id/set-current', cvRateLimit, authenticate, async (req, res, next) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const check = await client.query(`SELECT id, filename FROM cvs WHERE id = $1`, [req.params.id]);
+    if (!check.rows.length) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'CV version not found' });
+    }
+    const { filename } = check.rows[0];
+    if (!fs.existsSync(cvPath(filename))) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'CV file missing from disk' });
+    }
+
+    await client.query(`UPDATE cvs SET is_current = FALSE WHERE is_current = TRUE`);
+    await client.query(`UPDATE cvs SET is_current = TRUE WHERE id = $1`, [req.params.id]);
+    await client.query('COMMIT');
+
+    await logAudit(req, 'cv.set_current', 'cv', req.params.id, { filename });
+    logger.info({ id: req.params.id, filename }, '[cv] CV version set as current');
+    res.json({ updated: true, id: req.params.id, filename });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    logger.error({ err }, '[cv] set-current failed');
+    next(err);
+  } finally {
+    client.release();
+  }
+});
+
+// Admin: delete a specific CV version
+router.delete('/:id', cvRateLimit, authenticate, async (req, res, next) => {
+  try {
+    const check = await pool.query(`SELECT id, filename, is_current FROM cvs WHERE id = $1`, [req.params.id]);
+    if (!check.rows.length) return res.status(404).json({ error: 'CV version not found' });
+
+    const { filename, is_current } = check.rows[0];
+    if (is_current) {
+      return res.status(400).json({ error: 'Cannot delete the current CV — set another version as current first, or upload a replacement' });
+    }
+
+    try { fs.unlinkSync(cvPath(filename)); } catch { /* already gone */ }
+    await pool.query(`DELETE FROM cvs WHERE id = $1`, [req.params.id]);
+
+    await logAudit(req, 'cv.delete', 'cv', req.params.id, { filename });
+    logger.info({ id: req.params.id, filename }, '[cv] CV version deleted');
     res.json({ deleted: true });
   } catch (err) {
     logger.error({ err }, '[cv] CV delete failed');
-    res.status(500).json({ error: 'Failed to delete CV' });
+    next(err);
   }
 });
 

--- a/backend/routes/cv.js
+++ b/backend/routes/cv.js
@@ -124,7 +124,7 @@ async function currentCvRow() {
 // ── Routes ────────────────────────────────────────────────────────────────────
 
 // Public: check whether a current CV exists
-router.get('/exists', async (_req, res, next) => {
+router.get('/exists', cvRateLimit, async (_req, res, next) => {
   try {
     const row = await currentCvRow();
     const exists = row ? fs.existsSync(cvPath(row.filename)) : false;
@@ -135,7 +135,7 @@ router.get('/exists', async (_req, res, next) => {
 });
 
 // Public: download the current CV
-router.get('/', async (req, res, next) => {
+router.get('/', cvRateLimit, async (req, res, next) => {
   try {
     const row = await currentCvRow();
     if (!row) return res.status(404).json({ error: 'No CV uploaded yet' });

--- a/backend/routes/deploy.js
+++ b/backend/routes/deploy.js
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'url';
 import fs                from 'fs/promises';
 import { authenticate }  from '../middleware/authenticate.js';
 import { spawnStream, spawnPromise } from '../utils/shell.js';
+import { logger }        from '../utils/logger.js';
+import { logAudit }     from '../utils/audit.js';
 
 const router   = Router();
 // /repo is the repo root mounted via docker-compose — the backend image only
@@ -124,6 +126,7 @@ router.get('/history', authenticate, async (req, res) => {
 // ── POST /api/deploy/fetch ───────────────────────────────────────────────────────────
 
 router.post('/fetch', authenticate, async (req, res) => {
+  await logAudit(req, 'deploy.fetch', 'deploy', null, { env: DEPLOY_ENV });
   await streamToSSE(res, spawnStream('git', ['fetch', 'origin'], { cwd: REPO_DIR }));
 });
 
@@ -133,6 +136,7 @@ router.post('/', authenticate, async (req, res) => {
   if (!await scriptExists()) {
     return res.status(400).json({ error: 'Deploy script not found — check DEPLOY_ENV and that deploy.sh is present' });
   }
+  await logAudit(req, 'deploy.start', 'deploy', null, { env: DEPLOY_ENV });
   await streamToSSE(res, spawnStream('bash', [DEPLOY_SCRIPT, '--env', DEPLOY_ENV], { cwd: REPO_DIR }));
 });
 
@@ -156,6 +160,7 @@ router.post('/rollback', authenticate, async (req, res) => {
     return res.status(400).json({ error: 'Deploy script not found — check DEPLOY_ENV and that deploy.sh is present' });
   }
 
+  await logAudit(req, 'deploy.rollback', 'deploy', null, { env: DEPLOY_ENV, sha });
   await streamToSSE(res, spawnStream('bash', [DEPLOY_SCRIPT, '--env', DEPLOY_ENV, '--rollback', sha], { cwd: REPO_DIR }));
 });
 

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -10,6 +10,7 @@ import { validate, CreatePostSchema, UpdatePostSchema } from '../middleware/vali
 import { logger } from '../utils/logger.js';
 import { EXCERPT_LENGTH, POSTS_RATE_WINDOW_MS, POSTS_RATE_LIMIT } from '../utils/constants.js';
 import { publicCache, noStore } from '../middleware/cacheHeaders.js';
+import { logAudit } from '../utils/audit.js';
 
 const router = Router();
 
@@ -120,6 +121,7 @@ router.post('/', postsRateLimit, resolveUser, authenticate, validate(CreatePostS
     const publishedAt = publish ? new Date() : null;
     const postDateVal  = post_date || null;
     const result = await insertPost('blog', title, body_markdown, postDateVal, publishedAt);
+    await logAudit(req, 'post.create', 'post', result.id, { title: result.title, published: !!publishedAt });
     res.status(201).json(result);
   } catch (err) {
     logger.error({ err }, '[posts] Request failed');
@@ -153,7 +155,15 @@ router.put('/:id', postsRateLimit, resolveUser, authenticate, validate(UpdatePos
        RETURNING *`,
       [title.trim(), slug, body_markdown || '', post_date || null, published_at, req.params.id]
     );
-    res.json(result.rows[0]);
+    const updated = result.rows[0];
+    // Determine if this was a publish/unpublish action
+    const wasPublished   = !!existing.rows[0].published_at;
+    const nowPublished   = !!updated.published_at;
+    const auditAction    = !wasPublished && nowPublished ? 'post.publish'
+                         : wasPublished && !nowPublished ? 'post.unpublish'
+                         : 'post.update';
+    await logAudit(req, auditAction, 'post', updated.id, { title: updated.title });
+    res.json(updated);
   } catch (err) {
     logger.error({ err }, '[posts] Request failed');
     next(err);
@@ -164,10 +174,11 @@ router.put('/:id', postsRateLimit, resolveUser, authenticate, validate(UpdatePos
 router.delete('/:id', postsRateLimit, resolveUser, authenticate, async (req, res, next) => {
   try {
     const result = await pool.query(
-      `DELETE FROM posts WHERE id = $1 AND post_type = 'blog' RETURNING id`,
+      `DELETE FROM posts WHERE id = $1 AND post_type = 'blog' RETURNING id, title`,
       [req.params.id]
     );
     if (!result.rows.length) return res.status(404).json({ error: 'Post not found' });
+    await logAudit(req, 'post.delete', 'post', result.rows[0].id, { title: result.rows[0].title });
     res.json({ deleted: true });
   } catch (err) {
     logger.error({ err }, '[posts] Request failed');

--- a/backend/routes/search.js
+++ b/backend/routes/search.js
@@ -1,0 +1,56 @@
+/**
+ * Full-text search route (#157)
+ *
+ * GET /search?q=<term>&type=blog|travel|all&limit=10
+ *
+ * Uses PostgreSQL tsvector/tsquery with ts_rank for relevance ordering.
+ * Published posts only — no draft leakage.
+ */
+import { Router } from 'express';
+import { pool }   from '../db/pool.js';
+import { logger } from '../utils/logger.js';
+
+const router = Router();
+
+// GET /search?q=term&type=all|blog|travel&limit=10
+router.get('/', async (req, res, next) => {
+  try {
+    const q     = (req.query.q || '').trim();
+    const type  = req.query.type && ['blog', 'travel'].includes(req.query.type)
+                  ? req.query.type : null;
+    const limit = Math.min(parseInt(req.query.limit, 10) || 10, 50);
+
+    if (!q) {
+      return res.status(400).json({ error: 'Query parameter "q" is required' });
+    }
+
+    logger.info({ q, type, limit }, '[search] Full-text search request');
+
+    const result = await pool.query(
+      `SELECT
+         id,
+         title,
+         slug,
+         post_type,
+         location,
+         published_at,
+         post_date,
+         left(body_markdown, 300) AS excerpt,
+         ts_rank(search_vector, plainto_tsquery('english', $1)) AS rank
+       FROM posts
+       WHERE search_vector @@ plainto_tsquery('english', $1)
+         AND published_at IS NOT NULL
+         AND ($2::text IS NULL OR post_type = $2)
+       ORDER BY rank DESC, published_at DESC
+       LIMIT $3`,
+      [q, type, limit]
+    );
+
+    res.json({ query: q, total: result.rows.length, results: result.rows });
+  } catch (err) {
+    logger.error({ err }, '[search] Search request failed');
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/routes/search.js
+++ b/backend/routes/search.js
@@ -6,14 +6,29 @@
  * Uses PostgreSQL tsvector/tsquery with ts_rank for relevance ordering.
  * Published posts only — no draft leakage.
  */
-import { Router } from 'express';
-import { pool }   from '../db/pool.js';
-import { logger } from '../utils/logger.js';
+import { Router }        from 'express';
+import { rateLimit }     from 'express-rate-limit';
+import { pool }          from '../db/pool.js';
+import { PostgresStore } from '../middleware/postgresStore.js';
+import { exemptIfTrusted } from '../utils/serviceKey.js';
+import { logger }        from '../utils/logger.js';
+import { publicCache }   from '../middleware/cacheHeaders.js';
 
 const router = Router();
 
+const searchRateLimit = rateLimit({
+  windowMs:        60 * 1000,
+  limit:           60,
+  keyGenerator:    (req) => req.headers['x-forwarded-for']?.split(',')[0] || req.socket.remoteAddress,
+  skip:            exemptIfTrusted,
+  message:         { error: 'Too many requests. Please try again later.' },
+  standardHeaders: true,
+  legacyHeaders:   false,
+  store:           new PostgresStore({ windowMs: 60 * 1000, keyType: 'search' }),
+});
+
 // GET /search?q=term&type=all|blog|travel&limit=10
-router.get('/', async (req, res, next) => {
+router.get('/', searchRateLimit, publicCache(60), async (req, res, next) => {
   try {
     const q     = (req.query.q || '').trim();
     const type  = req.query.type && ['blog', 'travel'].includes(req.query.type)

--- a/backend/routes/travel.js
+++ b/backend/routes/travel.js
@@ -10,6 +10,7 @@ import { validate, CreateTravelSchema, UpdateTravelSchema } from '../middleware/
 import { logger } from '../utils/logger.js';
 import { TRAVEL_RATE_WINDOW_MS, TRAVEL_RATE_LIMIT } from '../utils/constants.js';
 import { publicCache, noStore } from '../middleware/cacheHeaders.js';
+import { logAudit } from '../utils/audit.js';
 
 const router = Router();
 
@@ -184,6 +185,7 @@ router.post('/', travelRateLimit, resolveUser, authenticate, validate(CreateTrav
     const result = await pool.query(
       `SELECT ${TRAVEL_COLS} FROM posts p WHERE p.id = $1`, [postId]
     );
+    await logAudit(req, 'travel.create', 'travel', postId, { title: title.trim(), published: !!publishedAt });
     res.status(201).json(result.rows[0]);
   } catch (err) {
     await client.query('ROLLBACK');
@@ -238,7 +240,14 @@ router.put('/:id', travelRateLimit, resolveUser, authenticate, validate(UpdateTr
     const result = await pool.query(
       `SELECT ${TRAVEL_COLS} FROM posts p WHERE p.id = $1`, [req.params.id]
     );
-    res.json(result.rows[0]);
+    const updated = result.rows[0];
+    const wasPublished = !!existing.rows[0].published_at;
+    const nowPublished = !!updated?.published_at;
+    const auditAction  = !wasPublished && nowPublished ? 'travel.publish'
+                       : wasPublished && !nowPublished ? 'travel.unpublish'
+                       : 'travel.update';
+    await logAudit(req, auditAction, 'travel', req.params.id, { title: title?.trim() });
+    res.json(updated);
   } catch (err) {
     await client.query('ROLLBACK');
     logger.error({ err }, '[travel] Request failed');
@@ -252,10 +261,11 @@ router.put('/:id', travelRateLimit, resolveUser, authenticate, validate(UpdateTr
 router.delete('/:id', travelRateLimit, resolveUser, authenticate, async (req, res, next) => {
   try {
     const result = await pool.query(
-      `DELETE FROM posts WHERE id = $1 AND post_type = 'travel' RETURNING id`,
+      `DELETE FROM posts WHERE id = $1 AND post_type = 'travel' RETURNING id, title`,
       [req.params.id]
     );
     if (!result.rows.length) return res.status(404).json({ error: 'Memory not found' });
+    await logAudit(req, 'travel.delete', 'travel', result.rows[0].id, { title: result.rows[0].title });
     res.json({ deleted: true });
   } catch (err) {
     logger.error({ err }, '[travel] Request failed');

--- a/backend/scripts/seed-blog-posts.js
+++ b/backend/scripts/seed-blog-posts.js
@@ -1,0 +1,275 @@
+/**
+ * Seed script — blog posts documenting the portfolio site's development journey (#202)
+ *
+ * Usage (inside the backend container, or with env vars set):
+ *   node backend/scripts/seed-blog-posts.js
+ *
+ * Idempotent: checks for existing posts by slug before inserting.
+ * Atomic: runs in a single transaction — all-or-nothing insert.
+ * Logs inserted post IDs and count on completion.
+ */
+import 'dotenv/config';
+import { pool } from '../db/pool.js';
+
+// ── Slug helper (inline to avoid module-resolution issues when run standalone) ─
+
+function slugify(str) {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, 90);
+}
+
+// ── Blog posts ────────────────────────────────────────────────────────────────
+
+const POSTS = [
+  {
+    title:      'Building a Portfolio Site with AI — The Setup',
+    post_date:  '2025-01-15',
+    published:  true,
+    body: `## Starting from scratch
+
+In early 2025, I set out to build a personal portfolio site — not from a template, but properly engineered from the ground up. The tech choices were intentional: Node.js/Express on the backend, vanilla JavaScript on the frontend (no build step), PostgreSQL for persistence, and Nginx as the reverse proxy.
+
+The AI pair programmer — Claude Sonnet via the Anthropic API — joined as an active collaborator from day one. Every architectural decision was documented, debated, and committed with context.
+
+## Why no build step?
+
+The frontend loads ES modules directly via \`<script type="module">\`. No webpack, no Vite, no bundler. Nginx serves the files as-is. This keeps the development loop tight: edit a file, refresh the browser. It trades some convenience (no tree-shaking, no TypeScript) for radical simplicity.
+
+The constraint forced discipline: shared utilities live in \`resources/js/utils/\`, modules import from each other cleanly, and there's no opaque build artefact to debug.
+
+## Infrastructure
+
+Self-hosted on an Ubuntu Server (a repurposed gaming PC — the original Raspberry Pi proved too underpowered for Docker). Docker Compose orchestrates the backend, PostgreSQL, and Nginx containers. A \`.env\` file controls all environment-specific behaviour.
+
+The first working deploy happened in January 2025. It was a static page. But it deployed.`,
+  },
+  {
+    title:      'WebAuthn and Passkeys: Building Passwordless Auth',
+    post_date:  '2025-02-10',
+    published:  true,
+    body: `## The problem with passwords
+
+This is a single-admin site. There's one user. Adding a traditional password system would introduce a weak point (the password) for no meaningful benefit. WebAuthn — the FIDO2 standard — lets the browser authenticate using a hardware key, platform authenticator (Touch ID, Windows Hello), or a passkey synced to the cloud.
+
+## Implementation
+
+The \`@simplewebauthn/server\` library handles the ceremony mechanics. The backend:
+
+1. Generates a registration challenge and stores it in the \`webauthn_challenges\` table (ephemeral, short-lived)
+2. Verifies the credential response from the browser
+3. Stores the public key and counter in the \`passkeys\` table
+4. Issues a JWT on successful authentication
+
+The JWT is signed with a secret stored only in the backend environment, expires after a configurable duration, and is verified on every protected route.
+
+## Email magic links as backup
+
+WebAuthn requires a registered device. If the device is unavailable, email magic links provide a fallback. A secure random token is generated, its bcrypt hash stored in \`email_tokens\`, and the raw token sent in the email. On click, the backend verifies via \`crypt(raw, stored_hash)\` — constant-time comparison, no timing oracle.
+
+This dual-method auth system — passkey-first, email-fallback — provides both security and resilience.`,
+  },
+  {
+    title:      'Travel Memories: Maps, Timelines, and EXIF',
+    post_date:  '2025-03-05',
+    published:  true,
+    body: `## A different kind of content
+
+Blog posts are linear. Travel memories are spatial. The travel section needed a map view, a timeline, and support for multiple photos per memory — all without a heavy frontend framework.
+
+## Data model
+
+Posts and travel memories share a unified \`posts\` table, discriminated by \`post_type\`. Travel-specific columns (lat, lng, location, post_date) sit alongside the blog columns. The \`post_media\` table provides one-to-many media items for travel posts.
+
+## Maps
+
+Leaflet.js renders the map with OpenStreetMap tiles — no API key required. Each published travel post becomes a marker. The admin panel uses the Nominatim geocoding API (OpenStreetMap) to resolve place names to coordinates.
+
+## EXIF extraction
+
+When a photo is uploaded, the backend uses \`exifr\` to extract GPS coordinates from the image metadata. If coordinates are found, they pre-populate the lat/lng fields in the admin form — a small quality-of-life improvement that saves manual geocoding.
+
+## Timeline
+
+The public travel page renders a timeline alongside the map. Each entry shows a date marker, title, location, and thumbnail. The timeline and map are linked — clicking a timeline entry pans the map to that location.`,
+  },
+  {
+    title:      'The Admin Panel: Modular JavaScript Without a Framework',
+    post_date:  '2025-04-01',
+    published:  true,
+    body: `## One HTML file, many modules
+
+The admin panel is a single-page application built without React, Vue, or any other framework. It's a single \`admin/index.html\` file that loads ES modules via \`<script type="module">\`.
+
+Each feature has its own module under \`resources/js/admin/\`:
+
+- \`posts.js\` — blog post CRUD
+- \`travel.js\` — travel memory CRUD (the largest module at ~500 lines)
+- \`deploy.js\` — deployment console
+- \`cv.js\` — CV upload and version history
+- \`stats.js\` — site visit statistics
+- \`auth.js\` — JWT storage and logout
+- \`passkeys.js\` — passkey management
+
+\`admin.js\` is a thin entry point that imports and initialises each module. This modular structure keeps concerns separate and makes individual modules testable in isolation.
+
+## State management
+
+There's no state management library. Each module owns its own state. The JWT token lives in \`sessionStorage\` (not \`localStorage\` — it clears on tab close, which is the right security trade-off for an admin session). The modules communicate via DOM events where needed.
+
+## The constraint that helped
+
+No build step means no dead code elimination, but it also means no compilation step to debug. When something breaks, the browser console shows the actual line of actual source code. That's worth a lot.`,
+  },
+  {
+    title:      'Security Hardening: CSP, Rate Limiting, and Error Sanitisation',
+    post_date:  '2025-05-15',
+    published:  true,
+    body: `## Content Security Policy
+
+The most impactful security change was implementing a strict Content Security Policy. The CSP is defined in \`scripts/config/nginx-security-headers.conf\` — a single source of truth applied to all responses via Nginx.
+
+The policy allowlists:
+- Script sources: self only (no \`unsafe-inline\`, no \`unsafe-eval\`)
+- Style sources: self, Google Fonts
+- Image sources: self, data URIs, OpenStreetMap tile servers
+- Connect sources: self (the API)
+- Font sources: Google Fonts CDN
+
+Every external resource addition requires a corresponding CSP update. This constraint is visible at PR review time — the checklist item is mandatory.
+
+## Rate limiting
+
+Express rate limiting with a PostgreSQL-backed store (to survive container restarts) protects:
+- The contact form (5 per hour per IP)
+- Auth endpoints (login attempts)
+- Blog and travel write routes (120 per minute per IP, with admin exempt)
+- CV upload/delete (30 per minute per IP)
+
+The \`ServiceKey\` pattern exempts the admin (verified via JWT inline) so legitimate use is never throttled.
+
+## Error message sanitisation
+
+The Express error handler catches all unhandled errors and returns a sanitised response. In production, 5xx errors return a generic message — never the raw stack trace or database error. The full error is logged via \`pino\` with structured context so it's diagnosable from logs alone.`,
+  },
+  {
+    title:      'Docker, Nginx, and Deployment: Self-Hosting Lessons',
+    post_date:  '2025-06-01',
+    published:  true,
+    body: `## The deployment stack
+
+The production deployment is three Docker containers on a single host:
+
+1. **postgres** — PostgreSQL 16, data persisted to a named volume
+2. **backend** — Node.js/Express, built from a multi-stage Dockerfile
+3. **nginx** — Reverse proxy for HTTPS, static file serving, and API proxying
+
+A single \`docker-compose.yml\` handles both dev and prod environments. All environment differences (ports, cert paths, hostnames, volume names) come from a \`.env\` file. \`COMPOSE_PROJECT_NAME\` provides isolation between dev and prod on the same host.
+
+## The deploy script
+
+\`scripts/deploy/deploy.sh\` is the single entry point for all deployments. It:
+
+1. Validates environment variables
+2. Runs health checks before and after the deploy
+3. Updates the repo via \`git pull\`
+4. Rebuilds the backend image if needed
+5. Runs \`docker compose up -d\` with a rollback on failure
+6. Runs the Vitest suite inside the container post-deploy
+
+The deploy script is the highest-risk file in the codebase. It has its own sub-library structure (\`deploy-lib-*.sh\`) for separation of concerns.
+
+## Lessons learned
+
+The biggest time sink was orphan containers — stale containers from a previous compose project lingering after a rename. The solution was explicit \`docker compose down\` before each deploy, with cleanup of any lingering project.
+
+The second biggest: cert path mismatches. Let's Encrypt cert paths are not negotiable — they must match exactly what Nginx expects. Template variables in the Nginx config (\`CERT_MOUNT_SRC\`, \`CERT_MOUNT_DST\`) make this explicit and testable.`,
+  },
+  {
+    title:      'Infrastructure Migration: Raspberry Pi to Ubuntu Server',
+    post_date:  '2025-08-20',
+    published:  true,
+    body: `## Outgrowing the Pi
+
+The original Raspberry Pi 4 ran the site in its early days — acceptable for a static page, but Docker Compose with PostgreSQL, Nginx, and a Node.js backend pushed it to its limits. Build times were measured in minutes. Container startup was slow. Memory pressure was constant.
+
+## The new server
+
+A repurposed gaming PC (AMD Ryzen, 32GB RAM, NVMe SSD) replaced the Pi in mid-2025. The migration was:
+
+1. \`pg_dump\` on the Pi, \`pg_restore\` on the new server
+2. Copy the uploads volume
+3. Update the \`.env\` on the new server
+4. Point the DDNS record at the new IP
+5. Run \`./scripts/deploy/server-setup.sh\` on the new server
+
+The migration took about two hours including DNS propagation time.
+
+## What changed
+
+The speed difference is dramatic. Docker builds that took 4 minutes on the Pi take under 20 seconds. The server has headroom for the AI Lab experiments and future features.
+
+The Pi hasn't been decommissioned — it now runs Home Assistant for home automation, which is a better fit for its capabilities.
+
+## What stayed the same
+
+The deployment process is identical. The same \`docker-compose.yml\`, the same deploy script, the same \`.env\` structure. Infrastructure-as-code paid off here — the migration was a data move, not a reconfiguration.`,
+  },
+];
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function seedBlogPosts() {
+  const client = await pool.connect();
+  let inserted = 0;
+  let skipped  = 0;
+
+  try {
+    await client.query('BEGIN');
+
+    for (const post of POSTS) {
+      const slug = slugify(post.title);
+
+      // Check for existing post with this slug
+      const exists = await client.query(
+        `SELECT id FROM posts WHERE slug = $1 AND post_type = 'blog'`,
+        [slug]
+      );
+
+      if (exists.rows.length) {
+        console.log(`[seed] SKIP — already exists: ${slug}`);
+        skipped++;
+        continue;
+      }
+
+      const publishedAt = post.published ? new Date(post.post_date + 'T12:00:00Z') : null;
+
+      const result = await client.query(
+        `INSERT INTO posts (post_type, title, slug, body_markdown, post_date, published_at)
+         VALUES ('blog', $1, $2, $3, $4, $5)
+         RETURNING id, title`,
+        [post.title, slug, post.body.trim(), post.post_date, publishedAt]
+      );
+
+      const row = result.rows[0];
+      console.log(`[seed] INSERT id=${row.id} — "${row.title}"`);
+      inserted++;
+    }
+
+    await client.query('COMMIT');
+    console.log(`\n[seed] Done — ${inserted} inserted, ${skipped} skipped.`);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[seed] ERROR — transaction rolled back:', err.message);
+    process.exit(1);
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+seedBlogPosts();

--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -209,7 +209,19 @@ try {
   const cardCount = await page.$$eval('.admin-dashboard-card', els => els.length).catch(() => 0);
   smoke('Dashboard has 7 navigation cards', cardCount === 7, `found ${cardCount}`);
 
-  // S5: public search page loads without errors (#157)
+  // S5: Search link present in public nav on blog and travel pages (#157)
+  const blogNav = await page.evaluate(async (url) => {
+    const r = await fetch(url); const html = await r.text();
+    return html.includes('href="/search/"');
+  }, `${baseUrl}/blog/`);
+  smoke('Blog page — Search link in nav', blogNav, 'href="/search/" not found in /blog/');
+  const travelNav = await page.evaluate(async (url) => {
+    const r = await fetch(url); const html = await r.text();
+    return html.includes('href="/search/"');
+  }, `${baseUrl}/travel/`);
+  smoke('Travel page — Search link in nav', travelNav, 'href="/search/" not found in /travel/');
+
+  // S7: public search page loads without errors (#157)
   consoleErrors.length = 0;
   await page.goto(`${baseUrl}/search/`, { waitUntil: 'networkidle0', timeout: 20000 });
   const searchFormExists = await page.$('#search-form') !== null;
@@ -217,7 +229,7 @@ try {
   const searchPageErrors = consoleErrors.filter(e => !e.includes('zlib'));
   smoke('Search page — no JS console errors', searchPageErrors.length === 0, searchPageErrors.join('; '));
 
-  // S6: admin activity dashboard loads and shows table (#155)
+  // S8: admin activity dashboard loads and shows table (#155)
   consoleErrors.length = 0;
   await page.goto(`${baseUrl}/admin/activity.html`, { waitUntil: 'networkidle0', timeout: 20000 });
   const activityTableExists = await page.$('#activity-tbody') !== null;
@@ -225,7 +237,7 @@ try {
   const activityPageErrors = consoleErrors.filter(e => !e.includes('zlib'));
   smoke('Activity dashboard — no JS console errors', activityPageErrors.length === 0, activityPageErrors.join('; '));
 
-  // S7: CV history section present on media page (#109)
+  // S9: CV history section present on media page (#109)
   consoleErrors.length = 0;
   await page.goto(`${baseUrl}/admin/media.html`, { waitUntil: 'networkidle0', timeout: 20000 });
   const cvHistoryExists = await page.$('#cv-history') !== null;

--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -201,9 +201,9 @@ try {
     smoke('Dashboard active in sub-nav', activeLabel.includes('Dashboard'), `active item: "${activeLabel}"`);
   }
 
-  // S4: all 6 dashboard navigation cards present (#378)
+  // S4: all 7 dashboard navigation cards present (#378, +Activity card from #155)
   const cardCount = await page.$$eval('.admin-dashboard-card', els => els.length).catch(() => 0);
-  smoke('Dashboard has 6 navigation cards', cardCount === 6, `found ${cardCount}`);
+  smoke('Dashboard has 7 navigation cards', cardCount === 7, `found ${cardCount}`);
 
   // ── Interaction tests ────────────────────────────────────────────────────
 

--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -193,10 +193,14 @@ try {
   smoke('No unhandled JS exceptions on page load', pageErrors.length === 0, pageErrors.join('; '));
   const pageErrorsAtLoad = pageErrors.length; // snapshot — S-final only reports new errors from interactions
 
-  // S3: admin sub-nav present and Dashboard is the active item (#378)
+  // S3: admin sub-nav present, correct item count, and Dashboard is active (#378, +Activity #155)
   const subnavExists = await page.$('.admin-subnav') !== null;
   smoke('Admin sub-nav present', subnavExists, '.admin-subnav not found');
   if (subnavExists) {
+    const subnavCount = await page.$$eval('.admin-subnav-item', els => els.length);
+    smoke('Admin sub-nav has 8 items', subnavCount === 8, `found ${subnavCount}`);
+    const subnavLabels = await page.$$eval('.admin-subnav-item .admin-subnav-label', els => els.map(e => e.textContent.trim()));
+    smoke('Admin sub-nav includes Activity', subnavLabels.includes('Activity'), `labels: ${subnavLabels.join(', ')}`);
     const activeLabel = await page.$eval('.admin-subnav-item.active', el => el.textContent.trim()).catch(() => '');
     smoke('Dashboard active in sub-nav', activeLabel.includes('Dashboard'), `active item: "${activeLabel}"`);
   }

--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -205,6 +205,30 @@ try {
   const cardCount = await page.$$eval('.admin-dashboard-card', els => els.length).catch(() => 0);
   smoke('Dashboard has 7 navigation cards', cardCount === 7, `found ${cardCount}`);
 
+  // S5: public search page loads without errors (#157)
+  consoleErrors.length = 0;
+  await page.goto(`${baseUrl}/search/`, { waitUntil: 'networkidle0', timeout: 20000 });
+  const searchFormExists = await page.$('#search-form') !== null;
+  smoke('Search page — form present', searchFormExists, '#search-form not found');
+  const searchPageErrors = consoleErrors.filter(e => !e.includes('zlib'));
+  smoke('Search page — no JS console errors', searchPageErrors.length === 0, searchPageErrors.join('; '));
+
+  // S6: admin activity dashboard loads and shows table (#155)
+  consoleErrors.length = 0;
+  await page.goto(`${baseUrl}/admin/activity.html`, { waitUntil: 'networkidle0', timeout: 20000 });
+  const activityTableExists = await page.$('#activity-tbody') !== null;
+  smoke('Activity dashboard — table present', activityTableExists, '#activity-tbody not found');
+  const activityPageErrors = consoleErrors.filter(e => !e.includes('zlib'));
+  smoke('Activity dashboard — no JS console errors', activityPageErrors.length === 0, activityPageErrors.join('; '));
+
+  // S7: CV history section present on media page (#109)
+  consoleErrors.length = 0;
+  await page.goto(`${baseUrl}/admin/media.html`, { waitUntil: 'networkidle0', timeout: 20000 });
+  const cvHistoryExists = await page.$('#cv-history') !== null;
+  smoke('CV history — section present on media page', cvHistoryExists, '#cv-history not found');
+  const mediaPageErrors = consoleErrors.filter(e => !e.includes('zlib'));
+  smoke('CV history — no JS console errors on media page', mediaPageErrors.length === 0, mediaPageErrors.join('; '));
+
   // ── Interaction tests ────────────────────────────────────────────────────
 
   console.log('\n── Interaction tests ───────────────────────────────────────');
@@ -326,6 +350,45 @@ try {
     interact('Deploy fetch — output appeared', true);
   } catch (e) {
     interact('Deploy fetch — output appeared', false, e.message);
+  }
+
+  // ── I6: full-text search returns results (#157) ──────────────────────────
+  console.log('\n🔍 I6 — full-text search');
+  await page.goto(`${baseUrl}/search/`, { waitUntil: 'networkidle0', timeout: 20000 });
+  try {
+    await page.waitForSelector('#search-input', { timeout: 5000 });
+    await page.$eval('#search-input', el => { el.value = ''; });
+    await page.type('#search-input', 'portfolio');
+    await page.click('button[type="submit"]');
+    // Wait for results container to be populated (results or "no results" message)
+    await page.waitForFunction(
+      () => {
+        const el = document.getElementById('search-results');
+        return el && el.textContent.trim().length > 0;
+      },
+      { timeout: 10000 },
+    );
+    interact('Search — results container populated', true);
+  } catch (e) {
+    interact('Search — results container populated', false, e.message);
+  }
+
+  // ── I7: activity log shows entries written by I1–I4 (#154/#155) ──────────
+  console.log('\n📋 I7 — activity log has entries');
+  await page.goto(`${baseUrl}/admin/activity.html`, { waitUntil: 'networkidle0', timeout: 20000 });
+  try {
+    await page.waitForFunction(
+      () => {
+        const tbody = document.getElementById('activity-tbody');
+        if (!tbody) return false;
+        const rows = tbody.querySelectorAll('tr');
+        return rows.length > 0 && !tbody.textContent.includes('Failed to load');
+      },
+      { timeout: 10000 },
+    );
+    interact('Activity log — shows audit entries from test interactions', true);
+  } catch (e) {
+    interact('Activity log — shows audit entries from test interactions', false, e.message);
   }
 
   // S-final: no unhandled JS exceptions fired during interactions (#397)

--- a/backend/tests/routes/audit.test.js
+++ b/backend/tests/routes/audit.test.js
@@ -2,7 +2,7 @@
  * Audit route tests (#154)
  * GET /audit — auth required; supports ?limit and ?type filter
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import { createApp } from '../../app.js';
@@ -47,6 +47,11 @@ describe('GET /audit — auth gate', () => {
 });
 
 describe('GET /audit — authenticated', () => {
+  beforeEach(() => {
+    pool.query.mockReset();
+    pool.query.mockResolvedValue({ rows: [] });
+  });
+
   it('returns 200 with an empty array when no entries', async () => {
     pool.query.mockResolvedValue({ rows: [] });
     const res = await request(app)
@@ -73,8 +78,9 @@ describe('GET /audit — authenticated', () => {
       .get('/audit?limit=10')
       .set('Authorization', `Bearer ${makeToken()}`);
     expect(res.status).toBe(200);
-    // Verify limit was passed to query (cap at 200)
-    const call = pool.query.mock.calls[0];
+    // Verify limit was passed to query (cap at 200); use .at(-1) because the
+    // PostgresStore rate-limiter makes prior pool.query calls in each request.
+    const call = pool.query.mock.calls.at(-1);
     expect(call[1][1]).toBe(10);
   });
 
@@ -83,7 +89,7 @@ describe('GET /audit — authenticated', () => {
     await request(app)
       .get('/audit?limit=9999')
       .set('Authorization', `Bearer ${makeToken()}`);
-    const call = pool.query.mock.calls[0];
+    const call = pool.query.mock.calls.at(-1);
     expect(call[1][1]).toBe(200);
   });
 
@@ -92,7 +98,7 @@ describe('GET /audit — authenticated', () => {
     await request(app)
       .get('/audit?type=post')
       .set('Authorization', `Bearer ${makeToken()}`);
-    const call = pool.query.mock.calls[0];
+    const call = pool.query.mock.calls.at(-1);
     expect(call[1][0]).toBe('post');
   });
 
@@ -101,7 +107,27 @@ describe('GET /audit — authenticated', () => {
     await request(app)
       .get('/audit?type=all')
       .set('Authorization', `Bearer ${makeToken()}`);
-    const call = pool.query.mock.calls[0];
+    const call = pool.query.mock.calls.at(-1);
     expect(call[1][0]).toBeNull();
+  });
+
+  it('treats wildcard chars in ?type= as null (no filter)', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    const res = await request(app)
+      .get('/audit?type=p%25st')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    expect(res.status).toBe(200);
+    const call = pool.query.mock.calls.at(-1);
+    expect(call[1][0]).toBeNull();
+  });
+
+  it('accepts a valid dot-namespaced ?type=', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    const res = await request(app)
+      .get('/audit?type=post.create')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    expect(res.status).toBe(200);
+    const call = pool.query.mock.calls.at(-1);
+    expect(call[1][0]).toBe('post.create');
   });
 });

--- a/backend/tests/routes/audit.test.js
+++ b/backend/tests/routes/audit.test.js
@@ -1,0 +1,107 @@
+/**
+ * Audit route tests (#154)
+ * GET /audit — auth required; supports ?limit and ?type filter
+ */
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { createApp } from '../../app.js';
+
+vi.mock('../../db/pool.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+import { pool } from '../../db/pool.js';
+
+process.env.JWT_SECRET = 'test-secret-test-secret-test-secret-32';
+
+const app = createApp();
+
+function makeToken() {
+  return jwt.sign({ userId: 'test-user' }, process.env.JWT_SECRET, { expiresIn: '1h' });
+}
+
+const fakeRow = {
+  id:          'audit-id-1',
+  action:      'post.create',
+  entity_type: 'post',
+  entity_id:   'post-id-1',
+  detail:      { title: 'Hello World' },
+  ip:          '127.0.0.1',
+  created_at:  new Date().toISOString(),
+  username:    'andy',
+};
+
+describe('GET /audit — auth gate', () => {
+  it('returns 401 without a JWT', async () => {
+    const res = await request(app).get('/audit');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with an invalid JWT', async () => {
+    const res = await request(app)
+      .get('/audit')
+      .set('Authorization', 'Bearer bad.token.here');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /audit — authenticated', () => {
+  it('returns 200 with an empty array when no entries', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    const res = await request(app)
+      .get('/audit')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(0);
+  });
+
+  it('returns audit rows as JSON array', async () => {
+    pool.query.mockResolvedValue({ rows: [fakeRow] });
+    const res = await request(app)
+      .get('/audit')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    expect(res.status).toBe(200);
+    expect(res.body[0].action).toBe('post.create');
+    expect(res.body[0].username).toBe('andy');
+  });
+
+  it('accepts ?limit=10 parameter', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    const res = await request(app)
+      .get('/audit?limit=10')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    expect(res.status).toBe(200);
+    // Verify limit was passed to query (cap at 200)
+    const call = pool.query.mock.calls[0];
+    expect(call[1][1]).toBe(10);
+  });
+
+  it('caps limit at 200', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    await request(app)
+      .get('/audit?limit=9999')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    const call = pool.query.mock.calls[0];
+    expect(call[1][1]).toBe(200);
+  });
+
+  it('passes type filter to query', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    await request(app)
+      .get('/audit?type=post')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    const call = pool.query.mock.calls[0];
+    expect(call[1][0]).toBe('post');
+  });
+
+  it('passes null for type=all', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    await request(app)
+      .get('/audit?type=all')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    const call = pool.query.mock.calls[0];
+    expect(call[1][0]).toBeNull();
+  });
+});

--- a/backend/tests/routes/cv.test.js
+++ b/backend/tests/routes/cv.test.js
@@ -1,6 +1,6 @@
 /**
- * CV route tests — auth gate, MIME filtering, size limit, private-info scan.
- * Uses vi.spyOn on fs to avoid real disk I/O.
+ * CV route tests (#109) — auth gate, MIME filtering, size limit, private-info scan.
+ * Routes now use DB for version history; pool.query is mocked throughout.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
@@ -8,9 +8,15 @@ import jwt from 'jsonwebtoken';
 import fs from 'fs';
 import { createApp } from '../../app.js';
 
+// Mock DB pool — cv.js now queries `cvs` table
 vi.mock('../../db/pool.js', () => ({
-  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+  pool: {
+    query: vi.fn(),
+    connect: vi.fn(),
+  },
 }));
+
+import { pool } from '../../db/pool.js';
 
 process.env.JWT_SECRET   = 'test-secret-test-secret-test-secret-32';
 process.env.UPLOADS_DIR  = '/tmp/test-uploads';
@@ -29,32 +35,59 @@ let spyMkdirSync;
 let spyWriteFileSync;
 let spyUnlinkSync;
 
+// Fake DB client for pool.connect()
+function makeFakeClient(queryFn) {
+  return {
+    query: queryFn || vi.fn().mockResolvedValue({ rows: [] }),
+    release: vi.fn(),
+  };
+}
+
 beforeEach(() => {
   spyExistsSync    = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
   spyMkdirSync     = vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
   spyWriteFileSync = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
   spyUnlinkSync    = vi.spyOn(fs, 'unlinkSync').mockImplementation(() => {});
+
+  // Default: no current CV in DB
+  pool.query.mockResolvedValue({ rows: [] });
+  pool.connect.mockResolvedValue(makeFakeClient());
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
+// ── GET /cv/exists ────────────────────────────────────────────────────────────
+
 describe('GET /cv/exists', () => {
-  it('returns { exists: false } when no CV is present', async () => {
-    spyExistsSync.mockReturnValue(false);
+  it('returns { exists: false } when no current CV row in DB', async () => {
+    pool.query.mockResolvedValue({ rows: [] }); // no current row
     const res = await request(app).get('/cv/exists');
     expect(res.status).toBe(200);
     expect(res.body.exists).toBe(false);
   });
 
-  it('returns { exists: true } when CV is on disk', async () => {
+  it('returns { exists: true } when current CV row found and file on disk', async () => {
+    pool.query.mockResolvedValue({ rows: [{ id: 'abc', filename: 'cv-test.pdf' }] });
     spyExistsSync.mockReturnValue(true);
     const res = await request(app).get('/cv/exists');
     expect(res.status).toBe(200);
     expect(res.body.exists).toBe(true);
   });
 });
+
+// ── GET /cv ───────────────────────────────────────────────────────────────────
+
+describe('GET /cv', () => {
+  it('returns 404 when no current CV in DB', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    const res = await request(app).get('/cv');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /cv — auth gate ──────────────────────────────────────────────────────
 
 describe('POST /cv — auth gate', () => {
   it('returns 401 without a JWT', async () => {
@@ -73,6 +106,8 @@ describe('POST /cv — auth gate', () => {
   });
 });
 
+// ── POST /cv — MIME filtering ─────────────────────────────────────────────────
+
 describe('POST /cv — MIME filtering', () => {
   it('rejects a non-PDF file', async () => {
     const res = await request(app)
@@ -83,8 +118,21 @@ describe('POST /cv — MIME filtering', () => {
   });
 
   it('accepts application/pdf and writes the file', async () => {
-    // UPLOADS_DIR does not exist → mkdirSync + writeFileSync should be called
     spyExistsSync.mockReturnValue(false);
+
+    // Mock pool.connect() to return a client that handles the transaction steps
+    let queryCount = 0;
+    const fakeClient = makeFakeClient(async (sql) => {
+      queryCount++;
+      // INSERT INTO cvs returns new ID
+      if (sql && typeof sql === 'string' && sql.includes('INSERT INTO cvs')) {
+        return { rows: [{ id: 'new-cv-id' }] };
+      }
+      // SELECT offset for prune — no rows to prune
+      return { rows: [] };
+    });
+    pool.connect.mockResolvedValue(fakeClient);
+
     const res = await request(app)
       .post('/cv')
       .set('Authorization', `Bearer ${makeToken()}`)
@@ -94,6 +142,8 @@ describe('POST /cv — MIME filtering', () => {
     expect(spyWriteFileSync).toHaveBeenCalledOnce();
   });
 });
+
+// ── POST /cv — size limit ─────────────────────────────────────────────────────
 
 describe('POST /cv — size limit', () => {
   it('rejects a file over 5 MB', async () => {
@@ -107,9 +157,20 @@ describe('POST /cv — size limit', () => {
   });
 });
 
+// ── POST /cv — private info scan ──────────────────────────────────────────────
+
 describe('POST /cv — private info scan', () => {
   it('returns warnings for a PDF containing a card-number pattern', async () => {
     const cardPdf = Buffer.from('%PDF-1.4 card: 1234 5678 9012 3456 end');
+    spyExistsSync.mockReturnValue(false);
+    const fakeClient = makeFakeClient(async (sql) => {
+      if (sql && typeof sql === 'string' && sql.includes('INSERT INTO cvs')) {
+        return { rows: [{ id: 'new-cv-id' }] };
+      }
+      return { rows: [] };
+    });
+    pool.connect.mockResolvedValue(fakeClient);
+
     const res = await request(app)
       .post('/cv')
       .set('Authorization', `Bearer ${makeToken()}`)
@@ -119,6 +180,15 @@ describe('POST /cv — private info scan', () => {
   });
 
   it('returns no warnings for a clean PDF', async () => {
+    spyExistsSync.mockReturnValue(false);
+    const fakeClient = makeFakeClient(async (sql) => {
+      if (sql && typeof sql === 'string' && sql.includes('INSERT INTO cvs')) {
+        return { rows: [{ id: 'new-cv-id' }] };
+      }
+      return { rows: [] };
+    });
+    pool.connect.mockResolvedValue(fakeClient);
+
     const res = await request(app)
       .post('/cv')
       .set('Authorization', `Bearer ${makeToken()}`)
@@ -128,29 +198,66 @@ describe('POST /cv — private info scan', () => {
   });
 });
 
-describe('DELETE /cv — auth gate', () => {
+// ── GET /cv/history — auth gate ───────────────────────────────────────────────
+
+describe('GET /cv/history — auth gate', () => {
   it('returns 401 without a JWT', async () => {
-    const res = await request(app).delete('/cv');
+    const res = await request(app).get('/cv/history');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns version list when authenticated', async () => {
+    pool.query.mockResolvedValue({
+      rows: [
+        { id: 'abc', filename: 'cv-20260101.pdf', uploaded_at: new Date().toISOString(), is_current: true },
+      ],
+    });
+    const res = await request(app)
+      .get('/cv/history')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0].is_current).toBe(true);
+  });
+});
+
+// ── DELETE /cv/:id — auth gate ────────────────────────────────────────────────
+
+describe('DELETE /cv/:id — auth gate', () => {
+  it('returns 401 without a JWT', async () => {
+    const res = await request(app).delete('/cv/some-id');
     expect(res.status).toBe(401);
   });
 });
 
-describe('DELETE /cv', () => {
-  it('returns 404 when no CV exists', async () => {
-    spyExistsSync.mockReturnValue(false);
+describe('DELETE /cv/:id', () => {
+  it('returns 404 when version not found', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
     const res = await request(app)
-      .delete('/cv')
+      .delete('/cv/nonexistent-id')
       .set('Authorization', `Bearer ${makeToken()}`);
     expect(res.status).toBe(404);
   });
 
-  it('deletes the file and returns { deleted: true }', async () => {
-    spyExistsSync.mockReturnValue(true);
+  it('returns 400 when trying to delete the current version', async () => {
+    pool.query.mockResolvedValue({ rows: [{ id: 'abc', filename: 'cv.pdf', is_current: true }] });
     const res = await request(app)
-      .delete('/cv')
+      .delete('/cv/abc')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/current/i);
+  });
+
+  it('deletes a non-current version and returns { deleted: true }', async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ id: 'old-id', filename: 'cv-old.pdf', is_current: false }] })
+      .mockResolvedValueOnce({ rows: [] }); // DELETE
+    spyExistsSync.mockReturnValue(false);
+
+    const res = await request(app)
+      .delete('/cv/old-id')
       .set('Authorization', `Bearer ${makeToken()}`);
     expect(res.status).toBe(200);
     expect(res.body.deleted).toBe(true);
-    expect(spyUnlinkSync).toHaveBeenCalledOnce();
   });
 });

--- a/backend/tests/routes/cv.test.js
+++ b/backend/tests/routes/cv.test.js
@@ -271,10 +271,10 @@ describe('DELETE /cv/:id', () => {
 describe('POST /cv — clean upload', () => {
   it('sets is_current=TRUE immediately when no warnings', async () => {
     spyExistsSync.mockReturnValue(false);
-    let insertSql = '';
-    const fakeClient = makeFakeClient(async (sql) => {
+    let insertParams = null;
+    const fakeClient = makeFakeClient(async (sql, params) => {
       if (typeof sql === 'string' && sql.includes('INSERT INTO cvs')) {
-        insertSql = sql;
+        insertParams = params;
         return { rows: [{ id: 'new-cv-id' }] };
       }
       return { rows: [] };
@@ -288,7 +288,7 @@ describe('POST /cv — clean upload', () => {
     expect(res.status).toBe(200);
     expect(res.body.uploaded).toBe(true);
     expect(res.body.pending).toBeUndefined();
-    expect(insertSql).toContain('TRUE');
+    expect(insertParams[1]).toBe(true); // is_current param is boolean true, not literal 'TRUE'
   });
 });
 

--- a/backend/tests/routes/cv.test.js
+++ b/backend/tests/routes/cv.test.js
@@ -160,7 +160,7 @@ describe('POST /cv — size limit', () => {
 // ── POST /cv — private info scan ──────────────────────────────────────────────
 
 describe('POST /cv — private info scan', () => {
-  it('returns warnings for a PDF containing a card-number pattern', async () => {
+  it('returns warnings array and pending:true when private info detected', async () => {
     const cardPdf = Buffer.from('%PDF-1.4 card: 1234 5678 9012 3456 end');
     spyExistsSync.mockReturnValue(false);
     const fakeClient = makeFakeClient(async (sql) => {
@@ -177,6 +177,8 @@ describe('POST /cv — private info scan', () => {
       .attach('cv', cardPdf, { filename: 'cv.pdf', contentType: 'application/pdf' });
     expect(res.status).toBe(200);
     expect(res.body.warnings).toEqual(expect.arrayContaining([expect.stringMatching(/card/i)]));
+    expect(res.body.pending).toBe(true);
+    expect(res.body.uploaded).toBeUndefined();
   });
 
   it('returns no warnings for a clean PDF', async () => {
@@ -259,5 +261,66 @@ describe('DELETE /cv/:id', () => {
       .set('Authorization', `Bearer ${makeToken()}`);
     expect(res.status).toBe(200);
     expect(res.body.deleted).toBe(true);
+  });
+});
+
+// ── POST /cv — clean upload auto-publishes ────────────────────────────────────
+
+describe('POST /cv — clean upload', () => {
+  it('sets is_current=TRUE immediately when no warnings', async () => {
+    spyExistsSync.mockReturnValue(false);
+    let insertSql = '';
+    const fakeClient = makeFakeClient(async (sql) => {
+      if (typeof sql === 'string' && sql.includes('INSERT INTO cvs')) {
+        insertSql = sql;
+        return { rows: [{ id: 'new-cv-id' }] };
+      }
+      return { rows: [] };
+    });
+    pool.connect.mockResolvedValue(fakeClient);
+
+    const res = await request(app)
+      .post('/cv')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .attach('cv', minPdf, { filename: 'cv.pdf', contentType: 'application/pdf' });
+    expect(res.status).toBe(200);
+    expect(res.body.uploaded).toBe(true);
+    expect(res.body.pending).toBeUndefined();
+    expect(insertSql).toContain('TRUE');
+  });
+});
+
+// ── POST /cv/:id/confirm ──────────────────────────────────────────────────────
+
+describe('POST /cv/:id/confirm', () => {
+  it('returns 401 without a JWT', async () => {
+    const res = await request(app).post('/cv/00000000-0000-0000-0000-000000000001/confirm');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when the CV version does not exist', async () => {
+    const fakeClient = makeFakeClient(async () => ({ rows: [] }));
+    pool.connect.mockResolvedValue(fakeClient);
+    const res = await request(app)
+      .post('/cv/00000000-0000-0000-0000-000000000001/confirm')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('promotes a staged CV to current and returns confirmed:true', async () => {
+    const fakeClient = makeFakeClient(async (sql) => {
+      if (typeof sql === 'string' && sql.includes('SELECT id, filename FROM cvs WHERE id')) {
+        return { rows: [{ id: 'staged-id', filename: 'cv-20260614120000-abc123.pdf' }] };
+      }
+      return { rows: [] };
+    });
+    pool.connect.mockResolvedValue(fakeClient);
+    spyExistsSync.mockReturnValue(true);
+
+    const res = await request(app)
+      .post('/cv/staged-id/confirm')
+      .set('Authorization', `Bearer ${makeToken()}`);
+    expect(res.status).toBe(200);
+    expect(res.body.confirmed).toBe(true);
   });
 });

--- a/backend/tests/routes/cv.test.js
+++ b/backend/tests/routes/cv.test.js
@@ -242,22 +242,24 @@ describe('DELETE /cv/:id', () => {
   });
 
   it('returns 400 when trying to delete the current version', async () => {
-    pool.query.mockResolvedValue({ rows: [{ id: 'abc', filename: 'cv.pdf', is_current: true }] });
+    const cvId = '00000000-0000-0000-0000-000000000001';
+    pool.query.mockResolvedValue({ rows: [{ id: cvId, filename: 'cv.pdf', is_current: true }] });
     const res = await request(app)
-      .delete('/cv/abc')
+      .delete(`/cv/${cvId}`)
       .set('Authorization', `Bearer ${makeToken()}`);
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/current/i);
   });
 
   it('deletes a non-current version and returns { deleted: true }', async () => {
+    const cvId = '00000000-0000-0000-0000-000000000002';
     pool.query
-      .mockResolvedValueOnce({ rows: [{ id: 'old-id', filename: 'cv-old.pdf', is_current: false }] })
+      .mockResolvedValueOnce({ rows: [{ id: cvId, filename: 'cv-old.pdf', is_current: false }] })
       .mockResolvedValueOnce({ rows: [] }); // DELETE
     spyExistsSync.mockReturnValue(false);
 
     const res = await request(app)
-      .delete('/cv/old-id')
+      .delete(`/cv/${cvId}`)
       .set('Authorization', `Bearer ${makeToken()}`);
     expect(res.status).toBe(200);
     expect(res.body.deleted).toBe(true);
@@ -308,9 +310,10 @@ describe('POST /cv/:id/confirm', () => {
   });
 
   it('promotes a staged CV to current and returns confirmed:true', async () => {
+    const cvId = '00000000-0000-0000-0000-000000000003';
     const fakeClient = makeFakeClient(async (sql) => {
       if (typeof sql === 'string' && sql.includes('SELECT id, filename FROM cvs WHERE id')) {
-        return { rows: [{ id: 'staged-id', filename: 'cv-20260614120000-abc123.pdf' }] };
+        return { rows: [{ id: cvId, filename: 'cv-20260614120000-abc123.pdf' }] };
       }
       return { rows: [] };
     });
@@ -318,7 +321,7 @@ describe('POST /cv/:id/confirm', () => {
     spyExistsSync.mockReturnValue(true);
 
     const res = await request(app)
-      .post('/cv/staged-id/confirm')
+      .post(`/cv/${cvId}/confirm`)
       .set('Authorization', `Bearer ${makeToken()}`);
     expect(res.status).toBe(200);
     expect(res.body.confirmed).toBe(true);

--- a/backend/tests/routes/search.test.js
+++ b/backend/tests/routes/search.test.js
@@ -2,7 +2,7 @@
  * Search route tests (#157)
  * GET /search?q=<term>&type=<all|blog|travel>&limit=<n>
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import { createApp } from '../../app.js';
 
@@ -13,6 +13,14 @@ vi.mock('../../db/pool.js', () => ({
 import { pool } from '../../db/pool.js';
 
 const app = createApp();
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+// Helper: find the pool.query call that ran the actual search SQL
+// (PostgresStore rate-limit queries fire first; the search query contains search_vector)
+function findSearchCall() {
+  return pool.query.mock.calls.find(c => typeof c[0] === 'string' && c[0].includes('search_vector'));
+}
 
 const fakeRow = {
   id:           'post-id-1',
@@ -59,7 +67,7 @@ describe('GET /search', () => {
   it('passes type=blog filter to query', async () => {
     pool.query.mockResolvedValue({ rows: [] });
     await request(app).get('/search?q=hello&type=blog');
-    const call = pool.query.mock.calls[0];
+    const call = findSearchCall();
     // Second param is the type filter
     expect(call[1][1]).toBe('blog');
   });
@@ -67,21 +75,21 @@ describe('GET /search', () => {
   it('passes null for type=all (no filter)', async () => {
     pool.query.mockResolvedValue({ rows: [] });
     await request(app).get('/search?q=hello&type=all');
-    const call = pool.query.mock.calls[0];
+    const call = findSearchCall();
     expect(call[1][1]).toBeNull();
   });
 
   it('passes null for unknown type values (safety guard)', async () => {
     pool.query.mockResolvedValue({ rows: [] });
     await request(app).get('/search?q=hello&type=admin');
-    const call = pool.query.mock.calls[0];
+    const call = findSearchCall();
     expect(call[1][1]).toBeNull();
   });
 
   it('caps limit at 50', async () => {
     pool.query.mockResolvedValue({ rows: [] });
     await request(app).get('/search?q=hello&limit=999');
-    const call = pool.query.mock.calls[0];
+    const call = findSearchCall();
     expect(call[1][2]).toBe(50);
   });
 });

--- a/backend/tests/routes/search.test.js
+++ b/backend/tests/routes/search.test.js
@@ -1,0 +1,87 @@
+/**
+ * Search route tests (#157)
+ * GET /search?q=<term>&type=<all|blog|travel>&limit=<n>
+ */
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../../app.js';
+
+vi.mock('../../db/pool.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+import { pool } from '../../db/pool.js';
+
+const app = createApp();
+
+const fakeRow = {
+  id:           'post-id-1',
+  title:        'Tokyo Travel',
+  slug:         'tokyo-travel',
+  post_type:    'travel',
+  location:     'Tokyo, Japan',
+  published_at: new Date().toISOString(),
+  post_date:    '2023-04-10',
+  excerpt:      'A fantastic trip to Tokyo...',
+  rank:         0.9,
+};
+
+describe('GET /search', () => {
+  it('returns 400 when q is missing', async () => {
+    const res = await request(app).get('/search');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/required/i);
+  });
+
+  it('returns 400 when q is empty string', async () => {
+    const res = await request(app).get('/search?q=');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns search results for a valid query', async () => {
+    pool.query.mockResolvedValue({ rows: [fakeRow] });
+    const res = await request(app).get('/search?q=tokyo');
+    expect(res.status).toBe(200);
+    expect(res.body.query).toBe('tokyo');
+    expect(res.body.total).toBe(1);
+    expect(Array.isArray(res.body.results)).toBe(true);
+    expect(res.body.results[0].title).toBe('Tokyo Travel');
+  });
+
+  it('returns empty results array when no matches', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    const res = await request(app).get('/search?q=nonexistent');
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(0);
+    expect(res.body.results).toHaveLength(0);
+  });
+
+  it('passes type=blog filter to query', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    await request(app).get('/search?q=hello&type=blog');
+    const call = pool.query.mock.calls[0];
+    // Second param is the type filter
+    expect(call[1][1]).toBe('blog');
+  });
+
+  it('passes null for type=all (no filter)', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    await request(app).get('/search?q=hello&type=all');
+    const call = pool.query.mock.calls[0];
+    expect(call[1][1]).toBeNull();
+  });
+
+  it('passes null for unknown type values (safety guard)', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    await request(app).get('/search?q=hello&type=admin');
+    const call = pool.query.mock.calls[0];
+    expect(call[1][1]).toBeNull();
+  });
+
+  it('caps limit at 50', async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+    await request(app).get('/search?q=hello&limit=999');
+    const call = pool.query.mock.calls[0];
+    expect(call[1][2]).toBe(50);
+  });
+});

--- a/backend/utils/audit.js
+++ b/backend/utils/audit.js
@@ -1,0 +1,37 @@
+/**
+ * Audit logging utility (#154)
+ *
+ * logAudit(req, action, entityType, entityId, detail)
+ *   → writes one row to audit_log asynchronously (non-blocking)
+ *
+ * Sensitive fields (tokens, passwords, hashes) must NEVER appear in `detail`.
+ * The caller is responsible for scrubbing any such fields before passing them.
+ */
+import { pool } from '../db/pool.js';
+import { logger } from './logger.js';
+
+/**
+ * @param {import('express').Request} req        - Express request (for user_id and IP)
+ * @param {string}                    action      - Dot-namespaced action, e.g. 'post.publish'
+ * @param {string|null}               entityType  - e.g. 'post', 'travel', 'cv', 'deploy'
+ * @param {string|null}               entityId    - ID of the affected record
+ * @param {object|null}               detail      - Structured context (no secrets)
+ */
+export async function logAudit(req, action, entityType = null, entityId = null, detail = null) {
+  const userId = req.user?.userId ?? req.user?.id ?? null;
+  const ip     = req.headers['x-forwarded-for']?.split(',')[0]?.trim()
+              ?? req.socket?.remoteAddress
+              ?? null;
+
+  try {
+    await pool.query(
+      `INSERT INTO audit_log (user_id, action, entity_type, entity_id, detail, ip)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [userId, action, entityType, entityId ? String(entityId) : null,
+       detail ? JSON.stringify(detail) : null, ip]
+    );
+  } catch (err) {
+    // Audit failures are non-fatal — log and continue
+    logger.warn({ err, action, entityType, entityId }, '[audit] Failed to write audit log row');
+  }
+}

--- a/backend/utils/audit.js
+++ b/backend/utils/audit.js
@@ -11,14 +11,15 @@ import { pool } from '../db/pool.js';
 import { logger } from './logger.js';
 
 /**
- * @param {import('express').Request} req        - Express request (for user_id and IP)
- * @param {string}                    action      - Dot-namespaced action, e.g. 'post.publish'
- * @param {string|null}               entityType  - e.g. 'post', 'travel', 'cv', 'deploy'
- * @param {string|null}               entityId    - ID of the affected record
- * @param {object|null}               detail      - Structured context (no secrets)
+ * @param {import('express').Request}              req        - Express request (for user_id and IP)
+ * @param {string}                                 action      - Dot-namespaced action, e.g. 'post.publish'
+ * @param {string|null}                            entityType  - e.g. 'post', 'travel', 'cv', 'deploy'
+ * @param {string|null}                            entityId    - ID of the affected record
+ * @param {object|null}                            detail      - Structured context (no secrets)
+ * @param {{ userId?: string|number|null }}        [opts]      - Optional overrides (e.g. userId for login routes that lack req.user)
  */
-export async function logAudit(req, action, entityType = null, entityId = null, detail = null) {
-  const userId = req.user?.userId ?? req.user?.id ?? null;
+export async function logAudit(req, action, entityType = null, entityId = null, detail = null, opts = {}) {
+  const userId = opts.userId ?? req.user?.userId ?? req.user?.id ?? null;
   const ip     = req.headers['x-forwarded-for']?.split(',')[0]?.trim()
               ?? req.socket?.remoteAddress
               ?? null;

--- a/blog/index.html
+++ b/blog/index.html
@@ -35,6 +35,7 @@
             <li><a href="/#contact">✉ Contact</a></li>
             <li><a href="/blog/">✏ Blog</a></li>
             <li><a href="/travel/">✈ Travel</a></li>
+            <li><a href="/search/">🔍 Search</a></li>
             <li><a href="/login/">🔒 Admin</a></li>
             <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
         </ul>

--- a/blog/post/index.html
+++ b/blog/post/index.html
@@ -35,6 +35,7 @@
             <li><a href="/#contact">✉ Contact</a></li>
             <li><a href="/blog/">✏ Blog</a></li>
             <li><a href="/travel/">✈ Travel</a></li>
+            <li><a href="/search/">🔍 Search</a></li>
             <li><a href="/login/">🔒 Admin</a></li>
             <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
         </ul>

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,6 +1,14 @@
+# ── Shared log driver config (#437) ──────────────────────────────────────────
+# Applied to every service below via <<: *logging.
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16-alpine  # pin: update intentionally — test before bumping (#437)
     environment:
       POSTGRES_DB: ${DB_NAME:-portfolio_dev}
       POSTGRES_USER: ${DB_USER:-postgres}
@@ -10,16 +18,13 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/db/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql
+    # Canonical healthcheck for postgres — mirrors docker-compose.yml definition (#437).
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres}"]
       interval: 5s
       timeout: 5s
       retries: 5
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *logging
 
   backend:
     build:
@@ -58,19 +63,17 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # Canonical healthcheck for backend — mirrors docker-compose.yml definition (#437).
+    # Dockerfile also has a HEALTHCHECK directive; compose wins for local dev use.
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:${PORT:-8080}/health"]
       interval: 10s
       timeout: 5s
       retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *logging
 
   nginx:
-    image: nginx:alpine
+    image: nginx:alpine  # pin: update intentionally — test before bumping (#437)
     ports:
       - "80:80"
     volumes:
@@ -87,11 +90,7 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *logging
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,17 @@
 #     (bash scripts/setup/generate-dev-certs.sh $LAN_IP $SITE_HOST)
 #   - For prod: Let's Encrypt certs present at $CERT_MOUNT_SRC
 
+# ── Shared log driver config (#437) ──────────────────────────────────────────
+# Applied to every service below via <<: *logging.
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: "20m"
+    max-file: "5"
+
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16-alpine  # pin: update intentionally — test before bumping (#437)
     restart: always
     environment:
       POSTGRES_DB: ${DB_NAME}
@@ -27,16 +35,14 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/db/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql
+    # Canonical healthcheck for postgres in this project (#437).
+    # docker-compose.local.yml mirrors this definition.
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5
-    logging:
-      driver: json-file
-      options:
-        max-size: "20m"
-        max-file: "5"
+    logging: *logging
 
   backend:
     build:
@@ -85,19 +91,18 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # Canonical healthcheck for backend in this project (#437).
+    # docker-compose.local.yml mirrors this definition.
+    # Dockerfile also has a HEALTHCHECK directive; compose wins for local/server use.
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:${PORT}/health"]
       interval: 10s
       timeout: 5s
       retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: "20m"
-        max-file: "5"
+    logging: *logging
 
   nginx:
-    image: nginx:alpine
+    image: nginx:alpine  # pin: update intentionally — test before bumping (#437)
     restart: always
     ports:
       # Primary HTTPS port — 3001 (dev) or 443 (prod).
@@ -121,11 +126,7 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-    logging:
-      driver: json-file
-      options:
-        max-size: "20m"
-        max-file: "5"
+    logging: *logging
 
 # Explicit volume names let .env preserve existing data when upgrading from
 # the per-env compose files (uploads_dev_data → uploads_dev_data, etc.). Leave

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -104,6 +104,11 @@ Unified table for both blog posts and travel memories. Discriminated by `post_ty
 
 **Draft vs published:** `published_at IS NULL` = draft (hidden from public routes). Public API routes add `AND published_at IS NOT NULL` to all queries.
 
+**Migration note — search_vector column:** Adding a `GENERATED ALWAYS AS ... STORED` column rewrites
+every existing row under an `ACCESS EXCLUSIVE` lock. On first deploy to a populated database this
+is automatic (schema.sql uses `ADD COLUMN IF NOT EXISTS`) but takes a moment proportional to post
+count. The site has few posts so this completes in milliseconds; no manual step is needed.
+
 ---
 
 ### `post_media`

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -160,6 +160,51 @@ DB-backed rate limiting for the contact form. One row per IP address.
 | `idx_posts_created_at` | `posts` | `created_at DESC` | Sort by creation |
 | `idx_posts_type_published_date` | `posts` | `(post_type, published_at DESC, post_date DESC)` | Primary public list query |
 | `idx_post_media_post_id` | `post_media` | `post_id` | Media lookups by post |
+| `posts_search_vector_idx` | `posts` | `search_vector` (GIN) | Full-text search (#157) |
+| `audit_log_created_at` | `audit_log` | `created_at DESC` | Recent-first audit queries (#154) |
+| `audit_log_user_id` | `audit_log` | `user_id` | Audit queries by user (#154) |
+| `cvs_one_current` | `cvs` | `is_current` WHERE true (partial unique) | Enforce one current CV (#109) |
+
+---
+
+## Tables (continued)
+
+### `audit_log`
+
+Records admin actions with user, timestamp, action type, and structured context. Powers the admin activity dashboard (#155). Sensitive fields (tokens, passwords, hashes) are never stored in `detail`.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `UUID PK` | |
+| `user_id` | `UUID FK → users(id)` | `ON DELETE SET NULL` — preserved if user deleted |
+| `action` | `TEXT NOT NULL` | Dot-namespaced, e.g. `post.publish`, `auth.login`, `deploy.start` |
+| `entity_type` | `TEXT` | e.g. `post`, `travel`, `cv`, `deploy` |
+| `entity_id` | `TEXT` | ID of the affected record |
+| `detail` | `JSONB` | Structured context (title, method, sha, env). Never secrets. |
+| `ip` | `TEXT` | Client IP from `x-forwarded-for` or socket |
+| `created_at` | `TIMESTAMPTZ NOT NULL DEFAULT NOW()` | |
+
+**API:** `GET /api/audit?limit=50&type=<prefix|all>` — auth required.
+
+---
+
+### `cvs`
+
+Tracks every uploaded CV version with a timestamp. Only one row may have `is_current = TRUE` at a time (partial unique index). The public download endpoint always serves the current version. Older versions are kept for archival; uploads beyond 5 prune the oldest automatically (#109).
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `UUID PK` | |
+| `filename` | `TEXT NOT NULL` | Stored filename, e.g. `cv-20260604-120000.pdf` |
+| `uploaded_at` | `TIMESTAMPTZ NOT NULL DEFAULT NOW()` | |
+| `is_current` | `BOOLEAN NOT NULL DEFAULT FALSE` | Only one row may be TRUE (partial unique index) |
+
+**Endpoints:**
+- `GET /api/cv` — public download (serves current)
+- `GET /api/cv/exists` — public, returns `{ exists: bool }`
+- `GET /api/cv/history` — auth, lists all versions
+- `PUT /api/cv/:id/set-current` — auth, promotes a version
+- `DELETE /api/cv/:id` — auth, removes a non-current version
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
             <li><a href="#contact">✉ Contact</a></li>
             <li><a href="/blog/">✏ Blog</a></li>
             <li><a href="/travel/">✈ Travel</a></li>
+            <li><a href="/search/">🔍 Search</a></li>
             <li><a href="/login/">🔒 Admin</a></li>
             <li><button id="dark-mode-toggle" aria-label="Switch to dark mode">☾</button></li>
         </ul>

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -2620,3 +2620,237 @@ a.travel-card:visited {
 .travel-post-map {
     border: 1px solid var(--color-border);
 }
+
+/* ── Admin activity log (#155) ──────────────────────────────────────────────── */
+
+.activity-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--text-sm);
+}
+
+.activity-table th,
+.activity-table td {
+    padding: 0.4rem 0.6rem;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+    vertical-align: top;
+}
+
+.activity-table th {
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+}
+
+.activity-table tbody tr:hover {
+    background: var(--color-surface-alt);
+}
+
+/* Colour-coded row classes */
+.activity-table tr.activity-success td { border-left: 3px solid var(--color-success); }
+.activity-table tr.activity-danger  td { border-left: 3px solid var(--color-error); }
+.activity-table tr.activity-warn    td { border-left: 3px solid #e67e22; }
+.activity-table tr.activity-info    td { border-left: 3px solid var(--color-accent); }
+
+.activity-ts {
+    white-space: nowrap;
+    color: var(--color-text-muted);
+    cursor: default;
+    min-width: 5rem;
+}
+
+.activity-action code {
+    font-size: 0.8rem;
+    background: var(--color-surface-alt);
+    padding: 0.1rem 0.3rem;
+    border-radius: var(--radius-sm);
+}
+
+.activity-detail {
+    color: var(--color-text-secondary);
+    max-width: 18rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.activity-empty {
+    text-align: center;
+    color: var(--color-text-muted);
+    padding: 1.5rem !important;
+}
+
+.activity-filters .btn-small.active {
+    background: var(--color-accent);
+    color: #fff;
+    border-color: var(--color-accent);
+}
+
+/* ── Search page (#157) ─────────────────────────────────────────────────────── */
+
+.search-form {
+    margin-bottom: 2rem;
+}
+
+.search-input-wrap {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.search-input {
+    flex: 1;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    font-size: 1rem;
+    background: var(--color-surface);
+    color: var(--color-text);
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: var(--color-accent);
+}
+
+.search-submit {
+    white-space: nowrap;
+}
+
+.search-filters {
+    display: flex;
+    gap: 1rem;
+    font-size: var(--text-sm);
+}
+
+.search-filter-label {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    cursor: pointer;
+}
+
+.search-summary {
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+    margin-bottom: 1.5rem;
+}
+
+.search-group-heading {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 1.5rem 0 0.75rem;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.search-result-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.search-result-item {
+    border-bottom: 1px solid var(--color-border);
+}
+
+.search-result-link {
+    display: block;
+    padding: 0.75rem 0;
+    text-decoration: none;
+    color: inherit;
+}
+
+.search-result-link:hover .search-result-title {
+    color: var(--color-accent);
+    text-decoration: underline;
+}
+
+.search-result-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    display: block;
+    margin-bottom: 0.3rem;
+}
+
+.search-result-meta {
+    display: flex;
+    gap: 0.6rem;
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    margin-bottom: 0.3rem;
+    flex-wrap: wrap;
+}
+
+.search-result-type {
+    font-weight: 600;
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--radius-sm);
+}
+
+.tag-blog   { background: var(--color-accent); color: #fff; }
+.tag-travel { background: #27ae60; color: #fff; }
+
+.search-result-excerpt {
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.search-result-excerpt mark,
+.search-result-title mark {
+    background: #fef08a;
+    color: inherit;
+    border-radius: 2px;
+    padding: 0 0.1rem;
+}
+
+[data-theme="dark"] .search-result-excerpt mark,
+[data-theme="dark"] .search-result-title mark {
+    background: #713f12;
+}
+
+.search-empty {
+    color: var(--color-text-muted);
+    text-align: center;
+    padding: 2rem 0;
+}
+
+/* ── CV version history table (#109) ────────────────────────────────────────── */
+
+.cv-history-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--text-sm);
+    margin-top: 0.5rem;
+}
+
+.cv-history-table th,
+.cv-history-table td {
+    padding: 0.4rem 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+    vertical-align: middle;
+}
+
+.cv-history-table th {
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+}
+
+.cv-row-current {
+    background: color-mix(in srgb, var(--color-success) 8%, transparent);
+}
+
+.cv-row-actions {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}

--- a/resources/js/admin-activity-page.js
+++ b/resources/js/admin-activity-page.js
@@ -1,0 +1,6 @@
+import { requireAuth, setLogout } from './admin/auth.js';
+import { initActivity }           from './admin/activity.js';
+
+requireAuth();
+setLogout();
+initActivity();

--- a/resources/js/admin-subnav.js
+++ b/resources/js/admin-subnav.js
@@ -7,6 +7,7 @@
         { href: '/admin/travel.html',   label: 'Travel',    icon: '✈' },
         { href: '/admin/deploy.html',   label: 'Deploy',    icon: '⚡' },
         { href: '/admin/media.html',    label: 'Media',     icon: '📁' },
+        { href: '/admin/activity.html', label: 'Activity',  icon: '📋' },
         { href: '/admin/stats.html',    label: 'Stats',     icon: '📊' },
         { href: '/admin/settings.html', label: 'Settings',  icon: '⚙' },
     ];

--- a/resources/js/admin/activity.js
+++ b/resources/js/admin/activity.js
@@ -1,0 +1,136 @@
+/**
+ * Admin activity log (#155)
+ *
+ * Fetches recent audit log entries from GET /audit and renders them
+ * in a filterable, auto-refreshable table in the admin activity page.
+ */
+import { authFetch } from './auth.js';
+import { escapeHtml } from '../utils/html.js';
+
+// ── Colour coding by action prefix ───────────────────────────────────────────
+
+const ACTION_CLASS = {
+  'auth.login':          'activity-success',
+  'auth.login_failed':   'activity-danger',
+  'post.create':         'activity-success',
+  'post.publish':        'activity-success',
+  'post.update':         'activity-info',
+  'post.unpublish':      'activity-warn',
+  'post.delete':         'activity-danger',
+  'travel.create':       'activity-success',
+  'travel.publish':      'activity-success',
+  'travel.update':       'activity-info',
+  'travel.unpublish':    'activity-warn',
+  'travel.delete':       'activity-danger',
+  'cv.upload':           'activity-info',
+  'cv.delete':           'activity-danger',
+  'deploy.start':        'activity-success',
+  'deploy.rollback':     'activity-warn',
+  'deploy.fetch':        'activity-info',
+};
+
+function actionClass(action) {
+  return ACTION_CLASS[action] || 'activity-info';
+}
+
+// ── Relative time formatter ───────────────────────────────────────────────────
+
+function relativeTime(dateStr) {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60)          return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60)          return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24)          return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+function absoluteTime(dateStr) {
+  return new Date(dateStr).toLocaleString('en-GB', {
+    day: '2-digit', month: 'short', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+// ── Detail summary ────────────────────────────────────────────────────────────
+
+function detailSummary(detail) {
+  if (!detail) return '';
+  if (detail.title) return escapeHtml(detail.title);
+  if (detail.sha)   return escapeHtml(detail.sha.slice(0, 8));
+  if (detail.env)   return escapeHtml(detail.env);
+  return '';
+}
+
+// ── Render ────────────────────────────────────────────────────────────────────
+
+function renderRows(rows) {
+  if (!rows.length) {
+    return '<tr><td colspan="5" class="activity-empty">No activity recorded yet.</td></tr>';
+  }
+  return rows.map(r => {
+    const cls     = actionClass(r.action);
+    const rel     = relativeTime(r.created_at);
+    const abs     = absoluteTime(r.created_at);
+    const detail  = detailSummary(r.detail);
+    const entity  = r.entity_type ? escapeHtml(r.entity_type) : '';
+    return `<tr class="${escapeHtml(cls)}">
+      <td class="activity-ts" title="${escapeHtml(abs)}">${escapeHtml(rel)}</td>
+      <td class="activity-action"><code>${escapeHtml(r.action)}</code></td>
+      <td class="activity-entity">${entity}</td>
+      <td class="activity-detail">${detail}</td>
+      <td class="activity-user">${escapeHtml(r.username || '—')}</td>
+    </tr>`;
+  }).join('');
+}
+
+// ── Load ──────────────────────────────────────────────────────────────────────
+
+let _currentType   = 'all';
+let _refreshTimer  = null;
+
+async function loadActivity(type = _currentType) {
+  _currentType = type;
+  const tbody = document.getElementById('activity-tbody');
+  if (!tbody) return;
+
+  try {
+    const qs  = new URLSearchParams({ limit: '50' });
+    if (type !== 'all') qs.set('type', type);
+    const res = await authFetch(`/audit?${qs}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const rows = await res.json();
+    tbody.innerHTML = renderRows(rows);
+  } catch {
+    if (tbody) tbody.innerHTML = '<tr><td colspan="5" class="activity-empty" style="color:var(--color-error)">Failed to load activity log.</td></tr>';
+  }
+}
+
+// ── Init ──────────────────────────────────────────────────────────────────────
+
+export function initActivity() {
+  const container = document.getElementById('activity-log');
+  if (!container) return;
+
+  // Filter buttons
+  container.querySelectorAll('[data-activity-filter]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      container.querySelectorAll('[data-activity-filter]').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      loadActivity(btn.dataset.activityFilter);
+    });
+  });
+
+  // Refresh button
+  const refreshBtn = document.getElementById('activity-refresh');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', () => loadActivity());
+  }
+
+  // Auto-refresh every 60 s
+  _refreshTimer = setInterval(() => loadActivity(), 60_000);
+
+  loadActivity();
+}

--- a/resources/js/admin/activity.js
+++ b/resources/js/admin/activity.js
@@ -130,6 +130,7 @@ export function initActivity() {
   }
 
   // Auto-refresh every 60 s
+  if (_refreshTimer) clearInterval(_refreshTimer);
   _refreshTimer = setInterval(() => loadActivity(), 60_000);
 
   loadActivity();

--- a/resources/js/admin/cv.js
+++ b/resources/js/admin/cv.js
@@ -1,8 +1,18 @@
+/**
+ * Admin CV management (#109)
+ *
+ * Supports versioned CV uploads: every upload creates a new version.
+ * The version history table lets the admin set any previous version as current
+ * or delete old versions.
+ */
 import { authFetch, getToken } from './auth.js';
 import { API_BASE } from '../config.js';
 import { createMessenger } from '../utils/messenger.js';
+import { escapeHtml } from '../utils/html.js';
 
 const setMessage = createMessenger('cv-message');
+
+// ── Status badge ──────────────────────────────────────────────────────────────
 
 function updateStatusBadge(exists) {
     const badge = document.getElementById('cv-status-badge');
@@ -14,8 +24,6 @@ function updateStatusBadge(exists) {
         badge.textContent = '✕ No CV uploaded';
         badge.className = 'cv-status-badge not-uploaded';
     }
-    const deleteBtn = document.getElementById('cv-delete-btn');
-    if (deleteBtn) deleteBtn.disabled = !exists;
 }
 
 async function loadStatus() {
@@ -27,6 +35,101 @@ async function loadStatus() {
         setMessage('Could not check CV status.', true);
     }
 }
+
+// ── Version history table ─────────────────────────────────────────────────────
+
+function formatDate(dateStr) {
+    if (!dateStr) return '—';
+    return new Date(dateStr).toLocaleString('en-GB', {
+        day: '2-digit', month: 'short', year: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+    });
+}
+
+async function loadHistory() {
+    const container = document.getElementById('cv-history');
+    if (!container) return;
+
+    try {
+        const res  = await authFetch('/cv/history');
+        if (!res.ok) throw new Error();
+        const rows = await res.json();
+
+        if (!rows.length) {
+            container.innerHTML = '<p class="hint">No CV versions uploaded yet.</p>';
+            return;
+        }
+
+        container.innerHTML = `
+            <table class="cv-history-table">
+                <thead>
+                    <tr>
+                        <th>Filename</th>
+                        <th>Uploaded</th>
+                        <th>Status</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${rows.map(r => `
+                    <tr class="${r.is_current ? 'cv-row-current' : ''}">
+                        <td><code>${escapeHtml(r.filename)}</code></td>
+                        <td>${formatDate(r.uploaded_at)}</td>
+                        <td>${r.is_current ? '<strong>Current</strong>' : '<span class="hint">Archive</span>'}</td>
+                        <td class="cv-row-actions">
+                            ${!r.is_current ? `
+                            <button type="button" class="btn-small cv-set-current" data-id="${escapeHtml(r.id)}">Set current</button>
+                            <button type="button" class="btn-small btn-danger cv-delete-version" data-id="${escapeHtml(r.id)}">Delete</button>
+                            ` : '<span class="hint">—</span>'}
+                        </td>
+                    </tr>`).join('')}
+                </tbody>
+            </table>`;
+
+        // Bind actions
+        container.querySelectorAll('.cv-set-current').forEach(btn => {
+            btn.addEventListener('click', () => setCurrent(btn.dataset.id));
+        });
+        container.querySelectorAll('.cv-delete-version').forEach(btn => {
+            btn.addEventListener('click', () => deleteVersion(btn.dataset.id));
+        });
+    } catch {
+        container.innerHTML = '<p class="hint" style="color:var(--color-error)">Failed to load CV history.</p>';
+    }
+}
+
+async function setCurrent(id) {
+    setMessage('');
+    try {
+        const res = await authFetch(`/cv/${id}/set-current`, { method: 'PUT' });
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(data.error || 'Failed to set current');
+        }
+        setMessage('CV version set as current.');
+        await Promise.all([loadStatus(), loadHistory()]);
+    } catch (err) {
+        setMessage(err.message || 'Failed to set current.', true);
+    }
+}
+
+async function deleteVersion(id) {
+    if (!confirm('Delete this CV version? This cannot be undone.')) return;
+    setMessage('');
+    try {
+        const res = await authFetch(`/cv/${id}`, { method: 'DELETE' });
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(data.error || 'Failed to delete');
+        }
+        setMessage('CV version deleted.');
+        await Promise.all([loadStatus(), loadHistory()]);
+    } catch (err) {
+        setMessage(err.message || 'Failed to delete.', true);
+    }
+}
+
+// ── Upload ────────────────────────────────────────────────────────────────────
 
 async function uploadCv(file) {
     const uploadBtn = document.getElementById('cv-upload-btn');
@@ -51,15 +154,16 @@ async function uploadCv(file) {
                 `The scan found potential private information in this PDF:\n• ${warningList}\n\nDo you still want to publish it?`
             );
             if (!proceed) {
-                await authFetch('/cv', { method: 'DELETE' });
+                // Delete the just-uploaded version
+                await authFetch(`/cv/${data.id}`, { method: 'DELETE' });
                 setMessage('Upload cancelled — CV removed from server.', true);
-                await loadStatus();
+                await Promise.all([loadStatus(), loadHistory()]);
                 return;
             }
         }
 
-        setMessage('CV uploaded successfully.');
-        await loadStatus();
+        setMessage('CV uploaded successfully — now set as current.');
+        await Promise.all([loadStatus(), loadHistory()]);
     } catch (err) {
         setMessage(err.message || 'Upload failed.', true);
     } finally {
@@ -71,27 +175,14 @@ async function uploadCv(file) {
     }
 }
 
-async function deleteCv() {
-    if (!confirm('Delete the current CV? It will no longer be available for download.')) return;
-    setMessage('');
-    try {
-        const res = await authFetch('/cv', { method: 'DELETE' });
-        if (!res.ok) throw new Error();
-        setMessage('CV deleted.');
-        await loadStatus();
-    } catch {
-        setMessage('Failed to delete CV.', true);
-    }
-}
+// ── Init ──────────────────────────────────────────────────────────────────────
 
 export function initCv() {
     const cvFileInput = document.getElementById('cv-file-input');
     const cvUploadBtn = document.getElementById('cv-upload-btn');
-    const cvDeleteBtn = document.getElementById('cv-delete-btn');
 
     if (!cvFileInput) return;
 
-    // Enable upload button when a file is selected (rename notice handled by admin-init.js)
     cvFileInput.addEventListener('change', () => {
         cvUploadBtn.disabled = !cvFileInput.files[0];
     });
@@ -101,7 +192,6 @@ export function initCv() {
         if (file) uploadCv(file);
     });
 
-    cvDeleteBtn.addEventListener('click', deleteCv);
-
     loadStatus();
+    loadHistory();
 }

--- a/resources/js/admin/cv.js
+++ b/resources/js/admin/cv.js
@@ -148,18 +148,20 @@ async function uploadCv(file) {
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || 'Upload failed');
 
-        if (data.warnings && data.warnings.length) {
+        if (data.pending && data.warnings && data.warnings.length) {
             const warningList = data.warnings.join('\n• ');
             const proceed = confirm(
                 `The scan found potential private information in this PDF:\n• ${warningList}\n\nDo you still want to publish it?`
             );
             if (!proceed) {
-                // Delete the just-uploaded version
                 await authFetch(`/cv/${data.id}`, { method: 'DELETE' });
                 setMessage('Upload cancelled — CV removed from server.', true);
                 await Promise.all([loadStatus(), loadHistory()]);
                 return;
             }
+            // Admin confirmed — promote the staged version to current
+            const confirmRes = await authFetch(`/cv/${data.id}/confirm`, { method: 'POST' });
+            if (!confirmRes.ok) throw new Error('Failed to confirm CV upload');
         }
 
         setMessage('CV uploaded successfully — now set as current.');

--- a/resources/js/search.js
+++ b/resources/js/search.js
@@ -1,0 +1,137 @@
+/**
+ * Search page (#157)
+ *
+ * Calls GET /api/search?q=<term>&type=<all|blog|travel>&limit=20
+ * and renders ranked results with highlighted matched terms.
+ */
+import { API_BASE }   from './config.js';
+import { escapeHtml } from './utils/html.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Highlight occurrences of each word in `query` within `text`.
+ * Returns safe HTML with <mark> elements around matches.
+ */
+function highlight(text, query) {
+  if (!text || !query) return escapeHtml(text || '');
+  const words   = query.trim().split(/\s+/).filter(Boolean);
+  if (!words.length) return escapeHtml(text);
+  const pattern = new RegExp(`(${words.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`, 'gi');
+  return escapeHtml(text).replace(
+    // Work on the escaped string — escapeHtml has already made it safe,
+    // so we re-apply the pattern to the escaped result.
+    // Note: escapeHtml() replaces < > & " ' — query words should not match these.
+    pattern,
+    '<mark>$1</mark>'
+  );
+}
+
+function typeLabel(postType) {
+  return postType === 'travel' ? 'Travel' : 'Blog';
+}
+
+function postUrl(result) {
+  if (result.post_type === 'travel') return `/travel/post/?id=${result.id}`;
+  return `/blog/post/?slug=${result.slug}`;
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+// ── Render ────────────────────────────────────────────────────────────────────
+
+function renderResults(data, query) {
+  if (!data.results.length) {
+    return `<p class="search-empty">No results for <strong>${escapeHtml(query)}</strong>.</p>`;
+  }
+
+  const grouped = { blog: [], travel: [] };
+  data.results.forEach(r => grouped[r.post_type]?.push(r));
+
+  let html = `<p class="search-summary">${data.total} result${data.total !== 1 ? 's' : ''} for <strong>${escapeHtml(query)}</strong></p>`;
+
+  ['blog', 'travel'].forEach(type => {
+    const items = grouped[type];
+    if (!items.length) return;
+    html += `<h3 class="search-group-heading">${typeLabel(type)}</h3><ul class="search-result-list">`;
+    items.forEach(r => {
+      const excerpt    = r.excerpt || '';
+      const dateStr    = r.post_date || r.published_at;
+      html += `<li class="search-result-item">
+        <a href="${escapeHtml(postUrl(r))}" class="search-result-link">
+          <span class="search-result-title">${highlight(r.title, query)}</span>
+          <span class="search-result-meta">
+            <span class="search-result-type ${r.post_type === 'travel' ? 'tag-travel' : 'tag-blog'}">${typeLabel(r.post_type)}</span>
+            ${dateStr ? `<span class="search-result-date">${formatDate(dateStr)}</span>` : ''}
+            ${r.location ? `<span class="search-result-location">${escapeHtml(r.location)}</span>` : ''}
+          </span>
+          ${excerpt ? `<p class="search-result-excerpt">${highlight(excerpt, query)}</p>` : ''}
+        </a>
+      </li>`;
+    });
+    html += '</ul>';
+  });
+
+  return html;
+}
+
+// ── Search ────────────────────────────────────────────────────────────────────
+
+async function runSearch(query, type) {
+  const resultsEl = document.getElementById('search-results');
+  resultsEl.innerHTML = '<p class="hint">Searching…</p>';
+
+  try {
+    const qs  = new URLSearchParams({ q: query, limit: '20' });
+    if (type && type !== 'all') qs.set('type', type);
+    const res = await fetch(`${API_BASE}/search?${qs}`);
+
+    if (res.status === 400) {
+      resultsEl.innerHTML = '<p class="search-empty">Please enter a search term.</p>';
+      return;
+    }
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const data = await res.json();
+    resultsEl.innerHTML = renderResults(data, query);
+  } catch {
+    resultsEl.innerHTML = '<p class="hint" style="color:var(--color-error)">Search failed. Please try again.</p>';
+  }
+}
+
+// ── Init ──────────────────────────────────────────────────────────────────────
+
+const form    = document.getElementById('search-form');
+const input   = document.getElementById('search-input');
+const results = document.getElementById('search-results');
+
+// Pre-fill from URL query string if present (e.g. linked search)
+const urlParams = new URLSearchParams(window.location.search);
+const initialQ  = urlParams.get('q');
+if (initialQ) {
+  input.value = initialQ;
+  const initialType = urlParams.get('type') || 'all';
+  const radio = form.querySelector(`input[name="type"][value="${initialType}"]`);
+  if (radio) radio.checked = true;
+  runSearch(initialQ, initialType);
+}
+
+form?.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const q    = input.value.trim();
+  const type = form.querySelector('input[name="type"]:checked')?.value || 'all';
+  if (!q) {
+    results.innerHTML = '<p class="search-empty">Please enter a search term.</p>';
+    return;
+  }
+  // Update URL without reload for shareable links
+  const url = new URL(window.location);
+  url.searchParams.set('q', q);
+  url.searchParams.set('type', type);
+  window.history.pushState({}, '', url);
+  runSearch(q, type);
+});

--- a/resources/js/search.js
+++ b/resources/js/search.js
@@ -114,7 +114,9 @@ const urlParams = new URLSearchParams(window.location.search);
 const initialQ  = urlParams.get('q');
 if (initialQ) {
   input.value = initialQ;
-  const initialType = urlParams.get('type') || 'all';
+  const VALID_SEARCH_TYPES = ['blog', 'travel', 'all'];
+  const rawType = urlParams.get('type');
+  const initialType = VALID_SEARCH_TYPES.includes(rawType) ? rawType : 'all';
   const radio = form.querySelector(`input[name="type"][value="${initialType}"]`);
   if (radio) radio.checked = true;
   runSearch(initialQ, initialType);

--- a/scripts/deploy/output-lib.sh
+++ b/scripts/deploy/output-lib.sh
@@ -1,27 +1,43 @@
 #!/usr/bin/env bash
-# output-lib.sh — Shared box-drawing helpers for deploy, test, and ops scripts.
+# output-lib.sh — Shared console output primitives for deploy, test, and ops scripts (#314).
 #
-# Source this file to get _visual_width, _print_box, and _print_multi_box.
-# Callers supply their own colour escape strings; this lib provides _OUT_RESET.
+# Source this file to get:
+#   out_info / out_ok / out_warn / out_fail / out_section / out_die
+#   _visual_width / _print_box / _print_multi_box
 #
-# Log-file tee: if $LOG_FILE is set and non-empty in the calling script,
-# all box output is automatically tee'd to that file.
+# Configuration (set before sourcing, or export from calling script):
+#   OUTPUT_LOG_FILE — if set, all output is also tee'd to this file
+#   OUTPUT_QUIET=1  — suppress info/ok/section; warnings and errors always shown
+#
+# Callers that already define LOG_FILE (deploy-lib.sh) can alias it:
+#   export OUTPUT_LOG_FILE="$LOG_FILE"
 
-# ── Colour reset (detected once at source time) ───────────────────────────────
+# ── Colour detection (done once at source time) ───────────────────────────────
 
 if [ -t 1 ]; then
+  _OUT_RED='\033[0;31m'
+  _OUT_YELLOW='\033[0;33m'
+  _OUT_GREEN='\033[0;32m'
+  _OUT_CYAN='\033[0;36m'
   _OUT_RESET='\033[0m'
   _OUT_BOLD='\033[1m'
 else
+  _OUT_RED=''
+  _OUT_YELLOW=''
+  _OUT_GREEN=''
+  _OUT_CYAN=''
   _OUT_RESET=''
   _OUT_BOLD=''
 fi
 
 # ── Internal emit helpers ─────────────────────────────────────────────────────
 
-# Emit a line — tee to $LOG_FILE if set, otherwise plain stdout.
+# Emit a line — tee to $OUTPUT_LOG_FILE if set, otherwise plain stdout.
 _out_emit() {
-  if [ -n "${LOG_FILE:-}" ]; then
+  if [ -n "${OUTPUT_LOG_FILE:-}" ]; then
+    echo -e "$*" | tee -a "$OUTPUT_LOG_FILE"
+  elif [ -n "${LOG_FILE:-}" ]; then
+    # Legacy: deploy-lib.sh callers use LOG_FILE
     echo -e "$*" | tee -a "$LOG_FILE"
   else
     echo -e "$*"
@@ -30,11 +46,52 @@ _out_emit() {
 
 # printf variant of _out_emit — passes all args straight to printf.
 _out_printf() {
-  if [ -n "${LOG_FILE:-}" ]; then
+  if [ -n "${OUTPUT_LOG_FILE:-}" ]; then
+    printf "$@" | tee -a "$OUTPUT_LOG_FILE"
+  elif [ -n "${LOG_FILE:-}" ]; then
     printf "$@" | tee -a "$LOG_FILE"
   else
     printf "$@"
   fi
+}
+
+_out_quiet() { [ "${OUTPUT_QUIET:-0}" = "1" ]; }
+
+# ── Message functions (#314) ──────────────────────────────────────────────────
+
+# ℹ info line (cyan) — suppressed in quiet mode
+out_info() {
+  _out_quiet && return 0
+  _out_emit "${_OUT_CYAN}${_OUT_BOLD}ℹ  ${_OUT_RESET} $*"
+}
+
+# ✅ success line (green) — suppressed in quiet mode
+out_ok() {
+  _out_quiet && return 0
+  _out_emit "${_OUT_GREEN}${_OUT_BOLD}✅ ${_OUT_RESET} $*"
+}
+
+# ⚠️  warning line (yellow) — always shown
+out_warn() {
+  _out_emit "${_OUT_YELLOW}${_OUT_BOLD}⚠️  ${_OUT_RESET} $*"
+}
+
+# ❌ error line (red) — always shown
+out_fail() {
+  _out_emit "${_OUT_RED}${_OUT_BOLD}❌ ${_OUT_RESET} $*"
+}
+
+# 🔷 section header — suppressed in quiet mode
+out_section() {
+  _out_quiet && return 0
+  _out_emit ""
+  _out_emit "${_OUT_CYAN}${_OUT_BOLD}🔷 ── $* ───────────────────────────────────────────${_OUT_RESET}"
+}
+
+# Print error and exit 1 — always shown
+out_die() {
+  out_fail "$*"
+  exit 1
 }
 
 # ── Width helper ──────────────────────────────────────────────────────────────

--- a/search/index.html
+++ b/search/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Global error logger (load first to catch all errors) -->
+    <script type="module" src="/resources/js/error-logger.js"></script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Search | AK Portfolio</title>
+    <link rel="shortcut icon" href="/resources/img/AK.jpg" type="image/x-icon">
+    <link rel="stylesheet" href="/resources/css/reset.css" />
+    <link rel="stylesheet" href="/resources/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header id="home">
+        <h1>A|K</h1>
+        <h2>Andy | Keys</h2>
+        <h2>Search</h2>
+    </header>
+    <nav>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <span class="nav-toggle-label">A|K</span>
+            <span class="nav-toggle-icon">☰</span>
+        </button>
+        <ul class="nav">
+            <li><a href="/">🏠 Home</a></li>
+            <li><a href="/#about">👤 About</a></li>
+            <li><a href="/blog/">✏ Blog</a></li>
+            <li><a href="/travel/">✈ Travel</a></li>
+            <li><a href="/login/">🔒 Admin</a></li>
+            <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
+        </ul>
+    </nav>
+
+    <main>
+        <section class="sec-cont" id="search">
+            <h2>Search</h2>
+
+            <form id="search-form" class="search-form" role="search">
+                <div class="search-input-wrap">
+                    <input
+                        id="search-input"
+                        type="search"
+                        placeholder="Search posts and travel memories…"
+                        aria-label="Search"
+                        autocomplete="off"
+                        class="search-input"
+                    />
+                    <button type="submit" class="btn-primary search-submit">Search</button>
+                </div>
+
+                <div class="search-filters" role="group" aria-label="Filter by type">
+                    <label class="search-filter-label">
+                        <input type="radio" name="type" value="all" checked /> All
+                    </label>
+                    <label class="search-filter-label">
+                        <input type="radio" name="type" value="blog" /> Blog
+                    </label>
+                    <label class="search-filter-label">
+                        <input type="radio" name="type" value="travel" /> Travel
+                    </label>
+                </div>
+            </form>
+
+            <div id="search-results" aria-live="polite"></div>
+        </section>
+    </main>
+
+    <script src="/resources/js/dev-env.js"></script>
+    <script src="/resources/js/darkmode.js"></script>
+    <script src="/resources/js/nav.js"></script>
+    <script type="module" src="/resources/js/search.js"></script>
+</body>
+</html>

--- a/travel/index.html
+++ b/travel/index.html
@@ -37,6 +37,7 @@
             <li><a href="/#contact">✉ Contact</a></li>
             <li><a href="/blog/">✏ Blog</a></li>
             <li><a href="/travel/">✈ Travel</a></li>
+            <li><a href="/search/">🔍 Search</a></li>
             <li><a href="/login/">🔒 Admin</a></li>
             <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
         </ul>

--- a/travel/post/index.html
+++ b/travel/post/index.html
@@ -37,6 +37,7 @@
             <li><a href="/#contact">✉ Contact</a></li>
             <li><a href="/blog/">✏ Blog</a></li>
             <li><a href="/travel/">✈ Travel</a></li>
+            <li><a href="/search/">🔍 Search</a></li>
             <li><a href="/login/">🔒 Admin</a></li>
             <li><button id="dark-mode-toggle" type="button" aria-label="Switch to dark mode">☾</button></li>
         </ul>


### PR DESCRIPTION
## Summary

Batch implementation of seven open issues across backend, frontend, and ops, plus security/quality fixes from code review.

- #437 — Docker/Compose deduplication (YAML anchors, image pin comments)
- #154 — Audit logging (schema, utility, routes, integrated into all admin actions)
- #155 — Admin activity dashboard (new \`/admin/activity.html\` page)
- #157 — Full-text search via PostgreSQL tsvector (new \`/search\` page + API)
- #109 — CV version history (versioned filenames, cvs table, admin UI)
- #202 — Blog seed script (7 project-journey posts, idempotent)
- #314 — Shared output library extended with \`out_*\` message functions

Closes #437, Closes #154, Closes #155, Closes #157, Closes #109, Closes #202, Closes #314

## Changes

### Feature work
- \`docker-compose.yml\` / \`docker-compose.local.yml\` — x-logging YAML anchor, image pin comments, canonical healthcheck comments
- \`backend/db/schema.sql\` — add \`audit_log\` table + indexes, \`search_vector\` GENERATED STORED column + GIN index on \`posts\`, \`cvs\` table + partial unique index
- \`backend/utils/audit.js\` — new \`logAudit(req, action, entityType, entityId, detail, opts)\` helper (async, non-fatal)
- \`backend/routes/audit.js\` — new \`GET /audit?limit&type\` endpoint (auth + rate limit required)
- \`backend/routes/search.js\` — new \`GET /search?q&type&limit\` endpoint (public, rate-limited, published only, ts_rank ordered, Cache-Control: public 60s)
- \`backend/routes/cv.js\` — full rewrite for versioned CV management; backward-compatible public endpoints; all endpoints rate-limited
- \`backend/routes/posts.js\` / \`travel.js\` / \`auth.js\` / \`deploy.js\` — \`logAudit()\` calls added to all mutating actions
- \`backend/app.js\` — register \`/audit\` and \`/search\` routes
- \`backend/scripts/seed-blog-posts.js\` — idempotent seed script for 7 project-journey blog posts
- \`admin/activity.html\` — new admin activity log page
- \`admin/index.html\` — Activity card added to dashboard
- \`admin/media.html\` — CV history table added
- \`resources/js/admin/activity.js\` — activity log module with filter, auto-refresh, colour coding
- \`resources/js/admin/cv.js\` — version history table with set-current and delete actions
- \`resources/js/admin-activity-page.js\` — page entry point
- \`resources/js/search.js\` — search page module with highlight, type filter, URL sync
- \`search/index.html\` — public search page
- \`resources/css/styles.css\` — activity table and search page styles, CV history table styles
- \`docs/DATABASE.md\` — document audit_log, cvs tables, new indexes, search_vector migration note
- \`scripts/deploy/output-lib.sh\` — add \`out_info/ok/warn/fail/section/die\` message functions

### Security & quality fixes (post-review)
- **\`GET /search\` rate limit** — only public endpoint without one; added 60 req/min (CodeQL fix)
- **CV upload staging** — \`POST /cv\` no longer publishes before admin confirms privacy warnings; new \`POST /cv/:id/confirm\` endpoint promotes staged upload
- **\`auth.login_failed\` audit events** — failure branches in passkey and magic-link auth now write audit rows (email not logged — enumeration risk)
- **Login audit \`user_id\`** — \`logAudit\` gains \`opts.userId\` override; login handlers pass explicit user ID (was null before)
- **Audit \`?type=\` wildcard injection** — regex guard rejects SQL wildcards before LIKE query
- **CV filename collision** — 3-byte random hex suffix prevents 1-second same-filename overwrite
- **CV \`:id\` UUID validation** — malformed params return 404 not 500
- **\`GET /cv/exists\` + \`GET /cv\` rate limit** — public CV endpoints now use \`cvRateLimit\` (CodeQL fix)
- **\`GET /audit\` rate limit** — admin endpoint now has \`auditRateLimit\` (CodeQL fix)
- **\`setInterval\` cleanup** — \`clearInterval\` guard in \`initActivity()\`
- **Search URL \`?type=\` desync** — whitelisted against \`VALID_SEARCH_TYPES\`

## Test Plan

1. Run full test suite (must show 121 passed, 0 failed):
   ```bash
   docker compose exec backend npm test
   ```

2. Verify \`GET /search\` has rate limit header:
   ```bash
   curl -ksi https://localhost:3001/api/search?q=test | grep -i "ratelimit\|cache-control"
   # Expected: RateLimit-* headers present, Cache-Control: public, max-age=60
   ```

3. Verify public CV endpoints are rate-limited:
   ```bash
   curl -ksi https://localhost:3001/api/cv/exists | grep -i ratelimit
   # Expected: RateLimit-* headers present
   ```

4. Verify \`GET /audit\` is rate-limited:
   ```bash
   curl -ksi -H "Authorization: Bearer $JWT" https://localhost:3001/api/audit | grep -i ratelimit
   # Expected: RateLimit-* headers present
   ```

5. Verify CV staging — upload a PDF with a card number pattern and check it is NOT immediately public:
   ```bash
   curl -ks -H "Authorization: Bearer $JWT" https://localhost:3001/api/cv/exists
   # After upload of warned PDF: { "exists": false } until /confirm is called
   ```

6. Verify passkey login failure writes audit row:
   ```bash
   # Attempt passkey login with invalid challenge, then:
   curl -ks -H "Authorization: Bearer $JWT" "https://localhost:3001/api/audit?type=auth" | python3 -m json.tool
   # Expected: row with action: "auth.login_failed"
   ```

### Setup required
Schema migration: \`audit_log\`, \`cvs\`, and \`search_vector\` column added by \`schema.sql\` on next \`docker compose up\`. For existing DB:
```bash
docker compose exec postgres psql -U $DB_USER -d $DB_NAME -f /docker-entrypoint-initdb.d/01-schema.sql
```
**Note:** Adding \`search_vector\` (GENERATED STORED) briefly locks the \`posts\` table while Postgres back-fills — completes in milliseconds on this site.

## Smoke Test

- [ ] \`scripts/tests/Test-Regression.ps1\` run and passing
- [ ] Public search page (\`/search/\`) loads and returns results
- [ ] Admin activity dashboard (\`/admin/activity.html\`) loads and shows recent actions
- [ ] CV upload with clean PDF → published immediately
- [ ] CV upload with warned PDF → staging dialog → confirm → published

## Documentation

- [x] \`docs/DATABASE.md\` — \`audit_log\`, \`cvs\` tables, indexes, \`search_vector\` migration lock note
- [x] CSP allowlist — N/A: \`/api/search\` and \`/api/audit\` are same-origin
- [x] Audit log retention — tracked in #467 (on-boot or cron prune, 90-day window)

## Risk / Impact

- **Audit logging**: non-fatal — failures are warnings, no request blocked. Low risk.
- **CV staging**: backward-compatible public API (\`GET /cv\`, \`GET /cv/exists\`). Existing files without a \`cvs\` row not served until re-uploaded.
- **Full-text search**: GENERATED STORED column back-fills on first deploy (milliseconds on this site).
- **Rate limits on \`/cv/exists\` and \`/cv\`**: 30 req/min matches other write ops — appropriate for a public download endpoint.

## Squash Commit Message

```text
feat: audit log, search, CV history, activity dashboard, seed, compose dedup

Add audit_log table and logAudit() utility wired into all admin routes.
Add auth.login_failed audit events and fix user_id on login audit rows.
Add admin activity dashboard. Add full-text search via PostgreSQL tsvector
with /search page (rate-limited). Add CV version history with staged upload
for privacy warnings (cvs table, versioned filenames, confirm endpoint).
Add idempotent blog seed script. Dedup compose YAML with anchors. Extend
output-lib.sh with out_* functions. Rate-limit all new endpoints. Fix
audit ?type= wildcard injection, CV filename collision, UUID validation.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```