### PR TITLE
feat(#468): improve audit activity log UI (badges, scroll, icons)

### DIFF
--- a/admin/activity.html
+++ b/admin/activity.html
@@ -50,20 +50,22 @@
                 </div>
 
                 <div class="activity-table-wrap" style="overflow-x:auto">
-                    <table class="activity-table">
-                        <thead>
-                            <tr>
-                                <th>When</th>
-                                <th>Action</th>
-                                <th>Type</th>
-                                <th>Detail</th>
-                                <th>User</th>
-                            </tr>
-                        </thead>
-                        <tbody id="activity-tbody">
-                            <tr><td colspan="5" class="activity-empty">Loading…</td></tr>
-                        </tbody>
-                    </table>
+                    <div class="activity-scroll">
+                        <table class="activity-table">
+                            <thead>
+                                <tr>
+                                    <th>When</th>
+                                    <th>Action</th>
+                                    <th>Type</th>
+                                    <th>Detail</th>
+                                    <th>User</th>
+                                </tr>
+                            </thead>
+                            <tbody id="activity-tbody">
+                                <tr><td colspan="5" class="activity-empty">Loading…</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
 
                 <p class="hint" style="margin-top:0.75rem">

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -2667,6 +2667,36 @@ a.travel-card:visited {
     border-radius: var(--radius-sm);
 }
 
+.activity-scroll {
+    max-height: 420px;
+    overflow-y: auto;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+}
+
+.activity-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+    padding: 0.2em 0.55em;
+    border-radius: 4px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    white-space: nowrap;
+    background: var(--color-border);
+    color: var(--color-text);
+}
+
+.activity-badge.activity-success { background: rgba(39, 174, 96, 0.15);  color: #27ae60; }
+.activity-badge.activity-danger  { background: rgba(231, 76, 60, 0.15);  color: #e74c3c; }
+.activity-badge.activity-warn    { background: rgba(230, 126, 34, 0.15); color: #e67e22; }
+.activity-badge.activity-info    { background: rgba(52, 152, 219, 0.15); color: #3498db; }
+
+[data-theme="dark"] .activity-badge.activity-success { color: #2ecc71; }
+[data-theme="dark"] .activity-badge.activity-danger  { color: #e74c3c; }
+[data-theme="dark"] .activity-badge.activity-warn    { color: #e67e22; }
+[data-theme="dark"] .activity-badge.activity-info    { color: #74b9ff; }
+
 .activity-detail {
     color: var(--color-text-secondary);
     max-width: 18rem;

--- a/resources/js/admin/activity.js
+++ b/resources/js/admin/activity.js
@@ -33,6 +33,32 @@ function actionClass(action) {
   return ACTION_CLASS[action] || 'activity-info';
 }
 
+// ── Icon by action prefix ────────────────────────────────────────────────────
+
+const ACTION_ICON = {
+  'auth.login':        '✓',
+  'auth.login_failed': '✗',
+  'post.create':       '+',
+  'post.publish':      '▶',
+  'post.update':       '✎',
+  'post.unpublish':    '⏸',
+  'post.delete':       '✗',
+  'travel.create':     '+',
+  'travel.publish':    '▶',
+  'travel.update':     '✎',
+  'travel.unpublish':  '⏸',
+  'travel.delete':     '✗',
+  'cv.upload':         '↑',
+  'cv.delete':         '✗',
+  'deploy.start':      '▶',
+  'deploy.rollback':   '↩',
+  'deploy.fetch':      '↓',
+};
+
+function actionIcon(action) {
+  return ACTION_ICON[action] || '•';
+}
+
 // ── Relative time formatter ───────────────────────────────────────────────────
 
 function relativeTime(dateStr) {
@@ -72,13 +98,14 @@ function renderRows(rows) {
   }
   return rows.map(r => {
     const cls     = actionClass(r.action);
+    const icon    = actionIcon(r.action);
     const rel     = relativeTime(r.created_at);
     const abs     = absoluteTime(r.created_at);
     const detail  = detailSummary(r.detail);
     const entity  = r.entity_type ? escapeHtml(r.entity_type) : '';
     return `<tr class="${escapeHtml(cls)}">
       <td class="activity-ts" title="${escapeHtml(abs)}">${escapeHtml(rel)}</td>
-      <td class="activity-action"><code>${escapeHtml(r.action)}</code></td>
+      <td class="activity-action"><span class="activity-badge ${escapeHtml(cls)}" title="${escapeHtml(r.action)}"><span aria-hidden="true">${escapeHtml(icon)}</span>${escapeHtml(r.action)}</span></td>
       <td class="activity-entity">${entity}</td>
       <td class="activity-detail">${detail}</td>
       <td class="activity-user">${escapeHtml(r.username || '—')}</td>


### PR DESCRIPTION
## Summary
Replaces plain `<code>` action tags with coloured badge spans (icon + label), wraps the audit activity table in a scrollable container, and adds dark-mode-aware badge colours so high-activity periods stay glanceable on the admin activity page.

## Changes
- `resources/js/admin/activity.js` — new `ACTION_ICON` map + `actionIcon()` helper; row renderer now emits a `.activity-badge` span (icon + escaped action label) instead of a `<code>` tag.
- `resources/css/styles.css` — adds `.activity-scroll` (max-height 420px, bordered, vertical overflow) and `.activity-badge` plus `.activity-success/danger/warn/info` variants with light + `[data-theme=\"dark\"]` colour overrides.
- `admin/activity.html` — wraps the `<table class=\"activity-table\">` in a new `.activity-scroll` div inside the existing `.activity-table-wrap` so horizontal overflow on narrow screens still works.

Frontend-only; no backend, schema, route, or env changes.

## Test plan

```bash
# Confirm the existing Vitest suite still passes (no backend code changed, but smoke-check)
# Expected: 14 test files / 147 tests passed
docker compose exec backend npm test
```

Manual verification (admin must be logged in):

```text
# 1. Open https://dev.andykeys.me:3001/admin/activity.html
#    Expected: each row's Action cell shows a pill-shaped badge with an icon + action name
#    (e.g. green "✓ auth.login", red "✗ post.delete", orange "⏸ post.unpublish").
#
# 2. Trigger / wait for >~15 rows of activity (or temporarily reduce max-height in DevTools).
#    Expected: the table scrolls vertically inside a bordered container while the page
#    chrome (filters, header) stays fixed.
#
# 3. Toggle the site theme to dark via the theme toggle in the nav.
#    Expected: badge background tints stay subtle; success/info text shifts to the
#    dark-mode palette (#2ecc71 / #74b9ff); danger/warn keep their orange/red.
#
# 4. Hover any badge.
#    Expected: tooltip shows the raw action string (e.g. "deploy.rollback").
```

## Smoke tests
N/A — frontend-only UI polish, no API surface or auth changes.

## Documentation
N/A: no behaviour, deploy, or operator workflow change; activity log section in admin docs already reflects the page's purpose.

Closes #468