### PR TITLE
feat(#466): add Upload button for mobile photo geocoding

### DIFF
--- a/admin/travel.html
+++ b/admin/travel.html
@@ -61,6 +61,14 @@
                             <button type="button" class="btn-secondary file-input-btn" aria-label="Choose photos or videos">Add files…</button>
                             <span class="file-input-label">No files chosen</span>
                             <input id="travel-file" type="file" accept="image/*,video/*" class="file-input-hidden" multiple />
+                            <button
+                                type="button"
+                                id="travel-upload-btn"
+                                class="btn-small"
+                                disabled
+                                aria-label="Extract GPS location from selected photos"
+                            >Upload photos</button>
+                            <span id="travel-upload-status" class="upload-status-msg" aria-live="polite"></span>
                         </div>
                     </label>
                     <div id="travel-media-list" class="media-list hidden"></div>

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -2418,6 +2418,12 @@ footer {
     max-width: 260px;
 }
 
+.upload-status-msg {
+    font-size:   0.8rem;
+    color:       var(--color-muted, #888);
+    margin-left: 0.5rem;
+}
+
 /* ── Issue #39: Custom coordinate stepper ─────────────────────────────────── */
 
 /* Hide native browser up/down spinner arrows on number inputs */

--- a/resources/js/admin/travel.js
+++ b/resources/js/admin/travel.js
@@ -69,6 +69,7 @@ function renderMediaList() {
                 if (!pendingFiles.length && !existingMedia.length) {
                     document.querySelector('.file-input-label').textContent = 'No files chosen';
                 }
+                syncUploadBtn();
             });
         }
 
@@ -94,6 +95,8 @@ function clearForm() {
     renderMediaList();
     setMessage('');
     hideGeoconfirmMap();
+    syncUploadBtn();
+    if (uploadStatus) uploadStatus.textContent = '';
 }
 
 // ── Saved memories list ───────────────────────────────────────────────────────
@@ -184,6 +187,8 @@ async function loadForEdit(memory) {
             : (full.media_url ? [{ id: null, url: full.media_url, type: full.media_type }] : []);
         document.querySelector('.file-input-label').textContent = 'No files chosen';
         renderMediaList();
+        syncUploadBtn();
+        if (uploadStatus) uploadStatus.textContent = '';
 
         if (full.lat != null && full.lng != null) {
             updateGeoconfirmMap(parseFloat(full.lat), parseFloat(full.lng));
@@ -332,6 +337,9 @@ async function extractGpsFromFile(file) {
 }
 
 // Loop through sorted files to find the first one with valid GPS coords.
+// Returns true if GPS was found and applied, false otherwise — callers
+// (e.g. the manual Upload photos button on mobile) use this to surface
+// clear success/failure feedback to the user.
 async function tryAutofillGpsFromFileList(files) {
     const sortedImages = files
         .filter(f => f.type && f.type.startsWith('image/'))
@@ -345,10 +353,11 @@ async function tryAutofillGpsFromFileList(files) {
             setMessage(`GPS auto-filled from ${file.name}.`);
             updateGeoconfirmMap(gps.latitude, gps.longitude);
             await reverseGeocodeToLocation(gps.latitude, gps.longitude);
-            return;
+            return true;
         }
     }
     setMessage('No GPS data in any photo — enter coordinates manually or use Geocode.', false, true);
+    return false;
 }
 
 // Try to read DateTimeOriginal from image EXIF and populate the date input.
@@ -407,10 +416,44 @@ async function geocodeLocation() {
     }
 }
 
+// ── Upload-button helpers (#466) ──────────────────────────────────────────────
+
+// Module-scoped so non-init callers (renderMediaList remove handlers,
+// clearForm, loadForEdit) can keep the button's disabled state in sync
+// with pendingFiles.length.
+let uploadBtn    = null;
+let uploadStatus = null;
+
+function syncUploadBtn() {
+    if (!uploadBtn) return;
+    uploadBtn.disabled = pendingFiles.length === 0;
+}
+
 // ── Init ──────────────────────────────────────────────────────────────────────
 
 export function initTravel() {
     loadAll();
+
+    uploadBtn    = document.getElementById('travel-upload-btn');
+    uploadStatus = document.getElementById('travel-upload-status');
+    syncUploadBtn();
+
+    uploadBtn?.addEventListener('click', async () => {
+        if (!pendingFiles.length) return;
+        uploadBtn.disabled = true;
+        uploadBtn.textContent = 'Extracting GPS…';
+        if (uploadStatus) uploadStatus.textContent = '';
+
+        const found = await tryAutofillGpsFromFileList(pendingFiles);
+
+        uploadBtn.disabled = false;
+        uploadBtn.textContent = 'Upload photos';
+        if (uploadStatus) {
+            uploadStatus.textContent = found
+                ? 'GPS location auto-filled from photo.'
+                : 'No GPS data found — enter location manually.';
+        }
+    });
 
     document.getElementById('geocode-btn').addEventListener('click', () => geocodeLocation());
 
@@ -446,6 +489,8 @@ export function initTravel() {
             pendingFiles.length + ' file' + (pendingFiles.length !== 1 ? 's' : '') + ' selected';
         event.target.value = ''; // reset so same file can be re-added if removed
         renderMediaList();
+        syncUploadBtn();
+        if (uploadStatus) uploadStatus.textContent = '';
     });
 
     document.getElementById('travel-form').addEventListener('submit', async (event) => {


### PR DESCRIPTION
## Summary
Adds an explicit "Upload photos" button to the travel admin form. Enabled after file selection, triggers GPS extraction with user feedback.

On mobile, the file input `change` event fires but `exifr` does not always extract EXIF tags reliably (selection vs ready timing). This gives the user an explicit way to re-run extraction on demand.

## Changes
- `admin/travel.html` — button + status span inside the `.file-input-wrap` near `#travel-file`
- `resources/js/admin/travel.js` — module-scoped `uploadBtn` / `uploadStatus`, `syncUploadBtn()` called after every `pendingFiles` mutation (change handler, remove-row handler, `clearForm`, `loadForEdit`); new click handler runs `tryAutofillGpsFromFileList` and surfaces success/failure text; `tryAutofillGpsFromFileList` now returns a boolean
- `resources/css/styles.css` — `.upload-status-msg` style

## Test plan

```bash
# Confirm the existing Vitest suite is unaffected (frontend-only change,
# but verifies nothing in the repo broke and that imports still resolve).
docker compose exec backend npm test
# Expected: Test Files 14 passed, Tests 147 passed
```

Manual verification on the dev server (browser):

- Load `/admin/travel/`. **Expected:** "Upload photos" button is visible next to the file input and is disabled.
- Pick a photo with GPS EXIF (e.g. via "Add files…" or the native mobile picker). **Expected:** button becomes enabled.
- Tap "Upload photos". **Expected:** button shows "Extracting GPS…" briefly, then returns to "Upload photos"; lat/lng + location populate; status text reads "GPS location auto-filled from photo."
- Pick a photo with no GPS EXIF and tap "Upload photos". **Expected:** status text reads "No GPS data found — enter location manually."
- Remove the only file from the media list. **Expected:** Upload button disables again.
- Reset/clear the form. **Expected:** Upload button disables, status text clears.

## Smoke tests
N/A — frontend-only change, no backend or API surface affected.

## Documentation
N/A — behaviour-level change confined to a single admin form control; no operator/runbook/docs implications.

Closes #466