### PR TITLE
feat(#469): embed search input on blog and travel listing pages

### DIFF
--- a/backend/scripts/tests/test-admin-e2e.js
+++ b/backend/scripts/tests/test-admin-e2e.js
@@ -229,6 +229,14 @@ try {
   const searchPageErrors = consoleErrors.filter(e => !e.includes('zlib'));
   smoke('Search page — no JS console errors', searchPageErrors.length === 0, searchPageErrors.join('; '));
 
+  // S7b: embedded search input present on /blog/ and /travel/ listing pages (#469)
+  await page.goto(`${baseUrl}/blog/`, { waitUntil: 'networkidle0', timeout: 20000 });
+  const blogSearchInputExists = await page.$('#listing-search-input') !== null;
+  smoke('Blog page — embedded search input present', blogSearchInputExists, '#listing-search-input not found on /blog/');
+  await page.goto(`${baseUrl}/travel/`, { waitUntil: 'networkidle0', timeout: 20000 });
+  const travelSearchInputExists = await page.$('#listing-search-input') !== null;
+  smoke('Travel page — embedded search input present', travelSearchInputExists, '#listing-search-input not found on /travel/');
+
   // S8: admin activity dashboard loads and shows table (#155)
   consoleErrors.length = 0;
   await page.goto(`${baseUrl}/admin/activity.html`, { waitUntil: 'networkidle0', timeout: 20000 });

--- a/blog/index.html
+++ b/blog/index.html
@@ -45,6 +45,14 @@
         <section class="sec-cont" id="blog">
             <h2>Posts</h2>
 
+            <form id="listing-search-form" class="search-form listing-search-form" role="search">
+                <div class="search-input-wrap">
+                    <input id="listing-search-input" type="search" name="q" placeholder="Search posts…" class="search-input" aria-label="Search blog posts" autocomplete="off" />
+                    <button type="submit" class="btn-primary search-submit">Search</button>
+                </div>
+            </form>
+            <div id="listing-search-results" class="listing-search-results" aria-live="polite" hidden></div>
+
             <div class="blog-view-toggle" role="tablist">
                 <button type="button" class="view-toggle-btn active" data-view="timeline" role="tab" aria-selected="true">Timeline</button>
                 <button type="button" class="view-toggle-btn" data-view="cards" role="tab" aria-selected="false">Cards</button>

--- a/resources/js/blog.js
+++ b/resources/js/blog.js
@@ -1,6 +1,7 @@
 import { API_BASE } from './config.js';
 import { formatPostDate } from './utils/date.js';
 import { buildPostCard, buildTimelineItem } from './utils/dom.js';
+import { escapeHtml, highlight } from './utils/html.js';
 import { recordVisit } from './utils/stats.js';
 
 function truncate(str, len) {
@@ -100,3 +101,90 @@ function loadPosts() {
 recordVisit('blog');
 
 loadPosts();
+
+// ── Embedded listing search (#469) ────────────────────────────────────────────
+
+(function initListingSearch() {
+    var form    = document.getElementById('listing-search-form');
+    var input   = document.getElementById('listing-search-input');
+    var results = document.getElementById('listing-search-results');
+    var list    = document.getElementById('posts-list');
+    var timeline = document.getElementById('blog-timeline');
+    var toggle  = document.querySelector('.blog-view-toggle');
+
+    if (!form || !input || !results) return;
+
+    function setListingHidden(hidden) {
+        // Don't unhide #posts-list directly — its visibility is owned by the
+        // view toggle (Cards vs Timeline). We hide both containers when
+        // searching, then defer to applyBlogView() via the toggle when clearing.
+        if (timeline) timeline.classList.toggle('hidden', hidden);
+        if (list)     list.classList.toggle('hidden', hidden);
+        if (toggle)   toggle.classList.toggle('hidden', hidden);
+    }
+
+    function restoreListing() {
+        // Re-apply the toggle's active view so the right container is shown.
+        if (toggle) toggle.classList.remove('hidden');
+        var activeBtn = document.querySelector('.blog-view-toggle .view-toggle-btn.active');
+        var activeView = (activeBtn && activeBtn.dataset.view) || 'timeline';
+        if (activeView === 'timeline') {
+            if (list)     list.classList.add('hidden');
+            if (timeline) timeline.classList.remove('hidden');
+        } else {
+            if (list)     list.classList.remove('hidden');
+            if (timeline) timeline.classList.add('hidden');
+        }
+    }
+
+    var urlQ = new URLSearchParams(window.location.search).get('q') || '';
+    if (urlQ) { input.value = urlQ; runSearch(urlQ); }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var q   = input.value.trim();
+        var url = new URL(window.location.href);
+        if (q) url.searchParams.set('q', q); else url.searchParams.delete('q');
+        history.replaceState(null, '', url);
+        runSearch(q);
+    });
+
+    input.addEventListener('input', function () {
+        if (!input.value.trim()) runSearch('');
+    });
+
+    async function runSearch(q) {
+        if (!q) {
+            results.hidden = true;
+            results.innerHTML = '';
+            restoreListing();
+            return;
+        }
+        setListingHidden(true);
+        results.hidden = false;
+        results.innerHTML = '<p class="hint">Searching…</p>';
+        try {
+            var res  = await fetch(API_BASE + '/search?q=' + encodeURIComponent(q) + '&type=blog&limit=20');
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            var data = await res.json();
+            if (!data.results || !data.results.length) {
+                results.innerHTML = '<p class="search-empty">No posts found.</p>';
+                return;
+            }
+            results.innerHTML = '<ul class="search-result-list">' + data.results.map(function (r) {
+                var href    = '/blog/post/?slug=' + encodeURIComponent(r.slug || '');
+                var dateStr = r.post_date || r.published_at || '';
+                return '<li class="search-result-item">' +
+                    '<a href="' + escapeHtml(href) + '" class="search-result-link">' +
+                        '<span class="search-result-title">' + highlight(r.title, q) + '</span>' +
+                        (r.excerpt ? '<p class="search-result-excerpt">' + highlight(r.excerpt, q) + '</p>' : '') +
+                        '<span class="search-result-meta">' + escapeHtml(formatPostDate({ post_date: dateStr }) || '') + '</span>' +
+                    '</a>' +
+                '</li>';
+            }).join('') + '</ul>';
+        } catch (err) {
+            console.error('[blog-search] failed:', err && (err.message || String(err)));
+            results.innerHTML = '<p class="search-empty">Search failed — please try again.</p>';
+        }
+    }
+})();

--- a/resources/js/search.js
+++ b/resources/js/search.js
@@ -4,28 +4,10 @@
  * Calls GET /api/search?q=<term>&type=<all|blog|travel>&limit=20
  * and renders ranked results with highlighted matched terms.
  */
-import { API_BASE }   from './config.js';
-import { escapeHtml } from './utils/html.js';
+import { API_BASE }            from './config.js';
+import { escapeHtml, highlight } from './utils/html.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-/**
- * Highlight occurrences of each word in `query` within `text`.
- * Returns safe HTML with <mark> elements around matches.
- */
-function highlight(text, query) {
-  if (!text || !query) return escapeHtml(text || '');
-  const words   = query.trim().split(/\s+/).filter(Boolean);
-  if (!words.length) return escapeHtml(text);
-  const pattern = new RegExp(`(${words.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`, 'gi');
-  return escapeHtml(text).replace(
-    // Work on the escaped string — escapeHtml has already made it safe,
-    // so we re-apply the pattern to the escaped result.
-    // Note: escapeHtml() replaces < > & " ' — query words should not match these.
-    pattern,
-    '<mark>$1</mark>'
-  );
-}
 
 function typeLabel(postType) {
   return postType === 'travel' ? 'Travel' : 'Blog';

--- a/resources/js/travel.js
+++ b/resources/js/travel.js
@@ -1,5 +1,5 @@
 import { API_BASE } from './config.js';
-import { escapeHtml } from './utils/html.js';
+import { escapeHtml, highlight } from './utils/html.js';
 import { formatVisitDate } from './utils/date.js';
 import { buildTimelineItem, buildPublicTravelCard } from './utils/dom.js';
 import { initLightbox } from './utils/lightbox.js';
@@ -185,3 +185,84 @@ function loadPublicTravelPosts() {
 recordVisit('travel');
 loadPublicTravelPosts();
 initLightbox();
+
+// ── Embedded listing search (#469) ────────────────────────────────────────────
+
+(function initListingSearch() {
+    var form    = document.getElementById('listing-search-form');
+    var input   = document.getElementById('listing-search-input');
+    var results = document.getElementById('listing-search-results');
+    var mapEl   = document.getElementById('travel-map');
+    var grid    = document.getElementById('travel-grid');
+    var timeline = document.getElementById('travel-timeline');
+    var toggle  = document.querySelector('.travel-view-toggle');
+
+    if (!form || !input || !results) return;
+
+    function setListingHidden(hidden) {
+        if (mapEl)    mapEl.classList.toggle('hidden', hidden);
+        if (grid)     grid.classList.toggle('hidden', hidden);
+        if (timeline) timeline.classList.toggle('hidden', hidden);
+        if (toggle)   toggle.classList.toggle('hidden', hidden);
+    }
+
+    function restoreListing() {
+        // Re-apply the active view so the right containers are shown.
+        if (toggle) toggle.classList.remove('hidden');
+        var activeBtn = document.querySelector('.travel-view-toggle .view-toggle-btn.active');
+        var activeView = (activeBtn && activeBtn.dataset.view) || 'map-timeline';
+        applyTravelView(activeView);
+    }
+
+    var urlQ = new URLSearchParams(window.location.search).get('q') || '';
+    if (urlQ) { input.value = urlQ; runSearch(urlQ); }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var q   = input.value.trim();
+        var url = new URL(window.location.href);
+        if (q) url.searchParams.set('q', q); else url.searchParams.delete('q');
+        history.replaceState(null, '', url);
+        runSearch(q);
+    });
+
+    input.addEventListener('input', function () {
+        if (!input.value.trim()) runSearch('');
+    });
+
+    async function runSearch(q) {
+        if (!q) {
+            results.hidden = true;
+            results.innerHTML = '';
+            restoreListing();
+            return;
+        }
+        setListingHidden(true);
+        results.hidden = false;
+        results.innerHTML = '<p class="hint">Searching…</p>';
+        try {
+            var res  = await fetch(API_BASE + '/search?q=' + encodeURIComponent(q) + '&type=travel&limit=20');
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            var data = await res.json();
+            if (!data.results || !data.results.length) {
+                results.innerHTML = '<p class="search-empty">No travel memories found.</p>';
+                return;
+            }
+            results.innerHTML = '<ul class="search-result-list">' + data.results.map(function (r) {
+                var href    = '/travel/post/?id=' + encodeURIComponent(r.id);
+                var dateStr = r.post_date || r.published_at || '';
+                return '<li class="search-result-item">' +
+                    '<a href="' + escapeHtml(href) + '" class="search-result-link">' +
+                        '<span class="search-result-title">' + highlight(r.title, q) + '</span>' +
+                        (r.location ? '<span class="search-result-meta">' + escapeHtml(r.location) + '</span>' : '') +
+                        (r.excerpt ? '<p class="search-result-excerpt">' + highlight(r.excerpt, q) + '</p>' : '') +
+                        '<span class="search-result-meta">' + escapeHtml(formatVisitDate(dateStr) || '') + '</span>' +
+                    '</a>' +
+                '</li>';
+            }).join('') + '</ul>';
+        } catch (err) {
+            console.error('[travel-search] failed:', err && (err.message || String(err)));
+            results.innerHTML = '<p class="search-empty">Search failed — please try again.</p>';
+        }
+    }
+})();

--- a/resources/js/utils/html.js
+++ b/resources/js/utils/html.js
@@ -11,3 +11,21 @@ export function escapeHtml(str) {
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#039;');
 }
+
+/**
+ * Highlight occurrences of each word in `query` within `text`.
+ * Returns safe HTML with <mark> elements around matches.
+ *
+ * Used by both the standalone /search/ page and the embedded search
+ * forms on /blog/ and /travel/ listing pages (#469).
+ */
+export function highlight(text, query) {
+    if (!text || !query) return escapeHtml(text || '');
+    const words   = query.trim().split(/\s+/).filter(Boolean);
+    if (!words.length) return escapeHtml(text);
+    const pattern = new RegExp(
+        `(${words.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`,
+        'gi'
+    );
+    return escapeHtml(text).replace(pattern, '<mark>$1</mark>');
+}

--- a/travel/index.html
+++ b/travel/index.html
@@ -47,6 +47,14 @@
         <section class="sec-cont" id="travel">
             <h2>Travel Memories</h2>
 
+            <form id="listing-search-form" class="search-form listing-search-form" role="search">
+                <div class="search-input-wrap">
+                    <input id="listing-search-input" type="search" name="q" placeholder="Search travel memories…" class="search-input" aria-label="Search travel memories" autocomplete="off" />
+                    <button type="submit" class="btn-primary search-submit">Search</button>
+                </div>
+            </form>
+            <div id="listing-search-results" class="listing-search-results" aria-live="polite" hidden></div>
+
             <div class="travel-view-toggle" role="tablist">
                 <button type="button" class="view-toggle-btn active" data-view="map-timeline" role="tab" aria-selected="true">Map + timeline</button>
                 <button type="button" class="view-toggle-btn" data-view="both" role="tab" aria-selected="false">Map + cards</button>


### PR DESCRIPTION
## Summary

Adds a compact search input directly on \`/blog/\` and \`/travel/\` listing pages so users can search without leaving the page. Exports \`highlight()\` from \`utils/html.js\` for reuse across listings and the standalone search page.

Closes #469

## Changes

- \`resources/js/utils/html.js\` — export \`highlight(text, query)\` (escaped + \`<mark>\` wrapping)
- \`resources/js/search.js\` — drop local \`highlight\`, import from \`./utils/html.js\`
- \`blog/index.html\`, \`travel/index.html\` — add \`#listing-search-form\` and \`#listing-search-results\` markup before the view toggle (reuses existing \`.search-form\` / \`.search-input\` / \`.search-result-*\` CSS classes)
- \`resources/js/blog.js\`, \`resources/js/travel.js\` — append \`initListingSearch\` IIFE that calls \`/api/search?type=blog|travel\`, hides the regular listing while a query is active, restores it when the input is empty, and syncs \`?q=\` to the URL via \`history.replaceState\`
- \`backend/scripts/tests/test-admin-e2e.js\` — assert \`#listing-search-input\` is present on \`/blog/\` and \`/travel/\`

## Test Plan

### Happy path

1. Start the dev server, check out this branch, open \`https://dev.andykeys.me:3001/blog/\`
2. Type a known term (e.g. a blog post title word) and press Search — timeline/cards/toggle hide; results list appears with \`<mark>\` highlights
3. Clear the search box (select-all + delete) — results disappear; listing + toggle reappear in their previous view
4. Search for a term, then reload the page — input pre-fills from \`?q=\`, search re-runs automatically
5. Repeat steps 2–4 on \`https://dev.andykeys.me:3001/travel/\` — map + grid + timeline + toggle hide; travel-only results render

```bash
# Confirm backend suite unaffected (frontend-only change)
docker compose exec backend npm test
# Expected: Test Files 14 passed (14), Tests 147 passed (147)
```

### Edge cases

- [ ] Empty search box — no results panel shown, full listing displayed
- [ ] No results found — "No posts found." / "No travel memories found." empty state shown
- [ ] Network error (simulate by disabling API) — graceful "Search failed" message, no crash
- [ ] Mobile — search form is visible and usable on small viewport (no layout breakage)

### Regression checks

- [ ] Standalone \`/search/\` page still works and \`highlight()\` still renders \`<mark>\` tags
- [ ] Blog timeline / cards view toggle still works after clearing search
- [ ] Travel map + grid + timeline view toggle still works after clearing search
- [ ] \`?q=\` URL sync does not interfere with normal page navigation

### Setup required before testing

- Check out branch \`feat/issue-469-embedded-search\` on the dev server so nginx serves the updated HTML:
  \`\`\`bash
  cd ~/MyPortfolioSite-dev && git checkout feat/issue-469-embedded-search
  \`\`\`
  No container restart needed — nginx mounts the repo root directly.

## Smoke Test

- [ ] \`scripts/tests/Test-Regression.ps1\` run and passing
- [ ] N/A — no new backend route added; e2e assertion in \`test-admin-e2e.js\` runs after container rebuild on next deploy

## Documentation

- [ ] N/A — behaviour and operator docs already match the change (no updates needed)
- [ ] CSP allowlist — N/A; no new external resources or inline scripts added

## Risk / Impact

Frontend-only change. The \`/api/search\` endpoint is already in production. Moving \`highlight()\` to \`utils/html.js\` is backwards-compatible — \`search.js\` imports it from there and the output is identical.

## Squash Commit Message

\`\`\`text
feat(#469): embed search input on blog and travel listings

Export highlight() from utils/html.js so listing pages can reuse it.
/blog/ and /travel/ each gain a search form that calls /api/search
with type=blog|travel, syncs ?q= to the URL, and restores the
listing when the input is empty.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
\`\`\`

## Notes for Reviewer

The search form is static HTML in \`blog/index.html\` / \`travel/index.html\` — visible immediately on page load without JS. The \`initListingSearch\` IIFE wires up the submit and input handlers after the module loads. To test, the branch must be checked out on the dev server (see Setup above); the containers do not need rebuilding.