### PR TITLE
fix(#475): nginx X-Forwarded-For spoofing + search query length limit

### DIFF
--- a/backend/routes/search.js
+++ b/backend/routes/search.js
@@ -39,6 +39,9 @@ router.get('/', searchRateLimit, publicCache(60), async (req, res, next) => {
     if (!q) {
       return res.status(400).json({ error: 'Query parameter "q" is required' });
     }
+    if (q.length > 500) {
+      return res.status(400).json({ error: 'Search query too long (max 500 characters).' });
+    }
 
     logger.info({ q, type, limit }, '[search] Full-text search request');
 

--- a/scripts/config/nginx-dev-server.conf.template
+++ b/scripts/config/nginx-dev-server.conf.template
@@ -47,7 +47,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_pass_header X-Request-Id;
     }

--- a/scripts/config/nginx-portfolio.conf.template
+++ b/scripts/config/nginx-portfolio.conf.template
@@ -49,7 +49,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_pass_header X-Request-Id;
     }


### PR DESCRIPTION
## Summary

Fixes two security findings from pre-release code review. Closes #475

## Changes

- \`scripts/config/nginx-dev-server.conf.template\` — \`X-Forwarded-For \$remote_addr\` (was \`\$proxy_add_x_forwarded_for\`)
- \`scripts/config/nginx-portfolio.conf.template\` — same
- \`backend/routes/search.js\` — reject \`q\` longer than 500 chars with HTTP 400

## Test Plan

### Happy path

1. Verify search still works for normal queries:
\`\`\`bash
# From the server — confirm short query returns results
curl -sk https://localhost:3001/api/search?q=test | python3 -m json.tool | grep total
# Expected: "total": <number>
\`\`\`

2. Verify long query is rejected:
\`\`\`bash
# From the server — confirm 501-char query returns 400
curl -sk "https://localhost:3001/api/search?q=$(python3 -c 'print(\"a\"*501)')" | python3 -m json.tool
# Expected: {"error": "Search query too long (max 500 characters)."}
\`\`\`

3. Verify boundary — exactly 500 chars is accepted:
\`\`\`bash
curl -sk "https://localhost:3001/api/search?q=$(python3 -c 'print(\"a\"*500)')" | python3 -m json.tool | grep total
# Expected: "total": 0  (no results, but not an error)
\`\`\`

### Edge cases

- [ ] 500-char query accepted (boundary condition)
- [ ] 501-char query returns HTTP 400
- [ ] Empty query still returns 400 ("Query parameter q is required")
- [ ] Nginx X-Forwarded-For header from client is replaced (not appended) — verify by checking rate-limit DB after sending spoofed header

### Regression checks

- [ ] All 147 backend tests still pass
- [ ] Existing search results unchanged for normal queries
- [ ] Rate limiting on all auth endpoints still functions

### Setup required before testing

- Dev server must be running with this branch deployed (nginx reload required for template change to take effect)

## Smoke Test

- [ ] \`scripts/tests/Test-Regression.ps1\` run and passing post-deploy
- [ ] N/A for pre-deploy backend tests (nginx change only takes effect after container restart)

## Documentation

- [ ] N/A — no operator or behaviour docs require updating for this change

## Risk / Impact

**nginx change:** \`\$remote_addr\` replaces the entire \`X-Forwarded-For\` header with the real connecting client IP (as seen by nginx). This removes the ability for any client to spoof their IP in rate-limit counters and audit log entries. Legitimate clients behind a single reverse proxy (this setup) are unaffected — their real IP was always \`\$remote_addr\`. Note: nginx reload/restart is required after deploy for the template change to take effect.

**search.js change:** Queries longer than 500 characters return HTTP 400 immediately, before reaching the database. Normal search usage is unaffected. Service-key holders previously unlimited on query length are now also capped.

## Squash Commit Message

\`\`\`text
fix(#475): nginx X-Forwarded-For spoofing + search query limit

Replace \$proxy_add_x_forwarded_for with \$remote_addr in both nginx
templates so the rate-limit keyGenerator always receives the real
client IP. Also caps /api/search?q= at 500 chars to prevent
expensive tsquery on long inputs.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
\`\`\`

## Notes for Reviewer

The nginx change is a 1-line swap in both templates — only the `X-Forwarded-For` directive changes. The `X-Real-IP` header (already set to `\$remote_addr`) is unchanged. After this change the backend's `split(',')[0]` in all rate-limit keyGenerators and `audit.js` IP logging will correctly receive the real client IP rather than an attacker-supplied value.