### PR TITLE
docs: add release 2026-06-15 to CHANGELOG and RELEASE_NOTES

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,49 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — entr
 
 ## Unreleased (dev)
 
+---
+
+## Release 2026-06-15
+
+### Added
+
+- Audit log table, activity dashboard in admin stats, full-text search route, CV version history, dev seed script, compose file deduplication (#464)
+- Embedded search input on public blog and travel listing pages (#469)
+- Upload button to trigger GPS extraction on mobile (#466)
+- Audit log UI improvements — status badges, scrollable feed, colour-coded event types (#468)
+- Location field normalised to "City, Country" on geocode (#248)
+- `docs/TECH_DEBT.md` — full codebase tech debt audit (#379)
+
+### Fixed
+
+- `ERR_ERL_INVALID_HITS` suppressed in test output (#465)
+- Error alert cooldown persisted in DB across container restarts — was reset on every container cycle, allowing repeated alert storms (#371)
+- CV download filename aligned to `Andy_Keys_CV.pdf` (#426)
+- `isAdminSession()` removed from `config.js` (#424)
+- Backup schedule check tightened to prevent false positives (#447)
+- `JWT_EXPIRY` env var now wired through in `auth.js` — was ignored, causing tokens to use the hardcoded default (#425)
+- Contact form now sends to `ADMIN_EMAIL` with structured delivery logging (#420)
+- `docker.sock` privilege escalation risk documented (#450)
+- Daily backup cron documented in `docs/BACKUP.md`; stale references corrected (#185)
+
+### Security
+
+- nginx `X-Forwarded-For` header stripped at proxy boundary to prevent IP spoofing; search query length capped at 200 chars (#475)
+- Hand-rolled HTML sanitizer replaced with DOMPurify — eliminates entire class of XSS bypass risk (#427)
+- Rate limit counters isolated per endpoint via `key_type` column — prevents one endpoint's burst from consuming another's quota (#445)
+- `next(err)` used in all DB-error catch blocks; rate limiting added to posts, travel, and account routes (#453)
+- Authenticated sessions exempted from rate limiting (#418)
+
 ### Changed
 
-- Daily backup cron installed on `ak-home-server` and docs aligned (#185): `scripts/backup/db-backup.sh` now runs at 02:00 daily (`pg_dump` of `portfolio_prod` + tar of `uploads/`, 7-day rotation, log to `~/backup.log`). `docs/BACKUP.md` rewritten to lead with the automated flow, document verification + ad-hoc usage, and reflect the actual restore path (`db-restore.sh` uses `gunzip | psql`, not `pg_restore`). Offsite sync (rclone → B2) remains scaffolded but deliberately unconfigured — local-only is sufficient for now. `CLAUDE.md` fragile-areas list corrected from "No backups" to the actual state.
+- `admin/travel.js` split into focused sub-modules (#438)
+- `dc()` wrapper added; 37 raw `docker compose` invocations in deploy scripts replaced (#455)
+- `UPLOADS_DIR`, `wrapMulter`, `findUniqueSlug` extracted as shared backend utilities (#429)
+- `recordVisit()` extracted with admin-session guard (#432)
+- Lightbox extracted to `utils/lightbox.js` — shared across blog and travel pages (#430)
+- `createMessenger` factory extracted for admin modules (#431)
+- Batch refactors: #433, #434, #150, #376, #111, #158
+- Deprecated deploy files deleted; rollback hardened; `server-setup.sh` improved (#435)
 
 ---
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,67 @@
 # Release Notes
 
+## Release 2026-06-15
+
+**Released:** 2026-06-15
+**Branch:** release/2026-06-15
+**PR:** [#477](https://github.com/AndyRKeys/MyPortfolioSite/pull/477)
+**Closes:** #475, #469, #466, #468, #465, #464, #438, #371, #429, #432, #435, #185, #455, #453, #450, #426, #430, #424, #447, #425, #445, #427, #431, #379, #248, #418, #420, #433, #434, #150, #376, #111, #158
+
+### Summary
+
+Security hardening, new features, and a large batch of code quality refactors. 29 commits bundled from `dev` since the 2026-05-31-3 release. Highlights: nginx `X-Forwarded-For` spoofing closed (#475), DOMPurify replaces hand-rolled XSS sanitizer (#427), rate-limit counter isolation (#445), embedded search on public pages (#469), audit log UI overhaul (#464, #468), mobile GPS upload button (#466), and a comprehensive code quality sweep.
+
+### Features
+
+- **feat(#469):** Embed search input on blog and travel listing pages — users can filter posts without navigating away
+- **feat(#466):** Upload button to trigger GPS coordinate extraction on mobile — restores one-tap GPS import when drag-and-drop is unavailable
+- **feat(#468):** Audit log UI improvements — status badges, scrollable feed, colour-coded event types
+- **feat(#464):** Audit log table, activity dashboard in admin stats, full-text search route, CV version history, dev seed script, compose file deduplication
+- **feat(#248):** Location field normalised to "City, Country" format on geocode — consistent presentation across all travel memories
+- **feat(#418):** Authenticated sessions exempted from rate limiting — admin workflows no longer blocked by rate limits
+- **fix(#420):** Contact form now delivers to `ADMIN_EMAIL` with structured delivery logging — was silently sending to a hardcoded address
+
+### Security
+
+- **fix(#475):** nginx `X-Forwarded-For` header stripped at the proxy boundary to prevent IP spoofing; search query length capped at 200 chars
+- **fix(#427):** Hand-rolled HTML sanitizer replaced with DOMPurify — eliminates entire class of XSS bypass risk
+- **fix(#445):** Rate limit counters isolated per endpoint via `key_type` column — prevents one endpoint's burst from consuming another's quota
+- **refactor+security(#453):** `next(err)` used in all DB-error catch blocks; rate limiting added to posts, travel, and account management routes
+
+### Bug Fixes
+
+- **fix(#465):** `ERR_ERL_INVALID_HITS` suppressed in test output
+- **fix(#371):** Error alert cooldown persisted in DB across container restarts — was reset on every container cycle, allowing repeated alert storms
+- **fix(#426):** CV download filename aligned to `Andy_Keys_CV.pdf`
+- **fix(#424):** `isAdminSession()` removed from `config.js`
+- **fix(#447):** Backup schedule check tightened to prevent false positives
+- **fix(#425):** `JWT_EXPIRY` env var now wired through in `auth.js` — was ignored, causing tokens to use the hardcoded default
+- **fix(#450):** `docker.sock` privilege escalation risk documented
+
+### Refactoring
+
+- **refactor(#438):** `admin/travel.js` split into focused sub-modules
+- **refactor(#455):** `dc()` wrapper added; 37 raw `docker compose` invocations in deploy scripts replaced
+- **refactor(#429):** `UPLOADS_DIR`, `wrapMulter`, `findUniqueSlug` extracted as shared backend utilities
+- **refactor(#432):** `recordVisit()` extracted with admin-session guard
+- **refactor(#430):** Lightbox extracted to `utils/lightbox.js` — shared across blog and travel pages
+- **refactor(#431):** `createMessenger` factory extracted for admin modules
+- **refactor:** Batch refactors closing #433, #434, #150, #376, #111, #158
+
+### Ops / Docs
+
+- **ops(#435):** Deprecated deploy files deleted; `|| true` on rollback fixed; `server-setup.sh` hardened
+- **docs(#185):** Daily backup cron documented in `docs/BACKUP.md`; stale references corrected
+- **docs(#379):** `docs/TECH_DEBT.md` added — full codebase tech debt audit
+
+### Deployment Notes
+
+- No breaking changes
+- DB schema: `audit_log` table added (`CREATE TABLE IF NOT EXISTS` — safe on existing DB, no data at risk)
+- No new required env vars
+
+---
+
 ## Release 2026-05-31-3
 
 **Released:** 2026-05-31


### PR DESCRIPTION
## Summary

Adds the missing 2026-06-15 release entries to both `docs/RELEASE_NOTES.md` and `docs/CHANGELOG.md`. These should have been included in the release PR (#477) but were omitted.

Also clears the stale `## Unreleased (dev)` entry for #185 (backup cron docs), which was released as part of #477.

## Changes

- `docs/RELEASE_NOTES.md` — prepended new Release 2026-06-15 entry (features, security, bug fixes, refactoring, ops/docs, deployment notes)
- `docs/CHANGELOG.md` — added Release 2026-06-15 section (Added/Fixed/Security/Changed groups); cleared stale #185 entry from Unreleased

## Test Plan

### Happy path

1. Open `docs/RELEASE_NOTES.md` and confirm the 2026-06-15 entry appears at the top, above Release 2026-05-31-3
2. Open `docs/CHANGELOG.md` and confirm the 2026-06-15 section appears after `## Unreleased (dev)` and before `## Release 2026-05-25`
3. Confirm `## Unreleased (dev)` is empty (no stale #185 entry)

### Edge cases

- [ ] N/A — docs-only PR

### Regression checks

- [ ] N/A — no behaviour change

### Setup required before testing

- None

## Smoke Test

- [ ] N/A — no backend changes in this PR

## Documentation

- [x] `docs/CHANGELOG.md` updated with 2026-06-15 release entry
- [x] `docs/RELEASE_NOTES.md` updated with 2026-06-15 release entry
- [x] N/A — no behaviour or ops changes

## Risk / Impact

- Docs-only. No code changes.

## Squash Commit Message

```text
docs: add release 2026-06-15 to CHANGELOG and RELEASE_NOTES

Entries missed from the release PR (#477). Covers 29 commits
released in the 2026-06-15 production deploy; clears the stale
#185 entry from the Unreleased section.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

## Notes for Reviewer

Straightforward catch-up docs PR. The content mirrors the PR #477 body.