### PR TITLE
security(#275): scoped service account JWTs for deploy routes

### DIFF
--- a/.env.dev-server.example
+++ b/.env.dev-server.example
@@ -51,8 +51,13 @@ JWT_SECRET=change-me-dev-jwt-secret-min-32-chars
 JWT_EXPIRY=1h
 # Internal service account key — used by regression tests to bypass contact
 # rate limiting. Generate with: openssl rand -hex 32
-# See: docs/SECURITY.md, issue #406, future: #275 (scoped service JWTs)
+# See: docs/SECURITY.md, issue #406
 SERVICE_KEY=change-me-dev-service-key-min-32-chars
+# Service account JWT secret — used by automated services (deploy webhooks, scripts).
+# Separate from JWT_SECRET so service credentials and admin credentials are non-interchangeable.
+# Generate with: openssl rand -hex 32 (must be different from JWT_SECRET)
+# See: scripts/ops/generate-service-token.js
+SERVICE_JWT_SECRET=change-me-dev-service-jwt-secret-min-32-chars
 
 # ── WebAuthn ─────────────────────────────────────────────────────────────────
 WEBAUTHN_RP_ID=dev.example.com

--- a/.env.example
+++ b/.env.example
@@ -48,8 +48,13 @@ JWT_SECRET=replace_with_long_random_string
 JWT_EXPIRY=1h
 # Internal service account key — used by regression tests to bypass contact
 # rate limiting. Generate with: openssl rand -hex 32
-# See: docs/SECURITY.md, issue #406, future: #275 (scoped service JWTs)
+# See: docs/SECURITY.md, issue #406
 SERVICE_KEY=replace_with_long_random_string
+# Service account JWT secret — used by automated services (deploy webhooks, scripts).
+# Separate from JWT_SECRET so service credentials and admin credentials are non-interchangeable.
+# Generate with: openssl rand -hex 32 (must be different from JWT_SECRET)
+# See: scripts/ops/generate-service-token.js
+SERVICE_JWT_SECRET=replace_with_long_random_string
 
 # ── WebAuthn ─────────────────────────────────────────────────────────────────
 WEBAUTHN_RP_ID=andykeys.me

--- a/backend/middleware/authenticateDeploy.js
+++ b/backend/middleware/authenticateDeploy.js
@@ -14,17 +14,28 @@ export function authenticateDeploy(req, res, next) {
 
   // Try admin JWT first
   try {
-    req.user = jwt.verify(token, process.env.JWT_SECRET);
+    const payload = jwt.verify(token, process.env.JWT_SECRET, { algorithms: ['HS256'] });
+    // A service-shaped payload signed with JWT_SECRET must be rejected — the
+    // admin path has no scope enforcement and must not accidentally accept it.
+    if (payload.role === 'service') {
+      return res.status(403).json({ error: 'Invalid service token scope' });
+    }
+    req.user = payload;
     return next();
   } catch {}
 
-  // Try service JWT
+  // Service token path: disabled when SERVICE_JWT_SECRET is missing or equals
+  // JWT_SECRET — equal secrets collapse the isolation the two paths provide.
   const serviceSecret = process.env.SERVICE_JWT_SECRET;
-  if (!serviceSecret) {
+  if (!serviceSecret || serviceSecret === process.env.JWT_SECRET) {
     return res.status(401).json({ error: 'Invalid or expired session' });
   }
   try {
-    const payload = jwt.verify(token, serviceSecret);
+    const payload = jwt.verify(token, serviceSecret, { algorithms: ['HS256'] });
+    // exp is required — tokens without a finite lifetime are not accepted.
+    if (!payload.exp) {
+      return res.status(403).json({ error: 'Service token must have an expiry' });
+    }
     if (payload.role !== 'service') {
       return res.status(403).json({ error: 'Invalid service token scope' });
     }

--- a/backend/middleware/authenticateDeploy.js
+++ b/backend/middleware/authenticateDeploy.js
@@ -1,0 +1,39 @@
+import jwt from 'jsonwebtoken';
+
+// ── authenticateDeploy ────────────────────────────────────────────────────────
+// Accepts either an admin JWT (JWT_SECRET) or a scoped service JWT
+// (SERVICE_JWT_SECRET). Service tokens must carry role:'service' and
+// service:'deploy-webhook' — any other scope returns 403 so a token
+// issued for a different purpose cannot be replayed against deploy routes.
+export function authenticateDeploy(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Not authenticated' });
+  }
+  const token = authHeader.slice(7);
+
+  // Try admin JWT first
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET);
+    return next();
+  } catch {}
+
+  // Try service JWT
+  const serviceSecret = process.env.SERVICE_JWT_SECRET;
+  if (!serviceSecret) {
+    return res.status(401).json({ error: 'Invalid or expired session' });
+  }
+  try {
+    const payload = jwt.verify(token, serviceSecret);
+    if (payload.role !== 'service') {
+      return res.status(403).json({ error: 'Invalid service token scope' });
+    }
+    if (payload.service !== 'deploy-webhook') {
+      return res.status(403).json({ error: 'Invalid service token scope' });
+    }
+    req.user = payload;
+    return next();
+  } catch {
+    return res.status(401).json({ error: 'Invalid or expired session' });
+  }
+}

--- a/backend/routes/deploy.js
+++ b/backend/routes/deploy.js
@@ -2,7 +2,7 @@ import { Router }        from 'express';
 import path              from 'path';
 import { fileURLToPath } from 'url';
 import fs                from 'fs/promises';
-import { authenticate }  from '../middleware/authenticate.js';
+import { authenticateDeploy } from '../middleware/authenticateDeploy.js';
 import { spawnStream, spawnPromise } from '../utils/shell.js';
 import { logger }        from '../utils/logger.js';
 import { logAudit }     from '../utils/audit.js';
@@ -51,7 +51,7 @@ async function streamToSSE(res, iter) {
 
 // ── GET /api/deploy/status ────────────────────────────────────────────────────────────
 
-router.get('/status', authenticate, async (req, res) => {
+router.get('/status', authenticateDeploy, async (req, res) => {
   try {
     // Fetch silently — ignore errors (offline / no remote access in dev)
     await spawnPromise('git', ['fetch', 'origin', 'main'], { cwd: REPO_DIR }).catch(() => {});
@@ -88,7 +88,7 @@ router.get('/status', authenticate, async (req, res) => {
 
 // ── GET /api/deploy/history ───────────────────────────────────────────────────────────
 
-router.get('/history', authenticate, async (req, res) => {
+router.get('/history', authenticateDeploy, async (req, res) => {
   try {
     const gitOut = await spawnPromise(
       'git', ['log', '--format=%H|%h|%s|%ci', '-10', 'origin/main'],
@@ -125,14 +125,14 @@ router.get('/history', authenticate, async (req, res) => {
 
 // ── POST /api/deploy/fetch ───────────────────────────────────────────────────────────
 
-router.post('/fetch', authenticate, async (req, res) => {
+router.post('/fetch', authenticateDeploy, async (req, res) => {
   await logAudit(req, 'deploy.fetch', 'deploy', null, { env: DEPLOY_ENV });
   await streamToSSE(res, spawnStream('git', ['fetch', 'origin'], { cwd: REPO_DIR }));
 });
 
 // ── POST /api/deploy ─────────────────────────────────────────────────────────────────────
 
-router.post('/', authenticate, async (req, res) => {
+router.post('/', authenticateDeploy, async (req, res) => {
   if (!await scriptExists()) {
     return res.status(400).json({ error: 'Deploy script not found — check DEPLOY_ENV and that deploy.sh is present' });
   }
@@ -142,7 +142,7 @@ router.post('/', authenticate, async (req, res) => {
 
 // ── POST /api/deploy/rollback ────────────────────────────────────────────────────────────
 
-router.post('/rollback', authenticate, async (req, res) => {
+router.post('/rollback', authenticateDeploy, async (req, res) => {
   const { sha } = req.body || {};
 
   if (!sha || !SHA_RE.test(sha)) {

--- a/backend/tests/routes/deploy.test.js
+++ b/backend/tests/routes/deploy.test.js
@@ -47,7 +47,8 @@ function adminToken() {
 function serviceToken(overrides = {}) {
   return jwt.sign(
     { role: 'service', service: 'deploy-webhook', ...overrides },
-    SERVICE_SECRET
+    SERVICE_SECRET,
+    { expiresIn: '1d' }
   );
 }
 
@@ -79,7 +80,7 @@ describe('GET /deploy/status — authenticateDeploy', () => {
   });
 
   it('returns 403 when service JWT has role:admin instead of role:service', async () => {
-    const token = jwt.sign({ role: 'admin', service: 'deploy-webhook' }, SERVICE_SECRET);
+    const token = jwt.sign({ role: 'admin', service: 'deploy-webhook' }, SERVICE_SECRET, { expiresIn: '1d' });
     const res = await request(app)
       .get('/deploy/status')
       .set('Authorization', `Bearer ${token}`);
@@ -99,6 +100,33 @@ describe('GET /deploy/status — authenticateDeploy', () => {
   it('returns 401 with no Authorization header', async () => {
     const res = await request(app).get('/deploy/status');
     expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when a service-claim token is signed with the admin secret', async () => {
+    // A service-shaped payload signed with JWT_SECRET (not SERVICE_JWT_SECRET)
+    // must be rejected — the admin path must not accept service-scoped tokens.
+    const token = jwt.sign(
+      { role: 'service', service: 'deploy-webhook' },
+      ADMIN_SECRET,
+      { algorithm: 'HS256' }
+    );
+    const res = await request(app)
+      .get('/deploy/status')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when service JWT has no expiry claim', async () => {
+    // Tokens without exp must be rejected to prevent indefinite-lifetime service tokens.
+    const token = jwt.sign(
+      { role: 'service', service: 'deploy-webhook' },
+      SERVICE_SECRET,
+      { algorithm: 'HS256' }
+    );
+    const res = await request(app)
+      .get('/deploy/status')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
   });
 });
 

--- a/backend/tests/routes/deploy.test.js
+++ b/backend/tests/routes/deploy.test.js
@@ -1,0 +1,117 @@
+/**
+ * Deploy route auth tests (#275) — verifies scope enforcement for
+ * authenticateDeploy: admin JWT, valid service JWT, wrong role, wrong
+ * service name, no token, and that service tokens are rejected by
+ * admin-only routes (different secret, so they fail authenticate).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const ADMIN_SECRET   = 'test-admin-secret-32-chars-minimum!';
+const SERVICE_SECRET = 'test-service-secret-32-chars-minimum';
+
+// ── Mocks (hoisted — must precede createApp/module imports) ──────────────────
+
+vi.mock('../../db/pool.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+// spawnPromise returns fake git output so /status resolves without a real repo.
+// spawnStream returns an empty async iterable so SSE routes close cleanly.
+vi.mock('../../utils/shell.js', () => ({
+  spawnPromise: vi.fn().mockImplementation((_cmd, args) => {
+    if (args.includes('--abbrev-ref')) return Promise.resolve('main\n');
+    if (args.includes('rev-parse'))   return Promise.resolve('abc1234def5678901234567890123456789012345\n');
+    if (args.includes('--format=%s')) return Promise.resolve('chore: test commit\n');
+    if (args.includes('--format=%ci')) return Promise.resolve('2026-01-01 00:00:00 +0000\n');
+    if (args.includes('--count'))     return Promise.resolve('0\n');
+    if (args.includes('fetch'))       return Promise.resolve('');
+    return Promise.resolve('');
+  }),
+  spawnStream: vi.fn().mockImplementation(() => {
+    return (async function* () {})();
+  }),
+}));
+
+import { createApp } from '../../app.js';
+
+const app = createApp();
+
+// ── Token helpers ─────────────────────────────────────────────────────────────
+
+function adminToken() {
+  return jwt.sign({ userId: 1 }, ADMIN_SECRET);
+}
+
+function serviceToken(overrides = {}) {
+  return jwt.sign(
+    { role: 'service', service: 'deploy-webhook', ...overrides },
+    SERVICE_SECRET
+  );
+}
+
+beforeEach(() => {
+  process.env.JWT_SECRET         = ADMIN_SECRET;
+  process.env.SERVICE_JWT_SECRET = SERVICE_SECRET;
+});
+
+afterEach(() => {
+  delete process.env.JWT_SECRET;
+  delete process.env.SERVICE_JWT_SECRET;
+});
+
+// ── /api/deploy/status auth tests ────────────────────────────────────────────
+
+describe('GET /deploy/status — authenticateDeploy', () => {
+  it('returns 200 with a valid admin JWT', async () => {
+    const res = await request(app)
+      .get('/deploy/status')
+      .set('Authorization', `Bearer ${adminToken()}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 200 with a valid service JWT (role:service, service:deploy-webhook)', async () => {
+    const res = await request(app)
+      .get('/deploy/status')
+      .set('Authorization', `Bearer ${serviceToken()}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 when service JWT has role:admin instead of role:service', async () => {
+    const token = jwt.sign({ role: 'admin', service: 'deploy-webhook' }, SERVICE_SECRET);
+    const res = await request(app)
+      .get('/deploy/status')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/scope/i);
+  });
+
+  it('returns 403 when service JWT has wrong service name', async () => {
+    const token = serviceToken({ service: 'wrong-service' });
+    const res = await request(app)
+      .get('/deploy/status')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/scope/i);
+  });
+
+  it('returns 401 with no Authorization header', async () => {
+    const res = await request(app).get('/deploy/status');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── Service token rejected by admin-only route ────────────────────────────────
+// Posts route uses authenticate (JWT_SECRET only) — a service token signed with
+// SERVICE_JWT_SECRET cannot verify against JWT_SECRET, so it gets 401.
+
+describe('POST /posts — service token does not grant admin access', () => {
+  it('returns 401 when a service JWT is used on an admin-only route', async () => {
+    const res = await request(app)
+      .post('/posts')
+      .set('Authorization', `Bearer ${serviceToken()}`)
+      .send({ title: 'Injected post', body_markdown: '# Hack' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/utils/audit.js
+++ b/backend/utils/audit.js
@@ -24,12 +24,19 @@ export async function logAudit(req, action, entityType = null, entityId = null, 
               ?? req.socket?.remoteAddress
               ?? null;
 
+  // Service tokens carry no numeric user_id; record their identity via sub so
+  // deploy actions are traceable even when user_id is null.
+  const actor = req.user?.sub ?? null;
+  const enrichedDetail = actor
+    ? JSON.stringify({ actor, ...(detail ?? {}) })
+    : (detail ? JSON.stringify(detail) : null);
+
   try {
     await pool.query(
       `INSERT INTO audit_log (user_id, action, entity_type, entity_id, detail, ip)
        VALUES ($1, $2, $3, $4, $5, $6)`,
       [userId, action, entityType, entityId ? String(entityId) : null,
-       detail ? JSON.stringify(detail) : null, ip]
+       enrichedDetail, ip]
     );
   } catch (err) {
     // Audit failures are non-fatal — log and continue

--- a/backend/utils/validateEnv.js
+++ b/backend/utils/validateEnv.js
@@ -15,6 +15,8 @@
 // Vars the app genuinely reads at runtime. Keep in sync with usage in
 // app.js (CORS/FRONTEND_URL/SITE_HOST), db/pool.js (DB_*), auth.js
 // (JWT_SECRET, WEBAUTHN_*, ADMIN_EMAIL), server.js (PORT), routes/deploy.js (DEPLOY_ENV, REPO_DIR).
+// NOTE: SERVICE_JWT_SECRET is intentionally omitted — deploy routes work for admin
+// users without it; service token auth simply fails gracefully when unset.
 export const REQUIRED_ENV = [
   'PORT',
   'DEPLOY_ENV',

--- a/scripts/ops/generate-service-token.js
+++ b/scripts/ops/generate-service-token.js
@@ -14,9 +14,9 @@ if (!secret) {
 }
 
 const token = jwt.sign(
-  { role: 'service', service: serviceName },
+  { role: 'service', service: serviceName, sub: `service:${serviceName}` },
   secret,
-  { expiresIn: `${expiryDays}d` }
+  { expiresIn: `${expiryDays}d`, algorithm: 'HS256' }
 );
 
 console.log(token);

--- a/scripts/ops/generate-service-token.js
+++ b/scripts/ops/generate-service-token.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// Run with: SERVICE_JWT_SECRET=<secret> node scripts/ops/generate-service-token.js [service-name] [expiry-days]
+// Never commit the generated token or the secret.
+import jwt from 'jsonwebtoken';
+
+const serviceName = process.argv[2] || 'deploy-webhook';
+const expiryDays  = parseInt(process.argv[3], 10) || 365;
+
+const secret = process.env.SERVICE_JWT_SECRET;
+if (!secret) {
+  console.error('Error: SERVICE_JWT_SECRET env var is required');
+  console.error('Usage: SERVICE_JWT_SECRET=<secret> node scripts/ops/generate-service-token.js [service-name] [expiry-days]');
+  process.exit(1);
+}
+
+const token = jwt.sign(
+  { role: 'service', service: serviceName },
+  secret,
+  { expiresIn: `${expiryDays}d` }
+);
+
+console.log(token);
+console.error(`Generated service token for '${serviceName}', expires in ${expiryDays} days.`);


### PR DESCRIPTION
## Summary
- Introduces `SERVICE_JWT_SECRET` for internal service tokens, separate from admin `JWT_SECRET`
- New `authenticateDeploy` middleware accepts both admin JWTs and scoped service JWTs on deploy routes
- Service tokens require `role: 'service'`, `service: 'deploy-webhook'`, and a mandatory `exp` claim — wrong scope returns 403
- Admin path rejects service-shaped payloads (prevents a service-claim token signed with JWT_SECRET bypassing scope check)
- Service path disabled if `SERVICE_JWT_SECRET === JWT_SECRET` (secret-isolation guard)
- HS256 algorithm pinned on all JWT operations
- Audit trail: service token actions record `actor: service:<name>` in `audit_log.detail`
- `scripts/ops/generate-service-token.js` generates tokens locally (never committed)

## Changes
- `backend/middleware/authenticateDeploy.js` — new dual-secret middleware with scope enforcement and hardening
- `backend/routes/deploy.js` — all 5 route handlers now use `authenticateDeploy`
- `backend/tests/routes/deploy.test.js` — 8 scope enforcement tests
- `scripts/ops/generate-service-token.js` — token generation utility (HS256, sub claim, expiry)
- `backend/utils/audit.js` — attach `actor: req.user.sub` when user_id is null (service token)
- `.env.example`, `.env.dev-server.example` — `SERVICE_JWT_SECRET` documented
- `backend/utils/validateEnv.js` — comment noting `SERVICE_JWT_SECRET` is optional

## Test plan

### Unit tests (run in Docker)
```bash
# Rebuild image to pick up new files, then run deploy-specific tests
docker compose build backend
docker compose exec backend npm test -- tests/routes/deploy.test.js
```
Expected: all 8 tests pass — admin 200, service 200, wrong role 403, wrong service 403, no token 401, service token on posts route 401, service-claim-signed-with-admin-secret 403, service token with no exp 403.

```bash
# Full suite — no regressions
docker compose exec backend npm test
```
Expected: full suite green.

### Manual verification
1. Confirm `SERVICE_JWT_SECRET` appears in both `.env.example` and `.env.dev-server.example`
2. Confirm `scripts/ops/generate-service-token.js` exists and includes usage comment
3. Admin routes (e.g. `POST /api/posts`) still require admin JWT — service token returns 401
4. Deploy routes still accept admin JWT — no regression for existing admin panel usage

### Smoke tests
```bash
# No token returns 401
curl -s https://localhost:3001/api/deploy/status -k | jq .
# Expected: {"error":"Not authenticated"}

# Admin token works on deploy route
ADMIN_TOK=$(docker compose exec -T backend node -e \
  "import('jsonwebtoken').then(m => console.log(m.default.sign({userId:1},process.env.JWT_SECRET)))")
curl -s -H "Authorization: Bearer $ADMIN_TOK" https://localhost:3001/api/deploy/status -k | jq .env
# Expected: "dev"
```

## Documentation
- Both env example files updated with `SERVICE_JWT_SECRET` entry and generation instructions
- `validateEnv.js` comment clarifies `SERVICE_JWT_SECRET` is optional

Closes #275

---

## Squash commit message

```
security(#275): scoped service account JWTs

Admin and service tokens use separate signing secrets so a compromised
service credential cannot access admin routes. Deploy routes accept both;
service tokens require role:service + service:deploy-webhook + exp claim.
Scope check rejects service-shaped payloads on the admin-secret path.
Token generation script in scripts/ops/. Audit trail records actor sub.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
```

---
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>